### PR TITLE
Allow vertex colors

### DIFF
--- a/internal/graphics/program.go
+++ b/internal/graphics/program.go
@@ -102,6 +102,11 @@ var (
 				dataType: opengl.Float,
 				num:      2,
 			},
+			{
+				name:     "color",
+				dataType: opengl.Float,
+				num:      4,
+			},
 		},
 	}
 )

--- a/internal/graphics/shader.go
+++ b/internal/graphics/shader.go
@@ -48,13 +48,17 @@ uniform mat4 projection_matrix;
 attribute vec2 vertex;
 attribute vec4 tex_coord;
 attribute vec4 geo_matrix_body;
+attribute vec4 color;
 attribute vec2 geo_matrix_translation;
 varying vec2 varying_tex_coord;
 varying vec2 varying_tex_coord_min;
 varying vec2 varying_tex_coord_max;
+varying vec4 varying_color;
 
 void main(void) {
   varying_tex_coord = vec2(tex_coord[0], tex_coord[1]);
+  varying_color = color;
+
   varying_tex_coord_min =
     vec2(min(tex_coord[0], tex_coord[2]), min(tex_coord[1], tex_coord[3]));
   varying_tex_coord_max =
@@ -90,6 +94,7 @@ uniform highp vec2 source_size;
 varying highp vec2 varying_tex_coord;
 varying highp vec2 varying_tex_coord_min;
 varying highp vec2 varying_tex_coord_max;
+varying vec4 varying_color;
 
 highp vec2 roundTexel(highp vec2 p) {
   // highp (relative) precision is 2^(-16) in the spec.
@@ -104,7 +109,7 @@ void main(void) {
   highp vec2 pos = varying_tex_coord;
 
 #if defined(FILTER_NEAREST)
-  vec4 color = texture2D(texture, pos);
+  vec4 color = texture2D(texture, pos) * varying_color;
   if (pos.x < varying_tex_coord_min.x ||
     pos.y < varying_tex_coord_min.y ||
     varying_tex_coord_max.x <= pos.x ||
@@ -142,7 +147,7 @@ void main(void) {
   }
 
   vec2 rate = fract(pos * source_size);
-  vec4 color = mix(mix(c0, c1, rate.x), mix(c2, c3, rate.x), rate.y);
+  vec4 color = mix(mix(c0, c1, rate.x), mix(c2, c3, rate.x), rate.y) * varying_color;
 #endif
 
   // Un-premultiply alpha

--- a/internal/restorable/image.go
+++ b/internal/restorable/image.go
@@ -66,6 +66,9 @@ type Image struct {
 	basePixels []uint8
 	baseColor  color.RGBA
 
+	// colors provides per-vertex color overrides
+	colors []color.RGBA
+
 	// drawImageHistory is a set of draw-image commands.
 	// TODO: This should be merged with the similar command queue in package graphics (#433).
 	drawImageHistory []*drawImageHistoryItem
@@ -170,6 +173,27 @@ func (i *Image) Fill(r, g, b, a uint8) {
 	i.drawImageHistory = nil
 	i.stale = false
 	i.image.Fill(r, g, b, a)
+}
+
+// Colors returns the vertex colors, if any.
+func (p *Image) Colors() []color.RGBA {
+	return p.colors
+}
+
+// SetColor sets a vertex color for one corner of the image.
+// If only some corners are set, others default to opaque
+// white, or no modification.
+func (p *Image) SetColor(index int, clr color.RGBA) {
+	if index < 0 || index > 3 {
+		return
+	}
+	if p.colors == nil {
+		p.colors = make([]color.RGBA, 4)
+		for i := 0; i < 4; i++ {
+			p.colors[i] = color.RGBA{255, 255, 255, 255}
+		}
+	}
+	p.colors[index] = clr
 }
 
 // ReplacePixels replaces the image pixels with the given pixels slice.
@@ -372,6 +396,7 @@ func (i *Image) Dispose() {
 	i.image = nil
 	i.basePixels = nil
 	i.baseColor = color.RGBA{}
+	i.colors = nil
 	i.drawImageHistory = nil
 	i.stale = false
 	theImages.remove(i)

--- a/internal/restorable/images_test.go
+++ b/internal/restorable/images_test.go
@@ -79,10 +79,10 @@ func vertices(sw, sh int, x, y int) []float32 {
 
 	// For the rule of values, see vertices.go.
 	return []float32{
-		0, 0, 0, 0, 1, 1, a, b, c, d, tx, ty,
-		0, shf, 0, 1, 1, 0, a, b, c, d, tx, ty,
-		swf, 0, 1, 0, 0, 1, a, b, c, d, tx, ty,
-		swf, shf, 1, 1, 0, 0, a, b, c, d, tx, ty,
+		0, 0, 0, 0, 1, 1, a, b, c, d, tx, ty, 1, 1, 1, 1,
+		0, shf, 0, 1, 1, 0, a, b, c, d, tx, ty, 1, 1, 1, 1,
+		swf, 0, 1, 0, 0, 1, a, b, c, d, tx, ty, 1, 1, 1, 1,
+		swf, shf, 1, 1, 0, 0, a, b, c, d, tx, ty, 1, 1, 1, 1,
 	}
 }
 

--- a/vertices.go
+++ b/vertices.go
@@ -15,6 +15,8 @@
 package ebiten
 
 import (
+	"image/color"
+
 	"github.com/hajimehoshi/ebiten/internal/affine"
 	"github.com/hajimehoshi/ebiten/internal/restorable"
 )
@@ -44,6 +46,10 @@ func (v *verticesBackend) get() []float32 {
 }
 
 func vertices(sx0, sy0, sx1, sy1 int, width, height int, geo *affine.GeoM) []float32 {
+	return verticesColor(sx0, sy0, sx1, sy1, width, height, color.RGBA{255, 255, 255, 255}, color.RGBA{255, 255, 255, 255}, color.RGBA{255, 255, 255, 255}, color.RGBA{255, 255, 255, 255}, geo)
+}
+
+func verticesColor(sx0, sy0, sx1, sy1 int, width, height int, c0, c1, c2, c3 color.RGBA, geo *affine.GeoM) []float32 {
 	if sx0 >= sx1 || sy0 >= sy1 {
 		return nil
 	}
@@ -110,45 +116,62 @@ func vertices(sx0, sy0, sx1, sy1 int, width, height int, geo *affine.GeoM) []flo
 	vs[9] = g3
 	vs[10] = g4
 	vs[11] = g5
+	// vertex color
+	vs[12] = float32(c0.R) / 255
+	vs[13] = float32(c0.G) / 255
+	vs[14] = float32(c0.B) / 255
+	vs[15] = float32(c0.A) / 255
 
-	vs[12] = x1
-	vs[13] = y0
-	vs[14] = u1
-	vs[15] = v0
-	vs[16] = u0
-	vs[17] = v1
-	vs[18] = g0
-	vs[19] = g1
-	vs[20] = g2
-	vs[21] = g3
-	vs[22] = g4
-	vs[23] = g5
+	vs[16] = x1
+	vs[17] = y0
+	vs[18] = u1
+	vs[19] = v0
+	vs[20] = u0
+	vs[21] = v1
+	vs[22] = g0
+	vs[23] = g1
+	vs[24] = g2
+	vs[25] = g3
+	vs[26] = g4
+	vs[27] = g5
+	vs[28] = float32(c1.R) / 255
+	vs[29] = float32(c1.G) / 255
+	vs[30] = float32(c1.B) / 255
+	vs[31] = float32(c1.A) / 255
 
-	vs[24] = x0
-	vs[25] = y1
-	vs[26] = u0
-	vs[27] = v1
-	vs[28] = u1
-	vs[29] = v0
-	vs[30] = g0
-	vs[31] = g1
-	vs[32] = g2
-	vs[33] = g3
-	vs[34] = g4
-	vs[35] = g5
+	vs[32] = x0
+	vs[33] = y1
+	vs[34] = u0
+	vs[35] = v1
+	vs[36] = u1
+	vs[37] = v0
+	vs[38] = g0
+	vs[39] = g1
+	vs[40] = g2
+	vs[41] = g3
+	vs[42] = g4
+	vs[43] = g5
+	vs[44] = float32(c2.R) / 255
+	vs[45] = float32(c2.G) / 255
+	vs[46] = float32(c2.B) / 255
+	vs[47] = float32(c2.A) / 255
 
-	vs[36] = x1
-	vs[37] = y1
-	vs[38] = u1
-	vs[39] = v1
-	vs[40] = u0
-	vs[41] = v0
-	vs[42] = g0
-	vs[43] = g1
-	vs[44] = g2
-	vs[45] = g3
-	vs[46] = g4
-	vs[47] = g5
+	vs[48] = x1
+	vs[49] = y1
+	vs[50] = u1
+	vs[51] = v1
+	vs[52] = u0
+	vs[53] = v0
+	vs[54] = g0
+	vs[55] = g1
+	vs[56] = g2
+	vs[57] = g3
+	vs[58] = g4
+	vs[59] = g5
+	vs[60] = float32(c3.R) / 255
+	vs[61] = float32(c3.G) / 255
+	vs[62] = float32(c3.B) / 255
+	vs[63] = float32(c3.A) / 255
 
 	return vs
 }


### PR DESCRIPTION
This is more applicable for things like line-drawing, but specifying
colors per-vertex allows OpenGL to handle gradients in hardware,
which makes them a lot prettier than if you had to do them in
your images, also quite a lot faster.

Signed-off-by: Seebs <seebs@seebs.net>

(This is related to my interest in using scaled "images" consisting of a single white pixel as a way to rapidly draw lines with actual thickness, etc., unlike what DrawLine and DrawRect can do.)