### PR TITLE
Added monitor cache and scale cache

### DIFF
--- a/internal/devicescale/impl_unix.go
+++ b/internal/devicescale/impl_unix.go
@@ -39,9 +39,9 @@ const (
 )
 
 var (
-	cachedScale    float64
-	cachedAt       int64
-	scaleExpiresMS = int64(16)
+	cachedScale  float64
+	cachedAt     int64
+	scaleExpires = int64(time.Second / 60)
 )
 
 func currentDesktop() desktop {
@@ -103,8 +103,8 @@ func cinnamonScale() float64 {
 }
 
 func impl(x, y int) float64 {
-	now := time.Now().UnixNano() / int64(time.Millisecond)
-	if now-cachedAt < scaleExpiresMS {
+	now := time.Now().UnixNano()
+	if now-cachedAt < scaleExpires {
 		return cachedScale
 	}
 
@@ -127,7 +127,7 @@ func impl(x, y int) float64 {
 	}
 
 	// Cache the scale for later.
-	now = time.Now().UnixNano() / int64(time.Millisecond)
+	now = time.Now().UnixNano()
 	cachedScale = s
 	cachedAt = now
 	return 1

--- a/internal/devicescale/impl_unix.go
+++ b/internal/devicescale/impl_unix.go
@@ -108,18 +108,17 @@ func impl(x, y int) float64 {
 		return cachedScale
 	}
 
-	// TODO: Can Linux has different scales for multiple monitors?
-	//  Gnome supports fractional and per-monitor scaling in wayland.
 	s := 1.0
 	switch currentDesktop() {
 	case desktopGnome:
+		// TODO: Support wayland and per-monitor scaling https://wiki.gnome.org/HowDoI/HiDpi
 		s = gnomeScale()
 	case desktopCinnamon:
 		s = cinnamonScale()
 	case desktopUnity:
-		// TODO: Implement
+		// TODO: Implement, supports per-monitor scaling
 	case desktopKDE:
-		// TODO: Implement
+		// TODO: Implement, appears to support per-monitor scaling
 	case desktopXfce:
 		// TODO: Implement
 	}

--- a/internal/ui/ui_glfw.go
+++ b/internal/ui/ui_glfw.go
@@ -594,6 +594,10 @@ func (u *userInterface) getScale() float64 {
 
 // actualScreenScale must be called from the main thread.
 func (u *userInterface) actualScreenScale() float64 {
+	// Avoid calling monitor.GetPos if we have the monitor position cached already.
+	if cm, ok := getCachedMonitor(u.window.GetPos()); ok {
+		return u.getScale() * devicescale.GetAt(cm.x, cm.y)
+	}
 	return u.getScale() * devicescale.GetAt(u.currentMonitor().GetPos())
 }
 

--- a/internal/ui/ui_glfw.go
+++ b/internal/ui/ui_glfw.go
@@ -129,7 +129,7 @@ type cachedMonitor struct {
 	y int
 }
 
-// monitors is the cache for unix monitor list.
+// monitors is the monitor list cache for desktop glfw compile targets.
 // populated by 'cacheMonitors' which is called on init and every
 // monitor config change event.
 var monitors []*cachedMonitor

--- a/internal/ui/ui_unix.go
+++ b/internal/ui/ui_unix.go
@@ -26,15 +26,6 @@ import (
 
 func glfwScale() float64 {
 	// This function must be called on the main thread.
-	cm := currentUI.currentMonitor()
-
-	// Figure out if we have that monitor cached.
-	for _, m := range monitors {
-		if m.m == cm {
-			return m.scale
-		}
-	}
-	// Fallback to just getting the devicescale if we don't have it cached.
 	return devicescale.GetAt(currentUI.currentMonitor().GetPos())
 }
 

--- a/internal/ui/ui_unix.go
+++ b/internal/ui/ui_unix.go
@@ -26,7 +26,11 @@ import (
 
 func glfwScale() float64 {
 	// This function must be called on the main thread.
-	return devicescale.GetAt(currentUI.currentMonitor().GetPos())
+	cm, ok := getCachedMonitor(currentUI.window.GetPos())
+	if !ok {
+		return devicescale.GetAt(currentUI.currentMonitor().GetPos())
+	}
+	return devicescale.GetAt(cm.x, cm.y)
 }
 
 func adjustWindowPosition(x, y int) (int, int) {

--- a/internal/ui/ui_unix.go
+++ b/internal/ui/ui_unix.go
@@ -26,6 +26,15 @@ import (
 
 func glfwScale() float64 {
 	// This function must be called on the main thread.
+	cm := currentUI.currentMonitor()
+
+	// Figure out if we have that monitor cached.
+	for _, m := range monitors {
+		if m.m == cm {
+			return m.scale
+		}
+	}
+	// Fallback to just getting the devicescale if we don't have it cached.
 	return devicescale.GetAt(currentUI.currentMonitor().GetPos())
 }
 
@@ -35,14 +44,8 @@ func adjustWindowPosition(x, y int) (int, int) {
 
 func (u *userInterface) currentMonitorImpl() *glfw.Monitor {
 	// TODO: Return more appropriate display.
-	w := u.window
-	wx, wy := w.GetPos()
-	for _, m := range glfw.GetMonitors() {
-		mx, my := m.GetPos()
-		v := m.GetVideoMode()
-		if mx <= wx && wx < mx+v.Width && my <= wy && wy < my+v.Height {
-			return m
-		}
+	if cm, ok := getCachedMonitor(u.window.GetPos()); ok {
+		return cm.m
 	}
 	return glfw.GetPrimaryMonitor()
 }


### PR DESCRIPTION
resolves https://github.com/hajimehoshi/ebiten/issues/729

In Linux (and at least when using Gnome) requesting the monitors and scaling factor is very time consuming.

We can cache the list of all monitors and simply subscribe to a window change event to recalculate the window cache. This will get rid of needing to re-calculate monitors on every call to 'currentMonitorImpl' (at least in unix). The cache is implemented for all desktop clients because it could be helpful to other OSes (not just unix)

Additionally the scale can be cached for at least a single frame. It is possible that different monitors have different scale factor so the cache will probably need to be upgraded to be per-monitor once that is supported in unix.

I am not sure how to tell when a frame begins and ends (might be easier with https://github.com/hajimehoshi/ebiten/issues/713) so this is implemented with a time check. 

Here are pictures of profiles comparing old to new code, see the change so that GetAt is taking much less time per frame.
Before:
![old_profile](https://user-images.githubusercontent.com/577261/48092508-1793b680-e1ca-11e8-99df-b15340ba9855.jpg)
After:
![new_profile](https://user-images.githubusercontent.com/577261/48092510-195d7a00-e1ca-11e8-8de3-1de3298ea0bf.jpg)

