### PR TITLE
Fix typo in the documentation for DrawImageOptions

### DIFF
--- a/image.go
+++ b/image.go
@@ -448,7 +448,7 @@ func (i *Image) DrawTriangles(vertices []Vertex, indices []uint16, img *Image, o
 // This API is experimental.
 type DrawRectShaderOptions struct {
 	// GeoM is a geometry matrix to draw.
-	// The default (zero) value is identify, which draws the rectangle at (0, 0).
+	// The default (zero) value is identity, which draws the rectangle at (0, 0).
 	GeoM GeoM
 
 	// CompositeMode is a composite mode to draw.


### PR DESCRIPTION
"The default (zero) value is identify" -> "The default (zero) value is identity"