### PR TITLE
Seebs/benchmark

### DIFF
--- a/examples/bench/.gitignore
+++ b/examples/bench/.gitignore
@@ -1,0 +1,2 @@
+/heap-profile.dat
+/alloc-profile.dat

--- a/examples/bench/README.md
+++ b/examples/bench/README.md
@@ -1,0 +1,30 @@
+Initial rough-draft benchmarks
+
+This is intended to hold some sample tests to check Ebiten's performance
+under common loads. The benchmark code will runs a provided rendering
+function once per frame for 60 frames, reporting on the accumulated time
+spent in the frame update. This includes both the user-provided code
+and ebiten's internal frame update logic.
+
+The default for testing.Benchmark is to aim for a full second of runtime
+to try to ensure "stable" behavior. A full second of runtime over sixty
+frames means that we're dropping frames, and will produce undesired
+behaviors. To avoid this, this example overrides the default time, by
+default to 240ms (about 4ms/frame of rendering). You can override
+this further by specifying `-test.benchtime=duration`. Times close to
+a full second will likely produce erratic results, because ebiten will
+notice if it's missing frames.
+
+The first benchmark, "warmup", should probably be ignored; there's a
+lot of one-time setup costs to do with creating lists, etcetera, which
+don't apply during regular execution, and that test tries to get those
+to happen before the things we start measuring.
+
+Occasionally, the first iteration of a benchmark takes unexpectedly
+long and the benchmark code decides that it's done, and I don't know
+why. If you see something running only for N=1, with very large numbers
+reported per-op, you may want to re-run the test to get better
+numbers.
+
+You can request CPU profiling (-cpuprofile profile.dat), and memory
+profiling is done automatically, because it's cheap.

