### PR TITLE
Add various build manifests

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -1,0 +1,17 @@
+image: alpine/latest
+packages:
+  - alsa-lib-dev
+  - libx11-dev
+  - libxrandr-dev
+  - libxcursor-dev
+  - libxinerama-dev
+  - libxi-dev
+  - mesa-dev
+  - pkgconf
+  - go
+sources:
+  - https://github.com/hajimehoshi/ebiten
+tasks:
+  - build: |
+      cd ebiten
+      go build . ./audio

--- a/.builds/arch.yml
+++ b/.builds/arch.yml
@@ -1,0 +1,16 @@
+image: archlinux
+packages:
+  - alsa-lib
+  - mesa
+  - libxrandr
+  - libxcursor
+  - libxinerama
+  - libxi
+  - pkg-config
+  - go
+sources:
+  - https://github.com/hajimehoshi/ebiten
+tasks:
+  - build: |
+      cd ebiten
+      go build . ./audio

--- a/.builds/debian.yml
+++ b/.builds/debian.yml
@@ -1,0 +1,19 @@
+image: debian/testing
+packages:
+  - libc6-dev
+  - libglu1-mesa-dev
+  - libgl1-mesa-dev
+  - libxcursor-dev
+  - libxi-dev
+  - libxinerama-dev
+  - libxrandr-dev
+  - libxxf86vm-dev
+  - libasound2-dev
+  - pkg-config
+  - golang
+sources:
+  - https://github.com/hajimehoshi/ebiten
+tasks:
+  - build: |
+      cd ebiten
+      go build . ./audio

--- a/.builds/fedora.yml
+++ b/.builds/fedora.yml
@@ -1,0 +1,18 @@
+image: fedora/rawhide
+packages:
+  - mesa-libGLU-devel
+  - mesa-libGLES-devel
+  - libXrandr-devel
+  - libXcursor-devel
+  - libXinerama-devel
+  - libXi-devel
+  - libXxf86vm-devel
+  - alsa-lib-devel
+  - pkg-config
+  - go
+sources:
+  - https://github.com/hajimehoshi/ebiten
+tasks:
+  - build: |
+      cd ebiten
+      go build . ./audio

--- a/.builds/ubuntu.yml
+++ b/.builds/ubuntu.yml
@@ -1,0 +1,19 @@
+image: ubuntu/lts
+packages:
+  - libc6-dev
+  - libglu1-mesa-dev
+  - libgl1-mesa-dev
+  - libxcursor-dev
+  - libxi-dev
+  - libxinerama-dev
+  - libxrandr-dev
+  - libxxf86vm-dev
+  - libasound2-dev
+  - pkg-config
+  - golang
+sources:
+  - https://github.com/hajimehoshi/ebiten
+tasks:
+  - build: |
+      cd ebiten
+      go build . ./audio


### PR DESCRIPTION
This pull request adds various build manifests that will be used by sourcehut builds. It tests the installation of Ebiten on the following distros:

- Alpine Linux
- Arch Linux
- Debian
- Fedora
- Ubuntu

If you configure sourcehut dispatch with this repository, they will be run after every commit.