### PR TITLE
Reduce allocs further by passing things directly to UI thread instead of through heap

### DIFF
--- a/internal/graphicsdriver/opengl/context_desktop.go
+++ b/internal/graphicsdriver/opengl/context_desktop.go
@@ -199,9 +199,10 @@ func (c *context) framebufferPixels(f *framebuffer, width, height int) ([]byte, 
 }
 
 func (c *context) bindTextureImpl(t textureNative) {
-	_ = c.t.Call(func() error {
+	_ = c.t.BoolCall1(uintptr(t), func(param1 uintptr) bool {
+		t := uint32(param1)
 		gl.BindTexture(gl.TEXTURE_2D, uint32(t))
-		return nil
+		return true
 	})
 }
 

--- a/internal/graphicsdriver/opengl/context_desktop.go
+++ b/internal/graphicsdriver/opengl/context_desktop.go
@@ -492,9 +492,11 @@ func (c *context) deleteBuffer(b buffer) {
 }
 
 func (c *context) drawElements(len int, offsetInBytes int) {
-	_ = c.t.Call(func() error {
+	_ = c.t.BoolCall2(uintptr(len), uintptr(offsetInBytes), func(param1, param2 uintptr) bool {
+		len := int32(param1)
+		offsetInBytes := param2
 		gl.DrawElements(gl.TRIANGLES, int32(len), gl.UNSIGNED_SHORT, uintptr(offsetInBytes))
-		return nil
+		return true
 	})
 }
 

--- a/internal/thread/thread.go
+++ b/internal/thread/thread.go
@@ -28,18 +28,19 @@ const (
 )
 
 const MaxPublicParams = 2
+
 type call struct {
-	funcType functionType
+	funcType          functionType
 	func0ReturnsError func() error
-	func1ReturnsBool func(uintptr) bool
-	func2ReturnsBool func(uintptr, uintptr) bool
-	funcReturns2 func() (uintptr, uintptr)
-	params [MaxPublicParams]uintptr
+	func1ReturnsBool  func(uintptr) bool
+	func2ReturnsBool  func(uintptr, uintptr) bool
+	funcReturns2      func() (uintptr, uintptr)
+	params            [MaxPublicParams]uintptr
 }
 
 type result struct {
-	err error
-	flag bool
+	err     error
+	flag    bool
 	result1 uintptr
 	result2 uintptr
 }
@@ -98,7 +99,7 @@ loop:
 // Call panics when Loop already ends.
 func (t *Thread) Call(f func() error) error {
 	thisCall := call{
-		funcType: type0ParamsReturnError,
+		funcType:          type0ParamsReturnError,
 		func0ReturnsError: f,
 	}
 	select {
@@ -117,9 +118,9 @@ func (t *Thread) Call(f func() error) error {
 // Call panics when Loop already ends.
 func (t *Thread) BoolCall1(param1 uintptr, f func(uintptr) bool) bool {
 	thisCall := call{
-		funcType: type1ParamsReturnBool,
+		funcType:         type1ParamsReturnBool,
 		func1ReturnsBool: f,
-		params: [MaxPublicParams]uintptr{param1, 0},
+		params:           [MaxPublicParams]uintptr{param1, 0},
 	}
 	select {
 	case t.calls <- thisCall:
@@ -137,9 +138,9 @@ func (t *Thread) BoolCall1(param1 uintptr, f func(uintptr) bool) bool {
 // Call panics when Loop already ends.
 func (t *Thread) BoolCall2(param1, param2 uintptr, f func(uintptr, uintptr) bool) bool {
 	thisCall := call{
-		funcType: type2ParamsReturnBool,
+		funcType:         type2ParamsReturnBool,
 		func2ReturnsBool: f,
-		params: [MaxPublicParams]uintptr{param1, param2},
+		params:           [MaxPublicParams]uintptr{param1, param2},
 	}
 	select {
 	case t.calls <- thisCall:
@@ -157,7 +158,7 @@ func (t *Thread) BoolCall2(param1, param2 uintptr, f func(uintptr, uintptr) bool
 // Call panics when Loop already ends.
 func (t *Thread) CallReturn2(f func() (uintptr, uintptr)) (uintptr, uintptr) {
 	thisCall := call{
-		funcType: typeReturn2,
+		funcType:     typeReturn2,
 		funcReturns2: f,
 	}
 	select {

--- a/internal/thread/thread.go
+++ b/internal/thread/thread.go
@@ -84,6 +84,8 @@ loop:
 				callResult.flag = c.func2ReturnsBool(c.params[0], c.params[1])
 			case typeReturn2:
 				callResult.result1, callResult.result2 = c.funcReturns2()
+			default:
+				panic("Internal error in thread.go - invalid function type encountered.")
 			}
 			t.results <- callResult
 		case <-context.Done():

--- a/internal/thread/thread.go
+++ b/internal/thread/thread.go
@@ -23,9 +23,10 @@ type functionType int
 const (
 	type0ParamsReturnError functionType = iota
 	type2ParamsReturnBool
+	type4ParamsReturnBool
 )
 
-const MaxPublicParams = 3
+const MaxPublicParams = 2
 type call struct {
 	funcType functionType
 	func0ReturnsError func() error
@@ -109,7 +110,7 @@ func (t *Thread) BoolCall2(param1, param2 uintptr, f func(uintptr, uintptr) bool
 	thisCall := call{
 		funcType: type2ParamsReturnBool,
 		func2ReturnsBool: f,
-		params: [MaxPublicParams]uintptr{param1, param2, 0},
+		params: [MaxPublicParams]uintptr{param1, param2},
 	}
 	select {
 	case t.calls <- thisCall:

--- a/internal/thread/thread.go
+++ b/internal/thread/thread.go
@@ -94,7 +94,7 @@ loop:
 	}
 }
 
-// Call calls f on the thread.
+// Call calls f on the thread. Takes 0 parameters, returns error.
 //
 // Do not call this from the same thread. This would block forever.
 //
@@ -113,7 +113,7 @@ func (t *Thread) Call(f func() error) error {
 	}
 }
 
-// Call calls f on the thread.
+// Call calls f on the thread. Takes 1 uintptr parameter, returns bool.
 //
 // Do not call this from the same thread. This would block forever.
 //
@@ -133,7 +133,7 @@ func (t *Thread) BoolCall1(param1 uintptr, f func(uintptr) bool) bool {
 	}
 }
 
-// Call calls f on the thread.
+// Call calls f on the thread. Takes 2 uintptr parameters, returns bool.
 //
 // Do not call this from the same thread. This would block forever.
 //
@@ -153,7 +153,7 @@ func (t *Thread) BoolCall2(param1, param2 uintptr, f func(uintptr, uintptr) bool
 	}
 }
 
-// Call calls f on the thread.
+// Call calls f on the thread. Takes 0 parameters, returns 2 uintptrs.
 //
 // Do not call this from the same thread. This would block forever.
 //

--- a/internal/thread/thread.go
+++ b/internal/thread/thread.go
@@ -22,7 +22,7 @@ type functionType int
 
 const (
 	type0ParamsReturnError functionType = iota
-	type1ParamsReturnBool
+	type1ParamReturnBool
 	type2ParamsReturnBool
 	typeReturn2
 )
@@ -78,7 +78,7 @@ loop:
 			switch c.funcType {
 			case type0ParamsReturnError:
 				callResult.err = c.func0ReturnsError()
-			case type1ParamsReturnBool:
+			case type1ParamReturnBool:
 				callResult.flag = c.func1ReturnsBool(c.params[0])
 			case type2ParamsReturnBool:
 				callResult.flag = c.func2ReturnsBool(c.params[0], c.params[1])
@@ -120,7 +120,7 @@ func (t *Thread) Call(f func() error) error {
 // Call panics when Loop already ends.
 func (t *Thread) BoolCall1(param1 uintptr, f func(uintptr) bool) bool {
 	thisCall := call{
-		funcType:         type1ParamsReturnBool,
+		funcType:         type1ParamReturnBool,
 		func1ReturnsBool: f,
 		params:           [MaxPublicParams]uintptr{param1, 0},
 	}

--- a/internal/thread/thread_test.go
+++ b/internal/thread/thread_test.go
@@ -1,0 +1,110 @@
+package thread
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+)
+
+func Test0ParamsReturnError(t *testing.T) {
+	const errorString = "foobar"
+	var err error
+	err = thread.Call(func () error {
+		return errors.New(errorString)
+	})
+
+	if err.Error() != errorString {
+		t.Error("Error string was wrong")
+	}
+
+	err = thread.Call(func () error {
+		return nil
+	})
+
+	if err != nil {
+		t.Error("Error should have been nil")
+	}
+}
+
+func Test1ParamReturnsBool(t *testing.T) {
+	var result bool
+	f := func(param uintptr) bool {
+		return param > 10
+	}
+	
+	result = thread.BoolCall1(11, f)
+	if !result {
+		t.Error("Should return true with param above 10")
+	}
+
+	result = thread.BoolCall1(10, f)
+	if result {
+		t.Error("Should return false with param not above 10")
+	}
+}
+
+func Test2ParamsReturnsBool(t *testing.T) {
+	var result bool
+	f := func(param1, param2 uintptr) bool {
+		return param1 > 10 && param2 > 10
+	}
+	
+	result = thread.BoolCall2(11, 11, f)
+	if !result {
+		t.Error("Should return true with both params above 10")
+	}
+
+	result = thread.BoolCall2(10, 11, f)
+	if result {
+		t.Error("Should return false with param1 not above 10")
+	}
+
+	result = thread.BoolCall2(11, 10, f)
+	if result {
+		t.Error("Should return false with param2 not above 10")
+	}
+}
+
+func TestReturns2(t *testing.T) {
+	var r1, r2 uintptr
+	
+	r1, r2 = thread.CallReturn2(func() (uintptr, uintptr) {
+		return 100, 100
+	})
+	if r1 != 100 || r2 != 100 {
+		t.Errorf("Expected 100, 100, got %d, %d", r1, r2)
+	}
+
+	r1, r2 = thread.CallReturn2(func() (uintptr, uintptr) {
+		return 250, 150
+	})
+	if r1 != 250 || r2 != 150 {
+		t.Errorf("Expected 250, 150, got %d, %d", r1, r2)
+	}
+}
+
+var thread *Thread
+func TestMain(m *testing.M) {
+	// Start the thread
+	ctx, cancel := context.WithCancel(context.Background())
+	thread = New()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go runThread(ctx, &wg)
+
+	result := m.Run()
+
+	cancel()
+	wg.Wait()
+
+	os.Exit(result)
+}
+
+func runThread(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	thread.Loop(ctx)
+}

--- a/internal/thread/thread_test.go
+++ b/internal/thread/thread_test.go
@@ -11,7 +11,7 @@ import (
 func Test0ParamsReturnError(t *testing.T) {
 	const errorString = "foobar"
 	var err error
-	err = thread.Call(func () error {
+	err = thread.Call(func() error {
 		return errors.New(errorString)
 	})
 
@@ -19,7 +19,7 @@ func Test0ParamsReturnError(t *testing.T) {
 		t.Error("Error string was wrong")
 	}
 
-	err = thread.Call(func () error {
+	err = thread.Call(func() error {
 		return nil
 	})
 
@@ -33,7 +33,7 @@ func Test1ParamReturnsBool(t *testing.T) {
 	f := func(param uintptr) bool {
 		return param > 10
 	}
-	
+
 	result = thread.BoolCall1(11, f)
 	if !result {
 		t.Error("Should return true with param above 10")
@@ -50,7 +50,7 @@ func Test2ParamsReturnsBool(t *testing.T) {
 	f := func(param1, param2 uintptr) bool {
 		return param1 > 10 && param2 > 10
 	}
-	
+
 	result = thread.BoolCall2(11, 11, f)
 	if !result {
 		t.Error("Should return true with both params above 10")
@@ -69,7 +69,7 @@ func Test2ParamsReturnsBool(t *testing.T) {
 
 func TestReturns2(t *testing.T) {
 	var r1, r2 uintptr
-	
+
 	r1, r2 = thread.CallReturn2(func() (uintptr, uintptr) {
 		return 100, 100
 	})
@@ -86,6 +86,7 @@ func TestReturns2(t *testing.T) {
 }
 
 var thread *Thread
+
 func TestMain(m *testing.M) {
 	// Start the thread
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/uidriver/glfw/input.go
+++ b/internal/uidriver/glfw/input.go
@@ -245,13 +245,13 @@ func (i *Input) IsKeyPressed(key driver.Key) bool {
 		return false
 	}
 	return i.ui.t.BoolCall2(uintptr(unsafe.Pointer(i)), uintptr(key), func(param1, param2 uintptr) bool {
-		innerInput := (*Input)(unsafe.Pointer(param1))
-		innerKey := driver.Key(param2)
-		if innerInput.keyPressed == nil {
-			innerInput.keyPressed = map[glfw.Key]bool{}
+		i := (*Input)(unsafe.Pointer(param1))
+		key := driver.Key(param2)
+		if i.keyPressed == nil {
+			i.keyPressed = map[glfw.Key]bool{}
 		}
-		gk, ok := driverKeyToGLFWKey[innerKey]
-		if ok && innerInput.keyPressed[gk] {
+		gk, ok := driverKeyToGLFWKey[key]
+		if ok && i.keyPressed[gk] {
 			return true
 		}
 		return false

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -756,11 +756,11 @@ func (u *UserInterface) update(context driver.UIContext) error {
 	}
 
 	// Update the screen size when the window is resizable.
-	var w, h int
-	_ = u.t.Call(func() error {
-		w, h = u.reqWidth, u.reqHeight
-		return nil
+	r1, r2 := u.t.CallReturn2(func() (uintptr, uintptr) {
+		w, h := u.reqWidth, u.reqHeight
+		return uintptr(w), uintptr(h)
 	})
+	w, h := int(r1), int(r2)
 	if w != 0 || h != 0 {
 		u.setWindowSize(w, h, u.isFullscreen(), u.vsync)
 	}

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -670,11 +670,10 @@ func (u *UserInterface) run(context driver.UIContext) error {
 }
 
 func (u *UserInterface) updateSize(context driver.UIContext) {
-	var w, h int
-	_ = u.t.Call(func() error {
-		w, h = u.windowWidth, u.windowHeight
-		return nil
+	r1, r2 := u.t.CallReturn2(func() (uintptr, uintptr) {
+		return uintptr(u.windowWidth), uintptr(u.windowHeight)
 	})
+	w, h := int(r1), int(r2)
 	u.setWindowSize(w, h, u.isFullscreen(), u.vsync)
 
 	sizeChanged := false


### PR DESCRIPTION
Some of our commonly called function calls to UI thread still require transferring parameters and return values via heap. This fixes several frequently called functions to pass them directly instead of through heap. The code in thread.go is intended to be extendable.

This change brings allocs per frame in my simple project from 474 to 250.

I'm probably going to stop focusing on reducing allocs after this change, because the others feel like golang compiler bugs where escape analysis should be smarter.