### PR TITLE
glfw: Add StickyModes to window.InputMode (resolve #314 #399)

### DIFF
--- a/internal/ui/ui_glfw.go
+++ b/internal/ui/ui_glfw.go
@@ -88,7 +88,8 @@ func initialize() error {
 		mode = glfw.CursorHidden
 	}
 	currentUI.window.SetInputMode(glfw.CursorMode, mode)
-
+	currentUI.window.SetInputMode(glfw.StickyMouseButtonsMode, glfw.True)
+	currentUI.window.SetInputMode(glfw.StickyKeysMode, glfw.True)
 	return nil
 }
 


### PR DESCRIPTION
I have implemented it just for desktop to detect the pulse input less than 1/60 minute. I don't know much about for browser or mobile.
It should resolve https://github.com/hajimehoshi/ebiten/issues/314 and https://github.com/hajimehoshi/ebiten/issues/399 for desktop.