### PR TITLE
Clarify the type of passing parameters

### DIFF
--- a/internal/graphicsdriver/metal/driver.go
+++ b/internal/graphicsdriver/metal/driver.go
@@ -170,7 +170,7 @@ fragment float4 FragmentShader(VertexOut v [[stage_in]],
   }
   c = (color_matrix_body * c) + color_matrix_translation;
   c *= v.color;
-  c = clamp(c, 0, 1);
+  c = clamp(c, 0.0f, 1.0f);
   c.rgb *= c.a;
   return c;
 }

--- a/internal/graphicsdriver/metal/driver.go
+++ b/internal/graphicsdriver/metal/driver.go
@@ -170,7 +170,7 @@ fragment float4 FragmentShader(VertexOut v [[stage_in]],
   }
   c = (color_matrix_body * c) + color_matrix_translation;
   c *= v.color;
-  c = clamp(c, 0.0f, 1.0f);
+  c = clamp(c, 0.0, 1.0);
   c.rgb *= c.a;
   return c;
 }


### PR DESCRIPTION
I was getting the following error on High Sierra
```
program_source:141:7: error: call to 'clamp' is ambiguous
```

This change fixes the compile error