### PR TITLE
Check was missing from context_js

### DIFF
--- a/internal/graphics/opengl/context_js.go
+++ b/internal/graphics/opengl/context_js.go
@@ -112,6 +112,13 @@ func (c *Context) init() {
 	gl.BlendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
 }
 
+func (c *Context) Check() {
+	gl := c.gl
+	if e := gl.GetError(); e != gl.NO_ERROR {
+		panic(fmt.Sprintf("check failed: %d", e))
+	}
+}
+
 func (c *Context) NewTexture(width, height int, pixels []uint8, filter Filter) (Texture, error) {
 	gl := c.gl
 	t := gl.CreateTexture()


### PR DESCRIPTION
Run calls Check whether or not gopherjs is used, and it was not implemented here.