--- a/examples/bench/main.go
+++ b/examples/bench/main.go
@@ -1,0 +1,435 @@
+// Copyright 2018 The Ebiten Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build example jsgo
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"image"
+	"image/color"
+	_ "image/png"
+	"log"
+	"os"
+	"runtime/pprof"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hajimehoshi/ebiten"
+	"github.com/hajimehoshi/ebiten/examples/resources/images"
+	"github.com/hajimehoshi/ebiten/internal/testflock"
+)
+
+var noErr = errors.New("clean")
+
+type benchmark struct {
+	name   string
+	fn     func(b *testing.B, screen *ebiten.Image)
+	result testing.BenchmarkResult
+	output []string
+}
+
+const (
+	MAX_TRIANGLES = 1000
+	TRIANGLE_SIZE = 20
+)
+
+var (
+	width  = 640
+	height = 480
+	// images to use during the benchmarks
+	px26  *ebiten.Image
+	px104 *ebiten.Image
+	px416 *ebiten.Image
+	box   *ebiten.Image
+
+	benchIdx    = 0
+	results     []testing.BenchmarkResult
+	setup       sync.Once
+	benchFunc   func(b *testing.B, screen *ebiten.Image)
+	benchGo     = make(chan struct{})
+	benchDone   = make(chan bool)
+	vertices    = make([]ebiten.Vertex, 0, MAX_TRIANGLES*3)
+	indices     = make([]uint16, 0, MAX_TRIANGLES*3)
+	rainbow     = make([][3]float32, 120)
+	rainbowBase = []color.RGBA{
+		{240, 0, 0, 255},
+		{240, 90, 0, 255},
+		{220, 220, 0, 255},
+		{0, 200, 0, 255},
+		{0, 0, 255, 255},
+		{180, 0, 200, 255},
+	}
+)
+
+func main() {
+	// You can't specify minimum bench time, or whether you want allocation,
+	// directly in code, but because benchmarking per-frame is weird, we really
+	// want to control those. So what if we faked up command line parameters
+	// which have special meaning to the testing package?
+	cpuprofile := flag.String("cpuprofile", "", "file to store CPU profile data in")
+	newArgs := []string{os.Args[0], "-test.benchmem", "-test.v"}
+	timeGiven := false
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "-test.benchtime") {
+			timeGiven = true
+			break
+		}
+	}
+	if !timeGiven {
+		newArgs = append(newArgs, "-test.benchtime=240ms")
+	}
+	os.Args = append(newArgs, os.Args[1:]...)
+	flag.Parse()
+	testflock.Lock()
+	defer testflock.Unlock()
+
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatalf("can't create %s: %s", *cpuprofile, err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+	// log memory usage, too
+	defer func() {
+		f, err := os.Create("heap-profile.dat")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "can't create heap-profile.dat: %s", err)
+		} else {
+			pprof.Lookup("heap").WriteTo(f, 0)
+		}
+		f, err = os.Create("alloc-profile.dat")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "can't create alloc-profile.dat: %s", err)
+		} else {
+			pprof.Lookup("allocs").WriteTo(f, 0)
+		}
+	}()
+
+	// Run an Ebiten process so that (*Image).At is available.
+	f := func(screen *ebiten.Image) error {
+		return runBenchmarks(screen)
+	}
+	if err := ebiten.Run(f, width, height, 1, "Test"); err != nil && err != noErr {
+		panic(err)
+	}
+	for _, b := range benchList {
+		fmt.Println(b.name)
+		fmt.Println(b.result)
+		fmt.Println(b.result.MemString())
+		for i := 0; i < len(b.output); i++ {
+			fmt.Println(b.output[i])
+		}
+	}
+}
+
+var benchList = []benchmark{
+	{
+		// the warmup function is because some allocations happen only during
+		// initial setup, and can throw timing severely off.
+		name: "warmup (ignore)",
+		fn: func(b *testing.B, screen *ebiten.Image) {
+			op := &ebiten.DrawImageOptions{}
+			for i := 0; i < b.N; i++ {
+				op.GeoM.Reset()
+				op.GeoM.Translate(float64(i*width/b.N), float64(i*height/b.N))
+				screen.DrawImage(px26, op)
+			}
+		},
+	},
+	{
+		name: "draw26",
+		fn: func(b *testing.B, screen *ebiten.Image) {
+			op := &ebiten.DrawImageOptions{}
+			for i := 0; i < b.N; i++ {
+				op.GeoM.Reset()
+				op.GeoM.Translate(float64(i*width/b.N), float64(i*height/b.N))
+				screen.DrawImage(px26, op)
+			}
+		},
+	},
+	{
+		name: "draw104",
+		fn: func(b *testing.B, screen *ebiten.Image) {
+			op := &ebiten.DrawImageOptions{}
+			for i := 0; i < b.N; i++ {
+				op.GeoM.Reset()
+				op.GeoM.Translate(float64(i*width/b.N), float64(i*height/b.N))
+				screen.DrawImage(px104, op)
+			}
+		},
+	},
+	{
+		name: "draw416",
+		fn: func(b *testing.B, screen *ebiten.Image) {
+			op := &ebiten.DrawImageOptions{}
+			for i := 0; i < b.N; i++ {
+				op.GeoM.Reset()
+				op.GeoM.Translate(float64(i*width/b.N), float64(i*height/b.N))
+				screen.DrawImage(px416, op)
+			}
+		},
+	},
+	{
+		name: "draw26color1",
+		fn: func(b *testing.B, screen *ebiten.Image) {
+			ops := []*ebiten.DrawImageOptions{&ebiten.DrawImageOptions{}, &ebiten.DrawImageOptions{}}
+			ops[0].ColorM.Scale(1.0, 0.2, 0.2, 1.0)
+			ops[1].ColorM.Scale(0.2, 1.0, 0.2, 1.0)
+			for i := 0; i < b.N; i++ {
+				idx := i
+				ops[idx%2].GeoM.Reset()
+				ops[idx%2].GeoM.Translate(float64(i*width/b.N), float64(i*height/b.N))
+				screen.DrawImage(px26, ops[idx%2])
+			}
+		},
+	},
+	{
+		name: "draw26color10",
+		fn: func(b *testing.B, screen *ebiten.Image) {
+			ops := []*ebiten.DrawImageOptions{&ebiten.DrawImageOptions{}, &ebiten.DrawImageOptions{}}
+			ops[0].ColorM.Scale(1.0, 0.2, 0.2, 1.0)
+			ops[1].ColorM.Scale(0.2, 1.0, 0.2, 1.0)
+			for i := 0; i < b.N; i++ {
+				idx := i / 10
+				ops[idx%2].GeoM.Reset()
+				ops[idx%2].GeoM.Translate(float64(i*width/b.N), float64(i*height/b.N))
+				screen.DrawImage(px26, ops[idx%2])
+			}
+		},
+	},
+	{
+		name: "triangles100",
+		fn:   drawNTrianglesFunc(100),
+	},
+	{
+		name: "triangles500",
+		fn:   drawNTrianglesFunc(500),
+	},
+	{
+		name: "triangles1000",
+		fn:   drawNTrianglesFunc(1000),
+	},
+}
+
+func interpolate(into [][3]float32, from, to color.RGBA) {
+	r0, g0, b0 := int(from.R), int(from.G), int(from.B)
+	r1, g1, b1 := int(to.R), int(to.G), int(to.B)
+	n := len(into)
+
+	for i := 0; i < n; i++ {
+		inv := n - i
+		r := (r0*inv + r1*i) / n
+		g := (g0*inv + g1*i) / n
+		b := (b0*inv + b1*i) / n
+
+		into[i] = [3]float32{float32(r) / 255, float32(g) / 255, float32(b) / 255}
+	}
+}
+
+func runBenchmarks(screen *ebiten.Image) error {
+	var setupErr error
+
+	// We need to run this exactly once, but it has to happen inside an
+	// actual update loop so ebiten is fully up and running.
+	setup.Do(func() {
+		eimg, _, err := openEbitenImage()
+		if err != nil {
+			setupErr = fmt.Errorf("can't open image: %s", err)
+			return
+		}
+		px26 = eimg
+		box, err = makeWhiteBox()
+		if err != nil {
+			setupErr = fmt.Errorf("can't create white box: %s", err)
+			return
+		}
+
+		w, h := eimg.Size()
+		img, err := ebiten.NewImage(w*4, h*4, ebiten.FilterNearest)
+		if err != nil {
+			setupErr = fmt.Errorf("can't create new image: %s", err)
+			return
+		}
+		px104 = img
+
+		op := &ebiten.DrawImageOptions{}
+		op.GeoM.Scale(4, 4)
+		px104.DrawImage(px26, op)
+
+		img, err = ebiten.NewImage(w*16, h*16, ebiten.FilterNearest)
+		if err != nil {
+			setupErr = fmt.Errorf("can't create new image: %s", err)
+			return
+		}
+		px416 = img
+		op.GeoM.Scale(4, 4)
+		px416.DrawImage(px26, op)
+
+		// initialize a pretty rainbow palette
+		prev := rainbowBase[0]
+		scale := len(rainbow) / len(rainbowBase)
+		for idx, next := range rainbowBase[1:] {
+			offset := idx * scale
+			interpolate(rainbow[offset:offset+scale], prev, next)
+			prev = next
+		}
+		interpolate(rainbow[(len(rainbowBase)-1)*scale:], prev, rainbowBase[0])
+	})
+	if setupErr != nil {
+		return setupErr
+	}
+
+	if benchFunc != nil {
+		benchGo <- struct{}{}
+		if <-benchDone {
+			benchFunc = nil
+		}
+	} else {
+		if benchIdx >= len(benchList) {
+			return noErr
+		}
+		benchFunc = benchList[benchIdx].fn
+		go func(idx int) {
+			benchList[idx].result = testing.Benchmark(func(b *testing.B) {
+				// ebiten will start/stop the benchmark's timer during the
+				// actual frame update, including time spent calling the user
+				// update function, but also any rendering calls during the
+				// update.
+				b.StopTimer()
+				// ensure that the change to the copy of the interface
+				// inside ebiten happens during the next frame, not the
+				// frame this goroutine started in.
+				<-benchGo
+				ebiten.SetBenchmark(b)
+				benchDone <- false
+				var elapsed time.Duration
+				// run for at least 60 frames, so the FPS value should mean something
+				for i := 0; i < 60; i++ {
+					<-benchGo
+					t0 := time.Now()
+					benchFunc(b, screen)
+					t1 := time.Now()
+					elapsed += t1.Sub(t0)
+					benchDone <- false
+				}
+				out := fmt.Sprintf("    N %5d, FPS: %5.2f, time %10v/60 frames", b.N, ebiten.CurrentFPS(), elapsed)
+				benchList[idx].output = append(benchList[idx].output, out)
+				<-benchGo
+				ebiten.SetBenchmark(nil)
+				benchDone <- false
+			})
+			<-benchGo
+			benchDone <- true
+		}(benchIdx)
+		benchIdx++
+	}
+	return nil
+}
+
+func openEbitenImage() (*ebiten.Image, image.Image, error) {
+	img, _, err := image.Decode(bytes.NewReader(images.Ebiten_png))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	eimg, err := ebiten.NewImageFromImage(img, ebiten.FilterNearest)
+	if err != nil {
+		return nil, nil, err
+	}
+	return eimg, img, nil
+}
+
+func makeWhiteBox() (*ebiten.Image, error) {
+	img := image.NewRGBA(image.Rectangle{Min: image.Point{X: 0, Y: 0}, Max: image.Point{X: 16, Y: 16}})
+	col := color.RGBA{255, 255, 255, 255}
+	for r := 0; r < 16; r++ {
+		for c := 0; c < 16; c++ {
+			img.Set(c, r, col)
+		}
+	}
+	whiteBox, err := ebiten.NewImageFromImage(img, ebiten.FilterDefault)
+	return whiteBox, err
+}
+
+func drawSomeTriangles(screen *ebiten.Image, count int) {
+	triop := &ebiten.DrawTrianglesOptions{CompositeMode: ebiten.CompositeModeLighter}
+	points := []image.Point{
+		{X: 0, Y: 0},
+		{X: TRIANGLE_SIZE, Y: 0},
+		{X: 0, Y: TRIANGLE_SIZE},
+	}
+	srcs := []image.Point{
+		{X: 0, Y: 16},
+		{X: 0, Y: 0},
+		{X: 16, Y: 0},
+	}
+	for i := 0; i < count; i++ {
+		vs := vertices[i*3 : (i+1)*3]
+		rgb := rainbow[i%len(rainbow)]
+		for j := 0; j < 3; j++ {
+			vs[j] = ebiten.Vertex{
+				DstX: float32(points[j].X), DstY: float32(points[j].Y),
+				SrcX: float32(srcs[j].X), SrcY: float32(srcs[j].Y),
+				ColorR: rgb[0], ColorG: rgb[1], ColorB: rgb[2],
+				ColorA: 0.2,
+			}
+		}
+		// after each point, we want to make a new point.
+		switch i % 2 {
+		case 0: // move X over
+			// note order changes
+			points[0] = points[2]
+			points[2] = image.Point{points[0].X + TRIANGLE_SIZE, points[0].Y}
+		case 1:
+			points[0] = points[1]
+			points[1] = image.Point{points[0].X + TRIANGLE_SIZE, points[0].Y}
+		}
+		if points[0].X >= width {
+			points[0].X -= width
+			points[1].X -= width
+			points[2].X -= width
+			points[0].Y += TRIANGLE_SIZE
+			points[1].Y += TRIANGLE_SIZE
+			points[2].Y += TRIANGLE_SIZE
+		}
+		// loop when we've filled the screen
+		if points[0].Y >= height {
+			points[0].Y -= height
+			points[1].Y -= height
+			points[2].Y -= height
+		}
+		vertices = append(vertices, vs...)
+		indices = append(indices, uint16(i*3), uint16(i*3+1), uint16(i*3+2))
+	}
+	screen.DrawTriangles(vertices, indices, box, triop)
+	vertices = vertices[:0]
+	indices = indices[:0]
+}
+
+func drawNTrianglesFunc(count int) func(b *testing.B, screen *ebiten.Image) {
+	return func(b *testing.B, screen *ebiten.Image) {
+		for loop := 0; loop < b.N; loop++ {
+			drawSomeTriangles(screen, count)
+		}
+	}
+}

