### PR TITLE
Fix initial world randomization

### DIFF
--- a/examples/life/main.go
+++ b/examples/life/main.go
@@ -157,7 +157,7 @@ const (
 )
 
 var (
-	world  = NewWorld(screenWidth, screenHeight, 0)
+	world  *World
 	pixels = make([]byte, screenWidth*screenHeight*4)
 )
 

--- a/examples/life/main.go
+++ b/examples/life/main.go
@@ -53,6 +53,7 @@ func NewWorld(width, height int, maxInitLiveCells int) *World {
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
+	world = NewWorld(screenWidth, screenHeight, int((screenWidth*screenHeight)/10))
 }
 
 // init inits world with a random state.
@@ -156,7 +157,7 @@ const (
 )
 
 var (
-	world  = NewWorld(screenWidth, screenHeight, int((screenWidth*screenHeight)/10))
+	world  = NewWorld(screenWidth, screenHeight, 0)
 	pixels = make([]byte, screenWidth*screenHeight*4)
 )
 


### PR DESCRIPTION
Because golang executes the init function after establishing
the variables in the var block, the random number seed wasn't
initializing until after the initial world state had gotten
established (leading to an identical game of Life on every run).
To fix this, we establish an empty world in the var block,
and then populate it in the init function after the random
number generator has been seeded.