### PR TITLE
Enable mouse wheel input

### DIFF
--- a/input.go
+++ b/input.go
@@ -52,7 +52,7 @@ func CursorPosition() (x, y int) {
 	return ui.AdjustedCursorPosition()
 }
 
-// MouseScroll returns the x and y offset of the scroll wheel.
+// MouseWheel returns the x and y offset of the scroll wheel.
 // It returns 0 if the wheel isn't being rolled.
 func MouseWheel() (xoff, yoff float64) {
 	return input.Get().MouseWheel()

--- a/input.go
+++ b/input.go
@@ -52,8 +52,8 @@ func CursorPosition() (x, y int) {
 	return ui.AdjustedCursorPosition()
 }
 
-// MouseScroll returns the x and y offset of the scroll wheel or scrolling device.
-// For a scroll wheel it returns 0 if the wheel isn't being rolled.
+// MouseScroll returns the x and y offset of the scroll wheel.
+// It returns 0 if the wheel isn't being rolled.
 func MouseScroll() (xoff, yoff float64) {
 	return input.Get().MouseScroll()
 }

--- a/input.go
+++ b/input.go
@@ -55,7 +55,7 @@ func CursorPosition() (x, y int) {
 // MouseScroll returns the x and y offset of the scroll wheel.
 // It returns 0 if the wheel isn't being rolled.
 func MouseWheel() (xoff, yoff float64) {
-	return input.Get().MouseScroll()
+	return input.Get().MouseWheel()
 }
 
 // IsMouseButtonPressed returns a boolean indicating whether mouseButton is pressed.

--- a/input.go
+++ b/input.go
@@ -52,8 +52,9 @@ func CursorPosition() (x, y int) {
 	return ui.AdjustedCursorPosition()
 }
 
-// MouseScroll returns the y offset of the mouse wheel
-func MouseScroll() float64 {
+// MouseScroll returns the x and y offset of the scroll wheel or scrolling device.
+// For a scroll wheel it returns 0 if the wheel isn't being rolled.
+func MouseScroll() (xoff, yoff float64) {
 	return input.Get().MouseScroll()
 }
 

--- a/input.go
+++ b/input.go
@@ -52,6 +52,11 @@ func CursorPosition() (x, y int) {
 	return ui.AdjustedCursorPosition()
 }
 
+// MouseScroll returns the y offset of the mouse wheel
+func MouseScroll() float64 {
+	return input.Get().MouseScroll()
+}
+
 // IsMouseButtonPressed returns a boolean indicating whether mouseButton is pressed.
 //
 // This function is concurrent-safe.

--- a/input.go
+++ b/input.go
@@ -54,7 +54,7 @@ func CursorPosition() (x, y int) {
 
 // MouseScroll returns the x and y offset of the scroll wheel.
 // It returns 0 if the wheel isn't being rolled.
-func MouseScroll() (xoff, yoff float64) {
+func MouseWheel() (xoff, yoff float64) {
 	return input.Get().MouseScroll()
 }
 

--- a/internal/input/input_glfw.go
+++ b/internal/input/input_glfw.go
@@ -30,9 +30,9 @@ import (
 type Input struct {
 	keyPressed         map[glfw.Key]bool
 	mouseButtonPressed map[glfw.MouseButton]bool
-	scrollX		   float64
-	scrollY		   float64
-	scrollTime	   time.Time
+	scrollX            float64
+	scrollY            float64
+	scrollTime         time.Time
 	cursorX            int
 	cursorY            int
 	gamepads           [16]gamePad

--- a/internal/input/input_glfw.go
+++ b/internal/input/input_glfw.go
@@ -21,7 +21,6 @@ package input
 
 import (
 	"sync"
-	"time"
 	"unicode"
 
 	glfw "github.com/go-gl/glfw/v3.2/glfw"
@@ -32,7 +31,6 @@ type Input struct {
 	mouseButtonPressed map[glfw.MouseButton]bool
 	scrollX            float64
 	scrollY            float64
-	scrollTime         time.Time
 	cursorX            int
 	cursorY            int
 	gamepads           [16]gamePad
@@ -51,6 +49,12 @@ func (i *Input) ClearRuneBuffer() {
 	i.m.RLock()
 	defer i.m.RUnlock()
 	i.runeBuffer = i.runeBuffer[:0]
+}
+
+func (i *Input) ResetScrollValues() {
+	i.m.RLock()
+	defer i.m.RUnlock()
+	i.scrollX, i.scrollY = 0, 0
 }
 
 func (i *Input) IsKeyPressed(key Key) bool {
@@ -116,12 +120,8 @@ func (i *Input) Update(window *glfw.Window, scale float64) {
 			i.m.Lock()
 			i.scrollX = xoff
 			i.scrollY = yoff
-			i.scrollTime = time.Now() // this is a rather inelegant way of setting the scroll value to 0 if no scrolling is happening
 			i.m.Unlock()
 		})
-	}
-	if time.Now() != i.scrollTime {
-		i.scrollX, i.scrollY = 0, 0
 	}
 	if i.keyPressed == nil {
 		i.keyPressed = map[glfw.Key]bool{}

--- a/internal/input/input_glfw.go
+++ b/internal/input/input_glfw.go
@@ -30,8 +30,9 @@ import (
 type Input struct {
 	keyPressed         map[glfw.Key]bool
 	mouseButtonPressed map[glfw.MouseButton]bool
-	scrollY			   float64
-	scrollTime		   time.Time
+	scrollX		   float64
+	scrollY		   float64
+	scrollTime	   time.Time
 	cursorX            int
 	cursorY            int
 	gamepads           [16]gamePad
@@ -86,10 +87,10 @@ func (i *Input) IsMouseButtonPressed(button MouseButton) bool {
 	return false
 }
 
-func (i *Input) MouseScroll() float64 {
+func (i *Input) MouseScroll() (xoff, yoff) float64) {
 	i.m.RLock()
 	defer i.m.RUnlock()
-	return i.scrollY
+	return i.scrollX, i.scrollY
 }
 
 var glfwMouseButtonToMouseButton = map[glfw.MouseButton]MouseButton{
@@ -113,12 +114,13 @@ func (i *Input) Update(window *glfw.Window, scale float64) {
 		// I added this in here so that it would only be run once too
 		window.SetScrollCallback(func(w *glfw.Window, xoff float64, yoff float64) {
 			i.m.Lock()
+			i.scrollX = xoff
 			i.scrollY = yoff
 			i.scrollTime = time.Now()
 			i.m.Unlock()
 		})
 	}
-	if time.Now() != i.scrollTime { i.scrollY = 0 } // this is a rather inelegant way of setting the scroll value to 0 if no scrolling is happening
+	if time.Now() != i.scrollTime { i.scrollX, i.scrollY = 0, 0 } // this is a rather inelegant way of setting the scroll value to 0 if no scrolling is happening
 	if i.keyPressed == nil {
 		i.keyPressed = map[glfw.Key]bool{}
 	}

--- a/internal/input/input_glfw.go
+++ b/internal/input/input_glfw.go
@@ -91,7 +91,7 @@ func (i *Input) IsMouseButtonPressed(button MouseButton) bool {
 	return false
 }
 
-func (i *Input) MouseScroll() (xoff, yoff float64) {
+func (i *Input) MouseWheel() (xoff, yoff float64) {
 	i.m.RLock()
 	defer i.m.RUnlock()
 	return i.scrollX, i.scrollY

--- a/internal/input/input_glfw.go
+++ b/internal/input/input_glfw.go
@@ -21,8 +21,8 @@ package input
 
 import (
 	"sync"
-	"unicode"
 	"time"
+	"unicode"
 
 	glfw "github.com/go-gl/glfw/v3.2/glfw"
 )
@@ -116,11 +116,13 @@ func (i *Input) Update(window *glfw.Window, scale float64) {
 			i.m.Lock()
 			i.scrollX = xoff
 			i.scrollY = yoff
-			i.scrollTime = time.Now()
+			i.scrollTime = time.Now() // this is a rather inelegant way of setting the scroll value to 0 if no scrolling is happening
 			i.m.Unlock()
 		})
 	}
-	if time.Now() != i.scrollTime { i.scrollX, i.scrollY = 0, 0 } // this is a rather inelegant way of setting the scroll value to 0 if no scrolling is happening
+	if time.Now() != i.scrollTime {
+		i.scrollX, i.scrollY = 0, 0
+	}
 	if i.keyPressed == nil {
 		i.keyPressed = map[glfw.Key]bool{}
 	}

--- a/internal/input/input_glfw.go
+++ b/internal/input/input_glfw.go
@@ -87,7 +87,7 @@ func (i *Input) IsMouseButtonPressed(button MouseButton) bool {
 	return false
 }
 
-func (i *Input) MouseScroll() (xoff, yoff) float64) {
+func (i *Input) MouseScroll() (xoff, yoff float64) {
 	i.m.RLock()
 	defer i.m.RUnlock()
 	return i.scrollX, i.scrollY

--- a/internal/input/input_js.go
+++ b/internal/input/input_js.go
@@ -49,11 +49,6 @@ func (i *Input) ClearRuneBuffer() {
 	i.runeBuffer = nil
 }
 
-func (i *Input) ResetScrollValues() {
-	// Do nothing
-	// TODO: add fields to 'Input' and implement mouse scroll functionality
-}
-
 func (i *Input) IsKeyPressed(key Key) bool {
 	if i.keyPressed != nil {
 		for _, c := range keyToCodes[key] {

--- a/internal/input/input_js.go
+++ b/internal/input/input_js.go
@@ -91,10 +91,6 @@ func (i *Input) IsMouseButtonPressed(button MouseButton) bool {
 	return false
 }
 
-func (i *Input) MouseScroll() (xoff, yoff float64) {
-	return 0, 0
-}
-
 func (i *Input) keyDown(code string) {
 	if i.keyPressed == nil {
 		i.keyPressed = map[string]bool{}

--- a/internal/input/input_js.go
+++ b/internal/input/input_js.go
@@ -91,9 +91,9 @@ func (i *Input) IsMouseButtonPressed(button MouseButton) bool {
 	return false
 }
 
-// TODO: Mouse scroll functionality is not yet implemented in js
 func (i *Input) MouseWheel() (xoff, yoff float64) {
 	return 0, 0
+	// TODO: Mouse scroll functionality is not yet implemented in js
 }
 
 func (i *Input) keyDown(code string) {

--- a/internal/input/input_js.go
+++ b/internal/input/input_js.go
@@ -49,6 +49,11 @@ func (i *Input) ClearRuneBuffer() {
 	i.runeBuffer = nil
 }
 
+func (i *Input) ResetScrollValues() {
+	// Do nothing
+	// TODO: add fields to 'Input' and implement mouse scroll functionality
+}
+
 func (i *Input) IsKeyPressed(key Key) bool {
 	if i.keyPressed != nil {
 		for _, c := range keyToCodes[key] {
@@ -91,6 +96,7 @@ func (i *Input) IsMouseButtonPressed(button MouseButton) bool {
 	return false
 }
 
+// TODO: Mouse scroll functionality is not yet implemented in js
 func (i *Input) MouseScroll() (xoff, yoff float64) {
 	return 0, 0
 }

--- a/internal/input/input_js.go
+++ b/internal/input/input_js.go
@@ -97,7 +97,7 @@ func (i *Input) IsMouseButtonPressed(button MouseButton) bool {
 }
 
 // TODO: Mouse scroll functionality is not yet implemented in js
-func (i *Input) MouseScroll() (xoff, yoff float64) {
+func (i *Input) MouseWheel() (xoff, yoff float64) {
 	return 0, 0
 }
 

--- a/internal/input/input_js.go
+++ b/internal/input/input_js.go
@@ -91,6 +91,10 @@ func (i *Input) IsMouseButtonPressed(button MouseButton) bool {
 	return false
 }
 
+func (i *Input) MouseScroll() (xoff, yoff float64) {
+	return 0, 0
+}
+
 func (i *Input) keyDown(code string) {
 	if i.keyPressed == nil {
 		i.keyPressed = map[string]bool{}

--- a/internal/input/input_mobile.go
+++ b/internal/input/input_mobile.go
@@ -38,7 +38,7 @@ func (i *Input) IsKeyPressed(key Key) bool {
 	return false
 }
 
-func (i *Input) MouseScroll() (xoff, yoff float64) {
+func (i *Input) MouseWheel() (xoff, yoff float64) {
 	return 0, 0
 }
 

--- a/internal/input/input_mobile.go
+++ b/internal/input/input_mobile.go
@@ -38,7 +38,6 @@ func (i *Input) IsKeyPressed(key Key) bool {
 	return false
 }
 
-// TODO: Scrolling is not yet implemented on mobile.
 func (i *Input) MouseWheel() (xoff, yoff float64) {
 	return 0, 0
 }

--- a/internal/input/input_mobile.go
+++ b/internal/input/input_mobile.go
@@ -23,6 +23,8 @@ import (
 type Input struct {
 	cursorX  int
 	cursorY  int
+	scrollX  float64
+	scrollY  float64
 	gamepads [16]gamePad
 	touches  []*Touch
 	m        sync.RWMutex
@@ -36,12 +38,12 @@ func (i *Input) IsKeyPressed(key Key) bool {
 	return false
 }
 
-func (i *Input) IsMouseButtonPressed(key MouseButton) bool {
-	return false
-}
-
 func (i *Input) MouseScroll() (xoff, yoff float64) {
 	return 0, 0
+}
+
+func (i *Input) IsMouseButtonPressed(key MouseButton) bool {
+	return false
 }
 
 func (i *Input) UpdateTouches(touches []*Touch) {

--- a/internal/input/input_mobile.go
+++ b/internal/input/input_mobile.go
@@ -38,6 +38,7 @@ func (i *Input) IsKeyPressed(key Key) bool {
 	return false
 }
 
+// TODO: Scrolling is not yet implemented on mobile.
 func (i *Input) MouseWheel() (xoff, yoff float64) {
 	return 0, 0
 }

--- a/internal/input/input_mobile.go
+++ b/internal/input/input_mobile.go
@@ -40,6 +40,10 @@ func (i *Input) IsMouseButtonPressed(key MouseButton) bool {
 	return false
 }
 
+func (i *Input) MouseScroll() (xoff, yoff float64) {
+	return 0, 0
+}
+
 func (i *Input) UpdateTouches(touches []*Touch) {
 	i.m.Lock()
 	i.touches = touches // TODO: Need copy?

--- a/internal/ui/ui_glfw.go
+++ b/internal/ui/ui_glfw.go
@@ -567,6 +567,7 @@ func (u *userInterface) update(g GraphicsContext) error {
 	})
 	if err := g.Update(func() {
 		input.Get().ClearRuneBuffer()
+		input.Get().ResetScrollValues()
 		// The offscreens must be updated every frame (#490).
 		u.updateGraphicsContext(g)
 	}); err != nil {

--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -194,6 +194,7 @@ func (u *userInterface) update(g GraphicsContext) error {
 	u.updateGraphicsContext(g)
 	if err := g.Update(func() {
 		input.Get().ClearRuneBuffer()
+		// TODO: insert ResetScrollValues() counterpart to 'ui_glfw.go' here
 		// The offscreens must be updated every frame (#490).
 		u.updateGraphicsContext(g)
 	}); err != nil {


### PR DESCRIPTION
This change simply adds the funcionality to read mouse wheel input, which (at least for me) is a very necessary feature. My solution is clearly not perfect, as I do rely on somewhat of a workaround to reset the scrolling value to 0 while no scroll events happen. That should probably be changed, but I hope  you forgive me for that, as I am absolutely new to go and haven't been able to find an alternative to this yet, though it's probably pretty easy.