### PR TITLE
Example for an orthogonal 2D camera

### DIFF
--- a/examples/camera/main.go
+++ b/examples/camera/main.go
@@ -1,0 +1,251 @@
+// Copyright 2018 The Ebiten Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build example jsgo
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	_ "image/png"
+	"log"
+
+	"github.com/hajimehoshi/ebiten"
+	"github.com/hajimehoshi/ebiten/ebitenutil"
+	"github.com/hajimehoshi/ebiten/examples/resources/images"
+)
+
+const (
+	screenWidth  = 240
+	screenHeight = 240
+)
+
+const (
+	tileSize = 16
+	tileXNum = 25
+)
+
+const (
+	worldSizeX = screenWidth / tileSize
+	worldSizeY = screenHeight / tileSize
+)
+
+var (
+	tilesImage *ebiten.Image
+)
+
+func init() {
+	// Decode image from a byte slice instead of a file so that
+	// this example works in any working directory.
+	// If you want to use a file, there are some options:
+	// 1) Use os.Open and pass the file to the image decoder.
+	//    This is a very regular way, but doesn't work on browsers.
+	// 2) Use ebitenutil.OpenFile and pass the file to the image decoder.
+	//    This works even on browsers.
+	// 3) Use ebitenutil.NewImageFromFile to create an ebiten.Image directly from a file.
+	//    This also works on browsers.
+	img, _, err := image.Decode(bytes.NewReader(images.Tiles_png))
+	if err != nil {
+		log.Fatal(err)
+	}
+	tilesImage, _ = ebiten.NewImageFromImage(img, ebiten.FilterDefault)
+}
+
+type vec2 struct {
+	X, Y float64
+}
+
+type Camera struct {
+	ViewPort    vec2
+	Position    vec2
+	Zoom        vec2
+	Rotation    float64
+	worldMatrix ebiten.GeoM
+}
+
+func (c *Camera) String() string {
+	return fmt.Sprintf(
+		"T: %.1f, R: %.1f, S: %.1f",
+		c.Position, c.Rotation, c.Zoom,
+	)
+}
+
+func (c *Camera) viewportCenter() vec2 {
+	return vec2{
+		c.ViewPort.X * 0.5,
+		c.ViewPort.Y * 0.5,
+	}
+}
+
+func (c *Camera) updateMatrix() {
+	c.worldMatrix.Reset()
+	c.worldMatrix.Translate(-c.Position.X, -c.Position.Y)
+	// We want to scale and rotate around center of image / screen
+	c.worldMatrix.Translate(-c.viewportCenter().X, -c.viewportCenter().Y)
+	c.worldMatrix.Scale(c.Zoom.X, c.Zoom.Y)
+	c.worldMatrix.Rotate(c.Rotation)
+	c.worldMatrix.Translate(c.viewportCenter().X, c.viewportCenter().Y)
+}
+
+func (c *Camera) Render(world, screen *ebiten.Image) error {
+	c.updateMatrix()
+	return screen.DrawImage(world, &ebiten.DrawImageOptions{
+		GeoM: c.worldMatrix,
+	})
+}
+
+func (c *Camera) ScreenToWorld(posX, posY int) (float64, float64) {
+	c.updateMatrix()
+	inverseMatrix := c.worldMatrix
+	inverseMatrix.Invert()
+	return inverseMatrix.Apply(float64(posX), float64(posY))
+}
+
+func (c *Camera) Reset() {
+	c.Position.X = 0
+	c.Position.Y = 0
+	c.Rotation = 0
+	c.Zoom.X = 1
+	c.Zoom.Y = 1
+	c.updateMatrix()
+}
+
+type Game struct {
+	layers [][]int
+	world  *ebiten.Image
+	camera Camera
+}
+
+func (g *Game) Update(screen *ebiten.Image) error {
+	if ebiten.IsKeyPressed(ebiten.KeyA) {
+		g.camera.Position.X -= 1
+	}
+	if ebiten.IsKeyPressed(ebiten.KeyD) {
+		g.camera.Position.X += 1
+	}
+	if ebiten.IsKeyPressed(ebiten.KeyW) {
+		g.camera.Position.Y -= 1
+	}
+	if ebiten.IsKeyPressed(ebiten.KeyS) {
+		g.camera.Position.Y += 1
+	}
+
+	if ebiten.IsKeyPressed(ebiten.KeyQ) {
+		g.camera.Zoom.X -= .1
+		g.camera.Zoom.Y -= .1
+	}
+	if ebiten.IsKeyPressed(ebiten.KeyE) {
+		g.camera.Zoom.X += .1
+		g.camera.Zoom.Y += .1
+	}
+
+	if ebiten.IsKeyPressed(ebiten.KeyR) {
+		g.camera.Rotation += .1
+	}
+
+	if ebiten.IsKeyPressed(ebiten.KeySpace) {
+		g.camera.Reset()
+	}
+
+	return nil
+}
+
+func (g *Game) Draw(screen *ebiten.Image) {
+	// Draw each tile with each DrawImage call.
+	// As the source images of all DrawImage calls are always same,
+	// this rendering is done very effectively.
+	// For more detail, see https://pkg.go.dev/github.com/hajimehoshi/ebiten#Image.DrawImage
+	for _, l := range g.layers {
+		for i, t := range l {
+			op := &ebiten.DrawImageOptions{}
+			op.GeoM.Translate(float64((i%worldSizeX)*tileSize), float64((i/worldSizeX)*tileSize))
+
+			sx := (t % tileXNum) * tileSize
+			sy := (t / tileXNum) * tileSize
+			g.world.DrawImage(tilesImage.SubImage(image.Rect(sx, sy, sx+tileSize, sy+tileSize)).(*ebiten.Image), op)
+		}
+	}
+	g.camera.Render(g.world, screen)
+
+	worldX, worldY := g.camera.ScreenToWorld(ebiten.CursorPosition())
+	ebitenutil.DebugPrint(screen, fmt.Sprintf("TPS: %0.2f\n%s\nCursor World Pos: %.2f%.2f", ebiten.CurrentTPS(), g.camera.String(), worldX, worldY))
+}
+
+func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
+	return screenWidth, screenHeight
+}
+
+func main() {
+	g := &Game{
+		layers: [][]int{
+			{
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+				243, 218, 243, 243, 243, 243, 243, 243, 243, 243, 243, 218, 243, 244, 243,
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+				243, 243, 244, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 219, 243, 243, 243, 219, 243,
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+				243, 218, 243, 243, 243, 243, 243, 243, 243, 243, 243, 244, 243, 243, 243,
+				243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243, 243,
+			},
+			{
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 26, 27, 28, 29, 30, 31, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 51, 52, 53, 54, 55, 56, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 76, 77, 78, 79, 80, 81, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 101, 102, 103, 104, 105, 106, 0, 0, 0, 0,
+
+				0, 0, 0, 0, 0, 126, 127, 128, 129, 130, 131, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 303, 303, 245, 242, 303, 303, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 245, 242, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 245, 242, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 245, 242, 0, 0, 0, 0, 0, 0,
+
+				0, 0, 0, 0, 0, 0, 0, 245, 242, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 245, 242, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 245, 242, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 245, 242, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 245, 242, 0, 0, 0, 0, 0, 0,
+			},
+		},
+		camera: Camera{
+			ViewPort: vec2{screenWidth, screenHeight},
+			Position: vec2{0, 0},
+			Rotation: 0,
+			Zoom:     vec2{1, 1},
+		},
+	}
+	var err error
+	g.world, err = ebiten.NewImage(worldSizeX*tileSize, worldSizeY*tileSize, ebiten.FilterDefault)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ebiten.SetWindowSize(screenWidth*2, screenHeight*2)
+	ebiten.SetWindowTitle("Tiles (Ebiten Demo)")
+	if err := ebiten.RunGame(g); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
As discussed on Slack, here is a first version for an orthogonal 2D camera example.

Several things to note / questions I have:
1. I have based this example on the `tiles` example. This introduced a lot of code duplication in the examples. What is the general approach taken here? Keep each example standalone, and accept code duplication? Or should I merge my changes into tiles so we have one example showing several things? I also noted there is an example just for rotation. More or less same questions here...keep separate or merge?
1. Documentation around examples in Ebiten is rather sparse. I would expect to have two kinds of information for this example in particular 1. How do I interact with the demo. In this case WASD (for translation), QE (for scaling), R (for rotation), space (for resetting camera). 2. What is the motivation of the example and why is it working. In this case having a world that is too big to draw on screen, and solution using 3d matrix. Are you interested in this? I could add a short README.[md,adoc], and write few notes, or is there already a place for information like this?
1. This code is based on [camera.go](https://github.com/datosh/goinvaders/blob/master/camera.go), where I have my own vec2.T typed, which handles most of the moving / scaling / rotation. I didn't want to copy the whole vector implementation, but using `image.*` types or just `x, y float64` also wasn't as nice. This is the most "satisfying" version I could come up with. Feel free to provide any feedback on that part in particular :)

Looking forward to your feedback, 
datosh