--- a/graphicscontext.go
+++ b/graphicscontext.go
@@ -91,6 +91,14 @@ func (c *graphicsContext) initializeIfNeeded() error {
 }
 
 func (c *graphicsContext) Update(afterFrameUpdate func()) error {
+	if activeBenchmark != nil {
+		activeBenchmark.StartTimer()
+		defer func() {
+			if activeBenchmark != nil {
+				activeBenchmark.StopTimer()
+			}
+		}()
+	}
 	tps := int(MaxTPS())
 	updateCount := clock.Update(tps)
 

--- a/run.go
+++ b/run.go
@@ -42,6 +42,24 @@ func CurrentFPS() float64 {
 	return clock.CurrentFPS()
 }
 
+// GraphicsBenchmark is a small-but-relevant subset of the interface
+// provided by testing.B; this is the subset of functionality needed to
+// have simple rendering benchmarks available.
+type GraphicsBenchmark interface {
+	StartTimer()
+	StopTimer()
+}
+
+var activeBenchmark GraphicsBenchmark
+
+// SetBenchmark tells the ebiten frame update loop to start and stop
+// a benchmark's timer during actual frame updates, allowing you to benchmark
+// performance of things happening during frames, over multiple frames;
+// see examples/bench for a usage example.
+func SetBenchmark(b GraphicsBenchmark) {
+	activeBenchmark = b
+}
+
 var (
 	isDrawingSkipped = int32(0)
 	currentMaxTPS    = int32(DefaultTPS)


### PR DESCRIPTION
This is not a very good benchmark tool, but it's any benchmark tool at all. The intrusive part is the hackery to run the benchmark's timer around the ResolveStaleImages call which actually does GL flushes; this gets us much more accurate data for things.

This runs each test for 60 frames, summing their times. Sample output:

```
draw26
    1000            150465 ns/op
    6455 B/op         11 allocs/op
draw104
    1000            147847 ns/op
    6900 B/op         12 allocs/op
draw416
    5000             26544 ns/op
    8344 B/op          8 allocs/op
draw26color1
      10          14516352 ns/op
   90716 B/op       1801 allocs/op
draw26color10
     100           1463022 ns/op
   14483 B/op        180 allocs/op
```

On my laptop, changing color with each draw operation costs nearly 10x as much as changing color every 10 draw operations, and any change of the ColorM value appears to cost an order of magnitude more than raw draw calls.

Now that I have this, I can try to compare it to, say, something that inserts the data in the vertex buffer.