### PR TITLE
input: Rename GamepadGUID -> GamepadSDLID

### DIFF
--- a/input.go
+++ b/input.go
@@ -92,13 +92,14 @@ func IsMouseButtonPressed(mouseButton MouseButton) bool {
 	return uiDriver().Input().IsMouseButtonPressed(driver.MouseButton(mouseButton))
 }
 
-// GamepadGUID returns a string with the uuid.
+// GamepadSDLID returns a string with the GUID generated in the same way as SDL.
+// To detect devices, see also the community project of gamepad devices database: https://github.com/gabomdq/SDL_GameControllerDB
 //
-// GamepadGUID always returns an empty string on browsers and mobiles.
+// GamepadSDLID always returns an empty string on browsers and mobiles.
 //
-// GamepadGUID is concurrent-safe.
-func GamepadGUID(id int) string {
-	return uiDriver().Input().GamepadGUID(id)
+// GamepadSDLID is concurrent-safe.
+func GamepadSDLID(id int) string {
+	return uiDriver().Input().GamepadSDLID(id)
 }
 
 // GamepadName returns a string with the name.

--- a/internal/driver/input.go
+++ b/internal/driver/input.go
@@ -16,7 +16,7 @@ package driver
 
 type Input interface {
 	CursorPosition() (x, y int)
-	GamepadGUID(id int) string
+	GamepadSDLID(id int) string
 	GamepadName(id int) string
 	GamepadAxis(id int, axis int) float64
 	GamepadAxisNum(id int) int

--- a/internal/uidriver/glfw/input.go
+++ b/internal/uidriver/glfw/input.go
@@ -87,7 +87,7 @@ func (i *Input) GamepadIDs() []int {
 	return r
 }
 
-func (i *Input) GamepadGUID(id int) string {
+func (i *Input) GamepadSDLID(id int) string {
 	if !i.ui.isRunning() {
 		return ""
 	}
@@ -356,6 +356,7 @@ func (i *Input) update(window *glfw.Window, context driver.UIContext) {
 				continue
 			}
 			i.gamepads[id].valid = true
+			// Note that GLFW's gamepad GUID follows SDL's GUID.
 			i.gamepads[id].guid = id.GetGUID()
 			i.gamepads[id].name = id.GetName()
 

--- a/internal/uidriver/js/input.go
+++ b/internal/uidriver/js/input.go
@@ -57,7 +57,9 @@ func (i *Input) CursorPosition() (x, y int) {
 	return int(xf), int(yf)
 }
 
-func (i *Input) GamepadGUID(id int) string {
+func (i *Input) GamepadSDLID(id int) string {
+	// TODO: Implement this. See the implementation of SDL:
+	// https://github.com/spurious/SDL-mirror/blob/master/src/joystick/emscripten/SDL_sysjoystick.c
 	return ""
 }
 

--- a/internal/uidriver/mobile/input.go
+++ b/internal/uidriver/mobile/input.go
@@ -42,7 +42,7 @@ func (i *Input) GamepadIDs() []int {
 	return nil
 }
 
-func (i *Input) GamepadGUID(id int) string {
+func (i *Input) GamepadSDLID(id int) string {
 	return ""
 }
 


### PR DESCRIPTION
Gamepad GUID is a SDL specific notion and, strictly speaking,
they are not GUID (UUID) since they don't follow UUID's
specifications.

Renaming the function makes the situation clearer.

Updates #1048