### PR TITLE
Fix the comment style cause heading in pkgsite

### DIFF
--- a/image.go
+++ b/image.go
@@ -399,7 +399,7 @@ func (i *Image) DrawTriangles(vertices []Vertex, indices []uint16, img *Image, o
 	i.mipmap.DrawTriangles(srcs, vs, is, options.ColorM.impl, mode, filter, address, sr, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 }
 
-// DrawTrianglesShaderOptions represents options for DrawTrianglesShader
+// DrawTrianglesShaderOptions represents options for DrawTrianglesShader.
 //
 // This API is experimental.
 type DrawTrianglesShaderOptions struct {
@@ -531,7 +531,7 @@ func (i *Image) DrawTrianglesShader(vertices []Vertex, indices []uint16, shader 
 	i.mipmap.DrawTriangles(imgs, vs, is, nil, mode, driver.FilterNearest, driver.AddressUnsafe, sr, offsets, shader.shader, us, false)
 }
 
-// DrawRectShaderOptions represents options for DrawRectShader
+// DrawRectShaderOptions represents options for DrawRectShader.
 //
 // This API is experimental.
 type DrawRectShaderOptions struct {

--- a/internal/graphicsdriver/opengl/gl/package_notwindows.go
+++ b/internal/graphicsdriver/opengl/gl/package_notwindows.go
@@ -727,7 +727,9 @@ func Viewport(x int32, y int32, width int32, height int32) {
 }
 
 // InitWithProcAddrFunc intializes the package using the specified OpenGL
-// function pointer loading function. For more cases Init should be used
+// function pointer loading function.
+//
+// For more cases Init should be used.
 func InitWithProcAddrFunc(getProcAddr func(name string) unsafe.Pointer) error {
 	gpActiveTexture = (C.GPACTIVETEXTURE)(getProcAddr("glActiveTexture"))
 	if gpActiveTexture == nil {

--- a/internal/graphicsdriver/opengl/gl/package_windows.go
+++ b/internal/graphicsdriver/opengl/gl/package_windows.go
@@ -360,7 +360,9 @@ func Viewport(x int32, y int32, width int32, height int32) {
 }
 
 // InitWithProcAddrFunc intializes the package using the specified OpenGL
-// function pointer loading function. For more cases Init should be used
+// function pointer loading function.
+//
+// For more cases Init should be used.
 func InitWithProcAddrFunc(getProcAddr func(name string) uintptr) error {
 	gpActiveTexture = getProcAddr("glActiveTexture")
 	if gpActiveTexture == 0 {

--- a/run.go
+++ b/run.go
@@ -366,7 +366,7 @@ func ScreenSizeInFullscreen() (int, int) {
 	return uiDriver().ScreenSizeInFullscreen()
 }
 
-// MonitorSize is an old name for ScreenSizeInFullscreen
+// MonitorSize is an old name for ScreenSizeInFullscreen.
 //
 // Deprecated: (as of 1.8.0) Use ScreenSizeInFullscreen instead.
 func MonitorSize() (int, int) {


### PR DESCRIPTION
### Overview
Fix the issue with comment heading in `pkgsite`: https://github.com/golang/go/issues/41616

### How
I wrote a simple [Go program](https://gist.github.com/trongbq/424bbc6a4cc79a20d17233d4fa1b1b5b) to detect these kind of comments. It showed following output:
```
1)File: cursormode.go:23
Comment: // Cursor Modes
2)File: examples/keyboard/keyboard/gen.go:262
Comment: // You may obtain a copy of the License at
3)File: gamepad.go:24
Comment: // GamepadButtons
4)File: genevents.go:309
Comment: // You may obtain a copy of the License at
5)File: genkeys.go:635
Comment: // You may obtain a copy of the License at
6)File: image.go:402
Comment: // DrawTrianglesShaderOptions represents options for DrawTrianglesShader
7)File: image.go:534
Comment: // DrawRectShaderOptions represents options for DrawRectShader
8)File: internal/graphicsdriver/opengl/gl/package_notwindows.go:729
Comment: // InitWithProcAddrFunc intializes the package using the specified OpenGL
9)File: internal/graphicsdriver/opengl/gl/package_windows.go:362
Comment: // InitWithProcAddrFunc intializes the package using the specified OpenGL
10)File: mousebuttons.go:24
Comment: // MouseButtons
11)File: run.go:369
Comment: // MonitorSize is an old name for ScreenSizeInFullscreen
```
After manually inspecting these 11 comments, there are 5 remaining comments need to be fixed: 6, 7, 8, 9, 11


