### PR TITLE
Hide console window on Windows

### DIFF
--- a/internal/ui/hide_console_dummy.go
+++ b/internal/ui/hide_console_dummy.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package ui
+
+import "github.com/go-gl/glfw/v3.2/glfw"
+
+func hideConsoleWindowOnWindows(*glfw.Window) {}

--- a/internal/ui/hide_console_dummy.go
+++ b/internal/ui/hide_console_dummy.go
@@ -1,7 +1,0 @@
-// +build !windows
-
-package ui
-
-import "github.com/go-gl/glfw/v3.2/glfw"
-
-func hideConsoleWindowOnWindows(*glfw.Window) {}

--- a/internal/ui/hide_console_notwindows.go
+++ b/internal/ui/hide_console_notwindows.go
@@ -16,4 +16,5 @@
 
 package ui
 
+// hideConsoleWindowOnWindows does nothing on non-Windows systems.
 func hideConsoleWindowOnWindows() {}

--- a/internal/ui/hide_console_notwindows.go
+++ b/internal/ui/hide_console_notwindows.go
@@ -12,19 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package ui
 
-import "syscall"
-
-var (
-	kernel32         = syscall.NewLazyDLL("kernel32.dll")
-	user32           = syscall.NewLazyDLL("user32.dll")
-	getConsoleWindow = kernel32.NewProc("GetConsoleWindow")
-	showWindowAsync  = user32.NewProc("ShowWindowAsync")
-)
-
-func hideConsoleWindowOnWindows() {
-	windowHandle, _, _ := getConsoleWindow.Call()
-	const SW_HIDE = 0
-	showWindowAsync.Call(windowHandle, SW_HIDE)
-}
+func hideConsoleWindowOnWindows() {}

--- a/internal/ui/hide_console_windows.go
+++ b/internal/ui/hide_console_windows.go
@@ -1,0 +1,16 @@
+package ui
+
+import "syscall"
+
+var (
+	kernel32         = syscall.NewLazyDLL("kernel32.dll")
+	user32           = syscall.NewLazyDLL("user32.dll")
+	getConsoleWindow = kernel32.NewProc("GetConsoleWindow")
+	showWindowAsync  = user32.NewProc("ShowWindowAsync")
+)
+
+func hideConsoleWindowOnWindows() {
+	windowHandle, _, _ := getConsoleWindow.Call()
+	const SW_HIDE = 0
+	showWindowAsync.Call(windowHandle, SW_HIDE)
+}

--- a/internal/ui/ui_glfw.go
+++ b/internal/ui/ui_glfw.go
@@ -64,6 +64,7 @@ func initialize() error {
 	if err != nil {
 		return err
 	}
+	hideConsoleWindowOnWindows(window)
 	u := &userInterface{
 		window:      window,
 		funcs:       make(chan func()),

--- a/internal/ui/ui_glfw.go
+++ b/internal/ui/ui_glfw.go
@@ -64,7 +64,7 @@ func initialize() error {
 	if err != nil {
 		return err
 	}
-	hideConsoleWindowOnWindows(window)
+	hideConsoleWindowOnWindows()
 	u := &userInterface{
 		window:      window,
 		funcs:       make(chan func()),


### PR DESCRIPTION
When compiling on Windows without the -ldflags "-Hwindowsgui" flag, a
console window pops up when running a compiled program.
This change hides the console after the program starts. The console is
visible for a moment before the actual game window shows.