### PR TITLE
Do not allocate a touch slice if no touches have been made

### DIFF
--- a/input.go
+++ b/input.go
@@ -122,16 +122,13 @@ type Touch interface {
 
 // Touches returns the current touch states.
 //
-// Touches will return nil when there are no touches.
+// Touches returns nil when there are no touches.
 // Touches always returns nil on desktops.
 func Touches() []Touch {
-	t := ui.AdjustedTouches()
-	if len(t) == 0 {
-		return nil
+	touches := ui.AdjustedTouches()
+	var copies []Touch
+	for _, touch := range touches {
+		copies = append(copies, touch)
 	}
-	tt := make([]Touch, len(t))
-	for i := 0; i < len(tt); i++ {
-		tt[i] = t[i]
-	}
-	return tt
+	return copies
 }

--- a/input.go
+++ b/input.go
@@ -122,6 +122,7 @@ type Touch interface {
 
 // Touches returns the current touch states.
 //
+// Touches will return nil when there are no touches.
 // Touches always returns nil on desktops.
 func Touches() []Touch {
 	t := ui.AdjustedTouches()

--- a/input.go
+++ b/input.go
@@ -125,6 +125,9 @@ type Touch interface {
 // Touches always returns nil on desktops.
 func Touches() []Touch {
 	t := ui.AdjustedTouches()
+	if len(t) == 0 {
+		return nil
+	}
 	tt := make([]Touch, len(t))
 	for i := 0; i < len(tt); i++ {
 		tt[i] = t[i]


### PR DESCRIPTION
Touches() will always allocate a new slice to copy touches into even if no touches are reported, for example on desktop. Adding a simple check makes sure that this unnecessary allocation does not happen.