### PR TITLE
fix jsutil for support GopherJS/wasm Go 1.12/1.13/1.14

### DIFF
--- a/internal/jsutil/go112_js.go
+++ b/internal/jsutil/go112_js.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !go1.13 !wasm
+// +build !go1.13
 
 package jsutil
 

--- a/internal/jsutil/go113_js.go
+++ b/internal/jsutil/go113_js.go
@@ -18,10 +18,7 @@ package jsutil
 
 import (
 	"fmt"
-	"reflect"
-	"runtime"
 	"syscall/js"
-	"unsafe"
 )
 
 func Uint8ArrayToSlice(value js.Value) []byte {
@@ -32,68 +29,6 @@ func Uint8ArrayToSlice(value js.Value) []byte {
 
 func ArrayBufferToSlice(value js.Value) []byte {
 	return Uint8ArrayToSlice(js.Global().Get("Uint8Array").New(value))
-}
-
-func sliceToByteSlice(s interface{}) (bs []byte) {
-	switch s := s.(type) {
-	case []int8:
-		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-		bs = *(*[]byte)(unsafe.Pointer(h))
-		runtime.KeepAlive(s)
-	case []int16:
-		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-		h.Len *= 2
-		h.Cap *= 2
-		bs = *(*[]byte)(unsafe.Pointer(h))
-		runtime.KeepAlive(s)
-	case []int32:
-		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-		h.Len *= 4
-		h.Cap *= 4
-		bs = *(*[]byte)(unsafe.Pointer(h))
-		runtime.KeepAlive(s)
-	case []int64:
-		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-		h.Len *= 8
-		h.Cap *= 8
-		bs = *(*[]byte)(unsafe.Pointer(h))
-		runtime.KeepAlive(s)
-	case []uint8:
-		return s
-	case []uint16:
-		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-		h.Len *= 2
-		h.Cap *= 2
-		bs = *(*[]byte)(unsafe.Pointer(h))
-		runtime.KeepAlive(s)
-	case []uint32:
-		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-		h.Len *= 4
-		h.Cap *= 4
-		bs = *(*[]byte)(unsafe.Pointer(h))
-		runtime.KeepAlive(s)
-	case []uint64:
-		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-		h.Len *= 8
-		h.Cap *= 8
-		bs = *(*[]byte)(unsafe.Pointer(h))
-		runtime.KeepAlive(s)
-	case []float32:
-		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-		h.Len *= 4
-		h.Cap *= 4
-		bs = *(*[]byte)(unsafe.Pointer(h))
-		runtime.KeepAlive(s)
-	case []float64:
-		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-		h.Len *= 8
-		h.Cap *= 8
-		bs = *(*[]byte)(unsafe.Pointer(h))
-		runtime.KeepAlive(s)
-	default:
-		panic(fmt.Sprintf("jsutil: unexpected value at sliceToBytesSlice: %T", s))
-	}
-	return
 }
 
 func CopySliceToJS(dst js.Value, src interface{}) {

--- a/internal/jsutil/slice_js.go
+++ b/internal/jsutil/slice_js.go
@@ -1,0 +1,14 @@
+// +build js,!wasm
+
+package jsutil
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+func sliceToByteSlice(s interface{}) (bs []byte) {
+	var b bytes.Buffer
+	binary.Write(&b, binary.LittleEndian, s)
+	return b.Bytes()
+}

--- a/internal/jsutil/slice_wasm.go
+++ b/internal/jsutil/slice_wasm.go
@@ -1,0 +1,72 @@
+// +build js,wasm
+
+package jsutil
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"unsafe"
+)
+
+func sliceToByteSlice(s interface{}) (bs []byte) {
+	switch s := s.(type) {
+	case []int8:
+		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+		bs = *(*[]byte)(unsafe.Pointer(h))
+		runtime.KeepAlive(s)
+	case []int16:
+		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+		h.Len *= 2
+		h.Cap *= 2
+		bs = *(*[]byte)(unsafe.Pointer(h))
+		runtime.KeepAlive(s)
+	case []int32:
+		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+		h.Len *= 4
+		h.Cap *= 4
+		bs = *(*[]byte)(unsafe.Pointer(h))
+		runtime.KeepAlive(s)
+	case []int64:
+		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+		h.Len *= 8
+		h.Cap *= 8
+		bs = *(*[]byte)(unsafe.Pointer(h))
+		runtime.KeepAlive(s)
+	case []uint8:
+		return s
+	case []uint16:
+		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+		h.Len *= 2
+		h.Cap *= 2
+		bs = *(*[]byte)(unsafe.Pointer(h))
+		runtime.KeepAlive(s)
+	case []uint32:
+		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+		h.Len *= 4
+		h.Cap *= 4
+		bs = *(*[]byte)(unsafe.Pointer(h))
+		runtime.KeepAlive(s)
+	case []uint64:
+		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+		h.Len *= 8
+		h.Cap *= 8
+		bs = *(*[]byte)(unsafe.Pointer(h))
+		runtime.KeepAlive(s)
+	case []float32:
+		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+		h.Len *= 4
+		h.Cap *= 4
+		bs = *(*[]byte)(unsafe.Pointer(h))
+		runtime.KeepAlive(s)
+	case []float64:
+		h := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+		h.Len *= 8
+		h.Cap *= 8
+		bs = *(*[]byte)(unsafe.Pointer(h))
+		runtime.KeepAlive(s)
+	default:
+		panic(fmt.Sprintf("jsutil: unexpected value at sliceToBytesSlice: %T", s))
+	}
+	return
+}


### PR DESCRIPTION
fix build support for GopherJS and wasm on Go 1.12 1.13 1.14

Go 1.13 and Go 1.14 gopherjs `sliceToByteSlice` use `"encoding/binary"`.

The gopherjs install for https://github.com/visualfc/gopherjs