### PR TITLE
examples/sprites: Reuse op

### DIFF
--- a/examples/sprites/main.go
+++ b/examples/sprites/main.go
@@ -102,7 +102,10 @@ const (
 	MaxSprites = 50000
 )
 
-var sprites = &Sprites{make([]*Sprite, MaxSprites), 500}
+var (
+	sprites *Sprites
+	op      *ebiten.DrawImageOptions
+)
 
 func update(screen *ebiten.Image) error {
 	if ebiten.IsKeyPressed(ebiten.KeyLeft) {
@@ -122,10 +125,6 @@ func update(screen *ebiten.Image) error {
 	if ebiten.IsRunningSlowly() {
 		return nil
 	}
-	op := &ebiten.DrawImageOptions{
-		ImageParts: sprites,
-	}
-	op.ColorM.Scale(1.0, 1.0, 1.0, 0.5)
 	if err := screen.DrawImage(ebitenImage, op); err != nil {
 		return err
 	}
@@ -139,6 +138,11 @@ Press <- or -> to change the number of sprites`, ebiten.CurrentFPS(), sprites.Le
 }
 
 func main() {
+	sprites = &Sprites{make([]*Sprite, MaxSprites), 500}
+	op = &ebiten.DrawImageOptions{
+		ImageParts: sprites,
+	}
+	op.ColorM.Scale(1.0, 1.0, 1.0, 0.5)
 	var err error
 	ebitenImage, _, err = ebitenutil.NewImageFromFile("_resources/images/ebiten.png", ebiten.FilterNearest)
 	if err != nil {


### PR DESCRIPTION
Hi, I have a question.

ebiten/examples/sprites/main.go
```go
	op := &ebiten.DrawImageOptions{
		ImageParts: sprites,
	}
	op.ColorM.Scale(1.0, 1.0, 1.0, 0.5)
	if err := screen.DrawImage(ebitenImage, op); err != nil {
		return err
	}
```
this sample codes generates new instance of  option on every update, 
Is this needed?
