### PR TITLE
ui: Add an optional function Draw function to Game interface

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -20,20 +20,16 @@
 //     type Game struct{}
 //
 //     // Update proceeds the game state.
-//     // Update is called every frame (1/60 [s]).
+//     // Update is called every tick (1/60 [s] by default).
 //     func (g *Game) Update(screen *ebiten.Image) error {
-//
 //         // Write your game's logical update.
-//
-//         if ebiten.IsDrawingSkipped() {
-//             // When the game is running slowly, the rendering result
-//             // will not be adopted.
-//             return nil
-//         }
-//
-//         // Write your game's rendering.
-//
 //         return nil
+//     }
+//
+//     // Draw draws the game screen.
+//     // Draw is called every frame (typically 1/60[s] for 60Hz display).
+//     func (g *Game) Update(screen *ebiten.Image) error {
+//         // Write your game's rendering.
 //     }
 //
 //     // Layout takes the outside size (e.g., the window size) and returns the (logical) screen size.

--- a/examples/moire/main.go
+++ b/examples/moire/main.go
@@ -86,13 +86,11 @@ func (g *game) Update(screen *ebiten.Image) error {
 		fullscreen = !fullscreen
 		ebiten.SetFullscreen(fullscreen)
 	}
-
-	if ebiten.IsDrawingSkipped() {
-		return nil
-	}
-
-	screen.ReplacePixels(getDots(screen.Size()))
 	return nil
+}
+
+func (g *game) Draw(screen *ebiten.Image) {
+	screen.ReplacePixels(getDots(screen.Size()))
 }
 
 func main() {

--- a/examples/windowsize/main.go
+++ b/examples/windowsize/main.go
@@ -99,8 +99,9 @@ func createRandomIconImage() image.Image {
 }
 
 type game struct {
-	width  int
-	height int
+	width       int
+	height      int
+	transparent bool
 }
 
 func (g *game) Layout(outsideWidth, outsideHeight int) (int, int) {
@@ -139,7 +140,7 @@ func (g *game) Update(screen *ebiten.Image) error {
 	tps := ebiten.MaxTPS()
 	decorated := ebiten.IsWindowDecorated()
 	positionX, positionY := ebiten.WindowPosition()
-	transparent := ebiten.IsScreenTransparent()
+	g.transparent = ebiten.IsScreenTransparent()
 	floating := ebiten.IsWindowFloating()
 	resizable := ebiten.IsWindowResizable()
 
@@ -269,12 +270,11 @@ func (g *game) Update(screen *ebiten.Image) error {
 	}
 
 	count++
+	return nil
+}
 
-	if ebiten.IsDrawingSkipped() {
-		return nil
-	}
-
-	if !transparent {
+func (g *game) Draw(screen *ebiten.Image) {
+	if !g.transparent {
 		screen.Fill(color.RGBA{0x80, 0x80, 0xc0, 0xff})
 	}
 	w, h := gophersImage.Size()
@@ -336,7 +336,6 @@ TPS: Current: %0.2f / Max: %s
 FPS: %0.2f
 Device Scale Factor: %0.2f`, msgS, msgM, msgR, fg, wx, wy, cx, cy, ebiten.CurrentTPS(), tpsStr, ebiten.CurrentFPS(), ebiten.DeviceScaleFactor())
 	ebitenutil.DebugPrint(screen, msg)
-	return nil
 }
 
 func parseWindowPosition() (int, int, bool) {

--- a/imagedumper_desktop.go
+++ b/imagedumper_desktop.go
@@ -158,6 +158,10 @@ func (i *imageDumper) update(screen *Image) error {
 		return nil
 	}
 
+	return i.dump(screen)
+}
+
+func (i *imageDumper) dump(screen *Image) error {
 	if i.toTakeScreenshot {
 		i.toTakeScreenshot = false
 		if err := takeScreenshot(screen); err != nil {

--- a/imagedumper_notdesktop.go
+++ b/imagedumper_notdesktop.go
@@ -23,3 +23,8 @@ type imageDumper struct {
 func (i *imageDumper) update(screen *Image) error {
 	return i.f(screen)
 }
+
+func (i *imageDumper) dump(screen *Image) error {
+	// Do nothing
+	return nil
+}

--- a/run.go
+++ b/run.go
@@ -219,7 +219,7 @@ func (i *imageDumperGameWithDraw) Draw(screen *Image) {
 
 	i.game.(interface{ Draw(*Image) }).Draw(screen)
 
-	// Call dump explicitly. IsDrawingSkipped alwasy returns true when Draw is defined.
+	// Call dump explicitly. IsDrawingSkipped always returns true when Draw is defined.
 	if i.d == nil {
 		i.d = &imageDumper{f: i.game.Update}
 	}

--- a/run.go
+++ b/run.go
@@ -109,7 +109,7 @@ func setDrawingSkipped(skipped bool) {
 //
 // IsDrawingSkipped is useful if you use Run function or RunGame function without implementing Game's Draw.
 // Otherwise, i.e., if you use RunGame function with implementing Game's Draw, IsDrawingSkipped should not be used.
-// If you use RunGame and Draw, IsDrawingSkipped always returns false.
+// If you use RunGame and Draw, IsDrawingSkipped always returns true.
 //
 // IsDrawingSkipped is concurrent-safe.
 func IsDrawingSkipped() bool {


### PR DESCRIPTION
This change adds an optional function Draw to the Game interface.
With Draw function, the game logic and rendering are separate.
There are some benefits:

  * The API is clearer and easier to understand.
  * When TPS < FPS, smoother rendering can be performed without
    changing the game logic depending on TPS.
  * Porting to XNA, which has separate functions Update and Draw,
    would be a little easier.

Draw is optional due to backward compatibility. Game interface was
already used before v1.11.x in mobile packages, and adding a
function would break existing code unfortunately. Then, we adopted
switching the behavior based on whether Draw is implemented or not
by type assertions.

IsDrawingSkipped will always return true when Draw is implemented.

Fixes #1104