### PR TITLE
allow for unexpectedly large gamepads

### DIFF
--- a/inpututil/inpututil.go
+++ b/inpututil/inpututil.go
@@ -115,6 +115,9 @@ func (i *inputState) update() {
 			i.gamepadButtonDurations[id] = make([]int, ebiten.GamepadButtonMax+1)
 		}
 		n := ebiten.GamepadButtonNum(id)
+		if n > int(ebiten.GamepadButtonMax+1) {
+			n = int(ebiten.GamepadButtonMax + 1)
+		}
 		for b := ebiten.GamepadButton(0); b < ebiten.GamepadButton(n); b++ {
 			if ebiten.IsGamepadButtonPressed(id, b) {
 				i.gamepadButtonDurations[id][b]++


### PR DESCRIPTION
we can't prove that no gamepad will ever have more than the supported
max number of buttons, but you can't USE the extra buttons in any way
through this API, so if a gamepad reports over GamepadButtonMax+1
buttons, we ignore the extras.

Fixes #1173 