### PR TITLE
Dump exp: remove, minify defer statements and use log.Fatal instead of panic in test

### DIFF
--- a/ebitenutil/loadimage.go
+++ b/ebitenutil/loadimage.go
@@ -38,9 +38,7 @@ func NewImageFromFile(path string, filter ebiten.Filter) (*ebiten.Image, image.I
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() {
-		_ = file.Close()
-	}()
+	defer file.Close()
 	img, _, err := image.Decode(file)
 	if err != nil {
 		return nil, nil, err

--- a/graphicscontext.go
+++ b/graphicscontext.go
@@ -142,7 +142,6 @@ func (c *graphicsContext) Update(afterFrameUpdate func()) error {
 			if err != nil {
 				return err
 			}
-			defer f.Close()
 			if err := png.Encode(f, img); err != nil {
 				return err
 			}

--- a/image_test.go
+++ b/image_test.go
@@ -21,6 +21,7 @@ import (
 	"image/color"
 	"image/draw"
 	_ "image/png"
+	"log"
 	"math"
 	"os"
 	"testing"
@@ -44,7 +45,7 @@ func TestMain(m *testing.M) {
 		return regularTermination
 	}
 	if err := Run(f, 320, 240, 1, "Test"); err != nil && err != regularTermination {
-		panic(err)
+		log.Fatal(err)
 	}
 	os.Exit(code)
 }


### PR DESCRIPTION
acording to 7e21a21c7663d88a7787270accddb50cc654e088, [this](https://github.com/hajimehoshi/ebiten/blob/7e21a21c7663d88a7787270accddb50cc654e088/graphicscontext.go#L145) could be dropped, also made a few small related changes. 