### PR TITLE
use Opengl instead on early MacOSX platform which does not support Metal

### DIFF
--- a/internal/graphicscommand/driver_mac.go
+++ b/internal/graphicscommand/driver_mac.go
@@ -20,8 +20,26 @@ package graphicscommand
 import (
 	"github.com/hajimehoshi/ebiten/internal/graphicsdriver"
 	"github.com/hajimehoshi/ebiten/internal/graphicsdriver/metal"
+	"github.com/hajimehoshi/ebiten/internal/graphicsdriver/metal/mtl"
+	"github.com/hajimehoshi/ebiten/internal/graphicsdriver/opengl"
 )
 
+// patch: some earlier Apple Mac product dose
+// NOT support Metal
+var is_MacOS_GPU_support_Metal = true
+
+func init() {
+	// on 1st initialization , detect Metal feature
+	_, err := mtl.CreateSystemDefaultDevice()
+	if err != nil {
+		is_MacOS_GPU_support_Metal = false
+	}
+}
+
 func Driver() graphicsdriver.GraphicsDriver {
-	return metal.Get()
+	if is_MacOS_GPU_support_Metal {
+		return metal.Get()
+	} else {
+		return opengl.Get()
+	}
 }

--- a/internal/graphicscommand/driver_mac.go
+++ b/internal/graphicscommand/driver_mac.go
@@ -24,20 +24,17 @@ import (
 	"github.com/hajimehoshi/ebiten/internal/graphicsdriver/opengl"
 )
 
-// patch: some earlier Apple Mac product dose
-// NOT support Metal
-var is_MacOS_GPU_support_Metal = true
+// isMetalSupported represents whether Metal is supported.
+var isMetalSupported = true
 
 func init() {
-	// on 1st initialization , detect Metal feature
-	_, err := mtl.CreateSystemDefaultDevice()
-	if err != nil {
-		is_MacOS_GPU_support_Metal = false
+	if _, err := mtl.CreateSystemDefaultDevice(); err != nil {
+		isMetalSupported = false
 	}
 }
 
 func Driver() graphicsdriver.GraphicsDriver {
-	if is_MacOS_GPU_support_Metal {
+	if isMetalSupported {
 		return metal.Get()
 	} else {
 		return opengl.Get()


### PR DESCRIPTION
Those early MacOS devices such like `iMac (21.5-inch, Mid 2011)`  do not support Metal.  
"Metal is not supported on this system"

I added a patch to detect whether this Mac support Metal , and use Opengl instead if not. 
