### PR TITLE
Typo Corrections from https://goreportcard.com/

### DIFF
--- a/internal/packing/packing.go
+++ b/internal/packing/packing.go
@@ -211,7 +211,7 @@ func walk(n *Node, f func(n *Node) error) error {
 
 func (p *Page) Extend(count int) bool {
 	if p.rollbackExtension != nil {
-		panic("packing: Extend cannot be called without rolling back or commiting")
+		panic("packing: Extend cannot be called without rolling back or committing")
 	}
 
 	if p.size >= p.maxSize {

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -771,7 +771,7 @@ func (u *UserInterface) loop(context driver.UIContext) error {
 
 		// On Windows, the focusing state might be always false (#987).
 		// On Windows, even if a window is in another workspace, vsync seems to work.
-		// Then let's assume the window is alwasy 'focused' as a workaround.
+		// Then let's assume the window is always 'focused' as a workaround.
 		if runtime.GOOS != "windows" {
 			unfocused = u.window.GetAttrib(glfw.Focused) == glfw.False
 		}


### PR DESCRIPTION
Fixes a typo in a comment and a typo in a panic message found via https://goreportcard.com/