### PR TITLE
Fix multiple close for channel

### DIFF
--- a/internal/uidriver/mobile/ui.go
+++ b/internal/uidriver/mobile/ui.go
@@ -104,6 +104,7 @@ type UserInterface struct {
 	gbuildWidthPx   int
 	gbuildHeightPx  int
 	setGBuildSizeCh chan struct{}
+	once            sync.Once
 
 	context driver.UIContext
 
@@ -336,7 +337,9 @@ func (u *UserInterface) setGBuildSize(widthPx, heightPx int) {
 	u.gbuildWidthPx = widthPx
 	u.gbuildHeightPx = heightPx
 	u.sizeChanged = true
-	close(u.setGBuildSizeCh)
+	u.once.Do(func() {
+		close(u.setGBuildSizeCh)
+	})
 	u.m.Unlock()
 }
 


### PR DESCRIPTION
Current implementation of `setGBuildSizeCh` causes `panic: close of closed channel`.
Introduced `sync.Once` to avoid this.