### PR TITLE
Fix delayed DrawImage()

### DIFF
--- a/internal/buffered/image.go
+++ b/internal/buffered/image.go
@@ -222,6 +222,8 @@ func (i *Image) DrawImage(src *Image, bounds image.Rectangle, a, b, c, d, tx, ty
 	delayedCommandsM.Lock()
 	if needsToDelayCommands {
 		delayedCommands = append(delayedCommands, func() {
+			src.resolvePendingPixels(true)
+			i.resolvePendingPixels(false)
 			i.img.DrawImage(src.img, bounds, g, colorm, mode, filter)
 		})
 		delayedCommandsM.Unlock()

--- a/internal/buffered/image.go
+++ b/internal/buffered/image.go
@@ -244,6 +244,8 @@ func (i *Image) DrawTriangles(src *Image, vertices []float32, indices []uint16, 
 	delayedCommandsM.Lock()
 	if needsToDelayCommands {
 		delayedCommands = append(delayedCommands, func() {
+			src.resolvePendingPixels(true)
+			i.resolvePendingPixels(false)
 			i.img.DrawTriangles(src.img, vertices, indices, colorm, mode, filter, address)
 		})
 		delayedCommandsM.Unlock()


### PR DESCRIPTION
`resolvePendingPixels` must be called in `delayedCommands`.
Otherwise, following `init` function does not work:

```go
func init() {
    srcImg, _ := ebiten.NewImage(w, h, ebiten.FilterDefault)
    dstImg, _ := ebiten.NewImage(w, h, ebiten.FilterDefault)

    // Set some pixels
    srcImg.Set(16, 16, clr)

    // Previous Set() is ignored, and nothing is drawn on dstImg.
    dstImg.DrawImage(srcImg, nil)
}
```