### PR TITLE
Add CompositeModeMultiply

### DIFF
--- a/graphics.go
+++ b/graphics.go
@@ -85,4 +85,8 @@ const (
 	// Sum of source and destination (a.k.a. 'plus' or 'additive')
 	// c_out = c_src + c_dst
 	CompositeModeLighter CompositeMode = CompositeMode(driver.CompositeModeLighter)
+
+	// The product of source and destination (a.k.a 'multiply blend mode')
+	// c_out = c_src * c_dst
+	CompositeModeMultiply CompositeMode = CompositeMode(driver.CompositeModeMultiply)
 )

--- a/internal/driver/compositemode.go
+++ b/internal/driver/compositemode.go
@@ -35,8 +35,9 @@ const (
 	CompositeModeDestinationAtop
 	CompositeModeXor
 	CompositeModeLighter
+	CompositeModeMultiply
 
-	CompositeModeMax = CompositeModeLighter
+	CompositeModeMax = CompositeModeMultiply
 )
 
 type Operation int
@@ -48,6 +49,7 @@ const (
 	DstAlpha
 	OneMinusSrcAlpha
 	OneMinusDstAlpha
+	DstColor
 )
 
 func (c CompositeMode) Operations() (src Operation, dst Operation) {
@@ -78,6 +80,8 @@ func (c CompositeMode) Operations() (src Operation, dst Operation) {
 		return OneMinusDstAlpha, OneMinusSrcAlpha
 	case CompositeModeLighter:
 		return One, One
+	case CompositeModeMultiply:
+		return DstColor, Zero
 	default:
 		panic(fmt.Sprintf("graphics: invalid composite mode: %d", c))
 	}

--- a/internal/graphicsdriver/opengl/context.go
+++ b/internal/graphicsdriver/opengl/context.go
@@ -36,6 +36,8 @@ func convertOperation(op driver.Operation) operation {
 		return oneMinusSrcAlpha
 	case driver.OneMinusDstAlpha:
 		return oneMinusDstAlpha
+	case driver.DstColor:
+		return dstColor
 	default:
 		panic(fmt.Sprintf("opengl: invalid operation %d at convertOperation", op))
 	}

--- a/internal/graphicsdriver/opengl/context_desktop.go
+++ b/internal/graphicsdriver/opengl/context_desktop.go
@@ -93,6 +93,7 @@ const (
 	dstAlpha         = operation(gl.DST_ALPHA)
 	oneMinusSrcAlpha = operation(gl.ONE_MINUS_SRC_ALPHA)
 	oneMinusDstAlpha = operation(gl.ONE_MINUS_DST_ALPHA)
+	dstColor         = operation(gl.DST_COLOR)
 )
 
 type contextImpl struct {

--- a/internal/graphicsdriver/opengl/context_js.go
+++ b/internal/graphicsdriver/opengl/context_js.go
@@ -90,6 +90,7 @@ var (
 	dstAlpha         operation
 	oneMinusSrcAlpha operation
 	oneMinusDstAlpha operation
+	dstColor         operation
 
 	blend               js.Value
 	clampToEdge         js.Value
@@ -144,6 +145,7 @@ func init() {
 	dstAlpha = operation(contextPrototype.Get("DST_ALPHA").Int())
 	oneMinusSrcAlpha = operation(contextPrototype.Get("ONE_MINUS_SRC_ALPHA").Int())
 	oneMinusDstAlpha = operation(contextPrototype.Get("ONE_MINUS_DST_ALPHA").Int())
+	dstColor = operation(contextPrototype.Get("DST_COLOR").Int())
 
 	blend = contextPrototype.Get("BLEND")
 	clampToEdge = contextPrototype.Get("CLAMP_TO_EDGE")

--- a/internal/graphicsdriver/opengl/context_mobile.go
+++ b/internal/graphicsdriver/opengl/context_mobile.go
@@ -91,6 +91,7 @@ const (
 	dstAlpha         = operation(mgl.DST_ALPHA)
 	oneMinusSrcAlpha = operation(mgl.ONE_MINUS_SRC_ALPHA)
 	oneMinusDstAlpha = operation(mgl.ONE_MINUS_DST_ALPHA)
+	dstColor         = operation(mgl.DST_COLOR)
 )
 
 type contextImpl struct {

--- a/internal/graphicsdriver/opengl/gl/package.go
+++ b/internal/graphicsdriver/opengl/gl/package.go
@@ -31,6 +31,7 @@ const (
 	DST_ALPHA           = 0x0304
 	ONE_MINUS_SRC_ALPHA = 0x0303
 	ONE_MINUS_DST_ALPHA = 0x0305
+	DST_COLOR           = 0x0306
 
 	FALSE = 0
 	TRUE  = 1


### PR DESCRIPTION
This pull request adds a new composite mode called `CompositeModeMultiply`, which multiplies the source color with the destination color.

I have tested my changes on Linux and Windows only.

Closes #410