### PR TITLE
image: clear mipmap map to avoid unnecessary allocation

### DIFF
--- a/image.go
+++ b/image.go
@@ -112,7 +112,9 @@ func (m *mipmap) disposeMipmaps() {
 			img.Dispose()
 		}
 	}
-	m.imgs = map[image.Rectangle][]*shareable.Image{}
+	for k := range m.imgs {
+		delete(m.imgs, k)
+	}
 }
 
 // Image represents a rectangle set of pixels.


### PR DESCRIPTION
This change uses a pattern that Go 1.11+ compilers can optimize to a clear operation
https://github.com/golang/go/blob/master/doc/go1.11.html#L447

**Why do this?**
Seems like an idiotmatic change and reduces amount of allocations used by Ebiten. I didn't see any performance improvement but it gave me one less thing to think about when profiling allocations.