### PR TITLE
Add cursor capture functionality

### DIFF
--- a/cursormodes.go
+++ b/cursormodes.go
@@ -16,13 +16,13 @@ package ebiten
 
 import "github.com/hajimehoshi/ebiten/internal/driver"
 
-// An InputCursorMode represents
+// A CursorModeType represents
 // a render and coordinate mode of a mouse cursor.
-type InputCursorMode int
+type CursorModeType int
 
 // Cursor Modes
 const (
-	CursorModeVisible  = InputCursorMode(driver.CursorModeVisible)
-	CursorModeHidden   = InputCursorMode(driver.CursorModeHidden)
-	CursorModeCaptured = InputCursorMode(driver.CursorModeCaptured)
+	CursorModeVisible  = CursorModeType(driver.CursorModeVisible)
+	CursorModeHidden   = CursorModeType(driver.CursorModeHidden)
+	CursorModeCaptured = CursorModeType(driver.CursorModeCaptured)
 )

--- a/cursormodes.go
+++ b/cursormodes.go
@@ -1,4 +1,4 @@
-// Copyright 209 The Ebiten Authors
+// Copyright 2019 The Ebiten Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cursormodes.go
+++ b/cursormodes.go
@@ -1,0 +1,28 @@
+// Copyright 209 The Ebiten Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebiten
+
+import "github.com/hajimehoshi/ebiten/internal/driver"
+
+// An InputCursorMode represents
+// a render and coordinate mode of a mouse cursor.
+type InputCursorMode int
+
+// Cursor Modes
+const (
+	CursorModeVisible  = InputCursorMode(driver.CursorModeVisible)
+	CursorModeHidden   = InputCursorMode(driver.CursorModeHidden)
+	CursorModeCaptured = InputCursorMode(driver.CursorModeCaptured)
+)

--- a/internal/driver/cursormode.go
+++ b/internal/driver/cursormode.go
@@ -1,0 +1,23 @@
+// Copyright 2019 The Ebiten Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+type CursorMode int
+
+const (
+	CursorModeVisible CursorMode = 1 << iota
+	CursorModeHidden
+	CursorModeCaptured
+)

--- a/internal/driver/ui.go
+++ b/internal/driver/ui.go
@@ -35,6 +35,7 @@ type UI interface {
 
 	DeviceScaleFactor() float64
 	IsCursorVisible() bool
+	IsCursorCaptured() bool
 	IsFullscreen() bool
 	IsRunnableInBackground() bool
 	IsVsyncEnabled() bool
@@ -47,6 +48,7 @@ type UI interface {
 	IsScreenTransparent() bool
 
 	SetCursorVisible(visible bool)
+	SetCursorCaptured(captured bool)
 	SetFullscreen(fullscreen bool)
 	SetRunnableInBackground(runnableInBackground bool)
 	SetScreenScale(scale float64)

--- a/internal/driver/ui.go
+++ b/internal/driver/ui.go
@@ -34,8 +34,7 @@ type UI interface {
 	RunWithoutMainLoop(width, height int, scale float64, title string, context UIContext, graphics Graphics) <-chan error
 
 	DeviceScaleFactor() float64
-	IsCursorVisible() bool
-	IsCursorCaptured() bool
+	CursorMode() CursorMode
 	IsFullscreen() bool
 	IsRunnableInBackground() bool
 	IsVsyncEnabled() bool
@@ -47,8 +46,7 @@ type UI interface {
 	WindowPosition() (int, int)
 	IsScreenTransparent() bool
 
-	SetCursorVisible(visible bool)
-	SetCursorCaptured(captured bool)
+	SetCursorMode(mode CursorMode)
 	SetFullscreen(fullscreen bool)
 	SetRunnableInBackground(runnableInBackground bool)
 	SetScreenScale(scale float64)

--- a/internal/glfw/const.go
+++ b/internal/glfw/const.go
@@ -90,9 +90,10 @@ const (
 )
 
 const (
-	CursorHidden = 0x00034002
-	CursorNormal = 0x00034001
-	NoAPI        = 0
+	CursorDisabled = 0x00034003
+	CursorHidden   = 0x00034002
+	CursorNormal   = 0x00034001
+	NoAPI          = 0
 )
 
 const (

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -491,13 +491,17 @@ func (u *UserInterface) CursorMode() driver.CursorMode {
 	if !u.isRunning() {
 		return u.getInitCursorMode()
 	}
-	v := driver.CursorModeVisible
+	var v driver.CursorMode
 	_ = u.t.Call(func() error {
 		switch u.window.GetInputMode(glfw.CursorMode) {
+		case glfw.CursorNormal:
+			v = driver.CursorModeVisible
 		case glfw.CursorHidden:
 			v = driver.CursorModeHidden
 		case glfw.CursorDisabled:
 			v = driver.CursorModeCaptured
+		default:
+			panic("Invalid cursor mode")
 		}
 		return nil
 	})
@@ -519,7 +523,7 @@ func (u *UserInterface) SetCursorMode(mode driver.CursorMode) {
 		case driver.CursorModeCaptured:
 			c = glfw.CursorDisabled
 		default:
-			return nil
+			panic("Invalid cursor mode")
 		}
 		u.window.SetInputMode(glfw.CursorMode, c)
 		return nil

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -493,7 +493,8 @@ func (u *UserInterface) CursorMode() driver.CursorMode {
 	}
 	var v driver.CursorMode
 	_ = u.t.Call(func() error {
-		switch u.window.GetInputMode(glfw.CursorMode) {
+		mode := u.window.GetInputMode(glfw.CursorMode)
+		switch mode {
 		case glfw.CursorNormal:
 			v = driver.CursorModeVisible
 		case glfw.CursorHidden:
@@ -501,7 +502,7 @@ func (u *UserInterface) CursorMode() driver.CursorMode {
 		case glfw.CursorDisabled:
 			v = driver.CursorModeCaptured
 		default:
-			panic("Invalid cursor mode")
+			panic(fmt.Sprintf("invalid cursor mode: %d", mode))
 		}
 		return nil
 	})
@@ -514,7 +515,7 @@ func (u *UserInterface) SetCursorMode(mode driver.CursorMode) {
 		return
 	}
 	_ = u.t.Call(func() error {
-		c := glfw.NoAPI
+		var c int
 		switch mode {
 		case driver.CursorModeVisible:
 			c = glfw.CursorNormal
@@ -523,7 +524,7 @@ func (u *UserInterface) SetCursorMode(mode driver.CursorMode) {
 		case driver.CursorModeCaptured:
 			c = glfw.CursorDisabled
 		default:
-			panic("Invalid cursor mode")
+			panic(fmt.Sprintf("invalid cursor mode: %d", mode))
 		}
 		u.window.SetInputMode(glfw.CursorMode, c)
 		return nil

--- a/internal/uidriver/js/ui.go
+++ b/internal/uidriver/js/ui.go
@@ -128,12 +128,20 @@ func (u *UserInterface) IsCursorVisible() bool {
 	return canvas.Get("style").Get("cursor").String() != "none"
 }
 
+func (u *UserInterface) IsCursorCaptured() bool {
+	return false
+}
+
 func (u *UserInterface) SetCursorVisible(visible bool) {
 	if visible {
 		canvas.Get("style").Set("cursor", "auto")
 	} else {
 		canvas.Get("style").Set("cursor", "none")
 	}
+}
+
+func (u *UserInterface) SetCursorCaptured(captured bool) {
+	// Do nothing
 }
 
 func (u *UserInterface) SetWindowTitle(title string) {

--- a/internal/uidriver/js/ui.go
+++ b/internal/uidriver/js/ui.go
@@ -139,7 +139,7 @@ func (u *UserInterface) SetCursorMode(mode driver.CursorMode) {
 	case driver.CursorModeHidden:
 		visible = false
 	default:
-		visible = canvas.Get("style").Get("cursor").String() != "none"
+		return
 	}
 
 	if visible {

--- a/internal/uidriver/js/ui.go
+++ b/internal/uidriver/js/ui.go
@@ -123,25 +123,30 @@ func (u *UserInterface) adjustPosition(x, y int) (int, int) {
 	return int(float64(x) / s), int(float64(y) / s)
 }
 
-func (u *UserInterface) IsCursorVisible() bool {
-	// The initial value is an empty string, so don't compare with "auto" here.
-	return canvas.Get("style").Get("cursor").String() != "none"
+func (u *UserInterface) CursorMode() driver.CursorMode {
+	if u.IsCursorVisible {
+		return driver.CursorModeVisible
+	} else {
+		return driver.CursorModeHidden
+	}
 }
 
-func (u *UserInterface) IsCursorCaptured() bool {
-	return false
-}
+func (u *UserInterface) SetCursorMode(mode driver.CursorMode) {
+	var visible bool
+	switch mode {
+	case driver.CursorModeVisible:
+		visible = true
+	case driver.CursorModeHidden:
+		visible = false
+	default:
+		visible = canvas.Get("style").Get("cursor").String() != "none"
+	}
 
-func (u *UserInterface) SetCursorVisible(visible bool) {
 	if visible {
 		canvas.Get("style").Set("cursor", "auto")
 	} else {
 		canvas.Get("style").Set("cursor", "none")
 	}
-}
-
-func (u *UserInterface) SetCursorCaptured(captured bool) {
-	// Do nothing
 }
 
 func (u *UserInterface) SetWindowTitle(title string) {

--- a/internal/uidriver/mobile/ui.go
+++ b/internal/uidriver/mobile/ui.go
@@ -384,7 +384,7 @@ func (u *UserInterface) adjustPosition(x, y int) (int, int) {
 }
 
 func (u *UserInterface) CursorMode() driver.CursorMode {
-	return 0
+	return driver.CursorModeHidden
 }
 
 func (u *UserInterface) SetCursorMode(mode driver.CursorMode) {

--- a/internal/uidriver/mobile/ui.go
+++ b/internal/uidriver/mobile/ui.go
@@ -388,7 +388,15 @@ func (u *UserInterface) IsCursorVisible() bool {
 	return false
 }
 
+func (u *UserInterface) IsCursorCaptured() bool {
+	return false
+}
+
 func (u *UserInterface) SetCursorVisible(visible bool) {
+	// Do nothing
+}
+
+func (u *UserInterface) SetCursorCaptured(captured bool) {
 	// Do nothing
 }
 

--- a/internal/uidriver/mobile/ui.go
+++ b/internal/uidriver/mobile/ui.go
@@ -383,19 +383,11 @@ func (u *UserInterface) adjustPosition(x, y int) (int, int) {
 	return int(float64(x)/s - ox/as), int(float64(y)/s - oy/as)
 }
 
-func (u *UserInterface) IsCursorVisible() bool {
-	return false
+func (u *UserInterface) CursorMode() driver.CursorMode {
+	return 0
 }
 
-func (u *UserInterface) IsCursorCaptured() bool {
-	return false
-}
-
-func (u *UserInterface) SetCursorVisible(visible bool) {
-	// Do nothing
-}
-
-func (u *UserInterface) SetCursorCaptured(captured bool) {
+func (u *UserInterface) SetCursorMode(mode driver.CursorMode) {
 	// Do nothing
 }
 

--- a/run.go
+++ b/run.go
@@ -287,7 +287,7 @@ func SetCursorVisibility(visible bool) {
 
 // IsCursorCaptured reports whether the cursor is captured or not.
 //
-// IsCursorCaptured always returns false on mobiles/JS/browsers.
+// IsCursorCaptured always returns false on mobiles or browsers.
 //
 // IsCursorCaptured is concurrent-safe.
 func IsCursorCaptured() bool {
@@ -298,7 +298,7 @@ func IsCursorCaptured() bool {
 // The system cursor is invisible and locked to the game window when captured.
 // Setting captured to false sets the cursor to visible.
 //
-// SetCursorCaptured does nothing on mobiles/JS/browsers.
+// SetCursorCaptured does nothing on mobiles or browsers.
 //
 // SetCursorVisible unlocks the cursor as well.
 // SetCursorVisible(false) can be used to unlock the cursor

--- a/run.go
+++ b/run.go
@@ -285,10 +285,9 @@ func SetCursorVisibility(visible bool) {
 	SetCursorVisible(visible)
 }
 
-// IsCursorCaptured returns a boolean valued indicating whether
-// the cursor is captured or not.
+// IsCursorCaptured reports whether the cursor is captured or not.
 //
-// IsCursorCaptured always returns false on mobile and JS.
+// IsCursorCaptured always returns false on mobiles/JS/browsers.
 //
 // IsCursorCaptured is concurrent-safe.
 func IsCursorCaptured() bool {

--- a/run.go
+++ b/run.go
@@ -285,6 +285,31 @@ func SetCursorVisibility(visible bool) {
 	SetCursorVisible(visible)
 }
 
+// IsCursorCaptured returns a boolean valued indicating whether
+// the cursor is captured or not.
+//
+// IsCursorCaptured always returns false on mobile and JS.
+//
+// IsCursorCaptured is concurrent-safe.
+func IsCursorCaptured() bool {
+	return uiDriver().IsCursorCaptured()
+}
+
+// SetCursorCaptured changes the capture state of the cursor.
+// The system cursor is invisible and locked to the game window when captured.
+// Setting captured to false sets the cursor to visible.
+//
+// SetCursorCaptured does nothing on mobile or JS.
+//
+// SetCursorVisible unlocks the cursor as well.
+// SetCursorVisible(false) can be used to unlock the cursor
+// to an invisible state.
+//
+// SetCursorCaptured is concurrent-safe.
+func SetCursorCaptured(captured bool) {
+	uiDriver().SetCursorCaptured(captured)
+}
+
 // IsFullscreen reports whether the current mode is fullscreen or not.
 //
 // IsFullscreen always returns false on browsers.

--- a/run.go
+++ b/run.go
@@ -265,11 +265,11 @@ func ScreenScale() float64 {
 //
 // On browsers, only CursorModeVisible and CursorModeHidden are supported.
 //
-// CursorMode returns 0 on mobiles.
+// CursorMode returns CursorModeHidden on mobiles.
 //
 // CursorMode is concurrent-safe.
-func CursorMode() InputCursorMode {
-	return InputCursorMode(uiDriver().CursorMode())
+func CursorMode() CursorModeType {
+	return CursorModeType(uiDriver().CursorMode())
 }
 
 // SetCursorMode sets the render and capture mode of the mouse cursor.
@@ -282,16 +282,16 @@ func CursorMode() InputCursorMode {
 // SetCursorMode does nothing on mobiles.
 //
 // SetCursorMode is concurrent-safe.
-func SetCursorMode(mode InputCursorMode) {
+func SetCursorMode(mode CursorModeType) {
 	uiDriver().SetCursorMode(driver.CursorMode(mode))
 }
 
-// IsCursorVisible is deprecated as of 1.11.0-alpha.2. Use CursorMode instead.
+// IsCursorVisible is deprecated as of 1.11.0-alpha. Use CursorMode instead.
 func IsCursorVisible() bool {
 	return CursorMode() == CursorModeVisible
 }
 
-// SetCursorVisible is deprecated as of 1.11.0-alpha.2. Use SetCursorMode instead.
+// SetCursorVisible is deprecated as of 1.11.0-alpha. Use SetCursorMode instead.
 func SetCursorVisible(visible bool) {
 	if visible {
 		SetCursorMode(CursorModeVisible)

--- a/run.go
+++ b/run.go
@@ -298,7 +298,7 @@ func IsCursorCaptured() bool {
 // The system cursor is invisible and locked to the game window when captured.
 // Setting captured to false sets the cursor to visible.
 //
-// SetCursorCaptured does nothing on mobile or JS.
+// SetCursorCaptured does nothing on mobiles/JS/browsers.
 //
 // SetCursorVisible unlocks the cursor as well.
 // SetCursorVisible(false) can be used to unlock the cursor

--- a/run.go
+++ b/run.go
@@ -261,52 +261,48 @@ func ScreenScale() float64 {
 	return uiDriver().ScreenScale()
 }
 
-// IsCursorVisible returns a boolean value indicating whether
-// the cursor is visible or not.
+// CursorMode returns the current cursor mode.
 //
-// IsCursorVisible always returns false on mobiles.
+// On browsers, only CursorModeVisible and CursorModeHidden are supported.
 //
-// IsCursorVisible is concurrent-safe.
+// CursorMode returns 0 on mobiles.
+//
+// CursorMode is concurrent-safe.
+func CursorMode() InputCursorMode {
+	return InputCursorMode(uiDriver().CursorMode())
+}
+
+// SetCursorMode sets the render and capture mode of the mouse cursor.
+// CursorModeVisible sets the cursor to always be visible.
+// CursorModeHidden hides the system cursor when over the window.
+// CursorModeCaptured hides the system cursor and locks it to the window.
+//
+// On browsers, only CursorModeVisible and CursorModeHidden are supported.
+//
+// SetCursorMode does nothing on mobiles.
+//
+// SetCursorMode is concurrent-safe.
+func SetCursorMode(mode InputCursorMode) {
+	uiDriver().SetCursorMode(driver.CursorMode(mode))
+}
+
+// IsCursorVisible is deprecated as of 1.11.0-alpha.2. Use CursorMode instead.
 func IsCursorVisible() bool {
-	return uiDriver().IsCursorVisible()
+	return CursorMode() == CursorModeVisible
 }
 
-// SetCursorVisible changes the state of cursor visiblity.
-//
-// SetCursorVisible does nothing on mobiles.
-//
-// SetCursorVisible is concurrent-safe.
+// SetCursorVisible is deprecated as of 1.11.0-alpha.2. Use SetCursorMode instead.
 func SetCursorVisible(visible bool) {
-	uiDriver().SetCursorVisible(visible)
+	if visible {
+		SetCursorMode(CursorModeVisible)
+	} else {
+		SetCursorMode(CursorModeHidden)
+	}
 }
 
-// SetCursorVisibility is deprecated as of 1.6.0-alpha. Use SetCursorVisible instead.
+// SetCursorVisibility is deprecated as of 1.6.0-alpha. Use SetCursorMode instead.
 func SetCursorVisibility(visible bool) {
 	SetCursorVisible(visible)
-}
-
-// IsCursorCaptured reports whether the cursor is captured or not.
-//
-// IsCursorCaptured always returns false on mobiles or browsers.
-//
-// IsCursorCaptured is concurrent-safe.
-func IsCursorCaptured() bool {
-	return uiDriver().IsCursorCaptured()
-}
-
-// SetCursorCaptured changes the capture state of the cursor.
-// The system cursor is invisible and locked to the game window when captured.
-// Setting captured to false sets the cursor to visible.
-//
-// SetCursorCaptured does nothing on mobiles or browsers.
-//
-// SetCursorVisible unlocks the cursor as well.
-// SetCursorVisible(false) can be used to unlock the cursor
-// to an invisible state.
-//
-// SetCursorCaptured is concurrent-safe.
-func SetCursorCaptured(captured bool) {
-	uiDriver().SetCursorCaptured(captured)
 }
 
 // IsFullscreen reports whether the current mode is fullscreen or not.


### PR DESCRIPTION
Closes #1014 

The API is separate from the cursor visibility function for backwards compatibility. Combining the APIs into one function (SetCursorMode, or something similar) may be more elegant.
