### PR TITLE
internal/shareable: Call DrawTriangles instead of ReplacePixels at makeShared

### DIFF
--- a/internal/restorable/image.go
+++ b/internal/restorable/image.go
@@ -297,7 +297,7 @@ func (i *Image) ReplacePixels(pixels []byte, x, y, width, height int) {
 		i.image.ReplacePixels(make([]byte, 4*width*height), x, y, width, height)
 	}
 
-	if !needsRestoring() || i.screen || i.volatile {
+	if !NeedsRestoring() || i.screen || i.volatile {
 		i.makeStale()
 		return
 	}
@@ -363,7 +363,7 @@ func (i *Image) DrawTriangles(srcs [graphics.ShaderImageNum]*Image, offsets [gra
 		}
 	}
 
-	if srcstale || i.screen || !needsRestoring() || i.volatile {
+	if srcstale || i.screen || !NeedsRestoring() || i.volatile {
 		i.makeStale()
 	} else {
 		i.appendDrawTrianglesHistory(srcs, offsets, vertices, indices, colorm, mode, filter, address, dstRegion, srcRegion, shader, uniforms)
@@ -496,7 +496,7 @@ func (i *Image) readPixelsFromGPU() error {
 
 // resolveStale resolves the image's 'stale' state.
 func (i *Image) resolveStale() error {
-	if !needsRestoring() {
+	if !NeedsRestoring() {
 		return nil
 	}
 

--- a/internal/restorable/images.go
+++ b/internal/restorable/images.go
@@ -24,8 +24,8 @@ import (
 // forceRestoring reports whether restoring forcely happens or not.
 var forceRestoring = false
 
-// needsRestoring reports whether restoring process works or not.
-func needsRestoring() bool {
+// NeedsRestoring reports whether restoring process works or not.
+func NeedsRestoring() bool {
 	if forceRestoring {
 		return true
 	}
@@ -59,7 +59,7 @@ func ResolveStaleImages() error {
 	if err := graphicscommand.FlushCommands(); err != nil {
 		return err
 	}
-	if !needsRestoring() {
+	if !NeedsRestoring() {
 		return nil
 	}
 	return theImages.resolveStaleImages()
@@ -69,7 +69,7 @@ func ResolveStaleImages() error {
 //
 // Restoring means to make all *graphicscommand.Image objects have their textures and framebuffers.
 func RestoreIfNeeded() error {
-	if !needsRestoring() {
+	if !NeedsRestoring() {
 		return nil
 	}
 
@@ -184,7 +184,7 @@ func (i *images) makeStaleIfDependingOnShader(shader *Shader) {
 //
 // Restoring means to make all *graphicscommand.Image objects have their textures and framebuffers.
 func (i *images) restore() error {
-	if !needsRestoring() {
+	if !NeedsRestoring() {
 		panic("restorable: restore cannot be called when restoring is disabled")
 	}
 


### PR DESCRIPTION
When context losts never happen, reading pixels and call replace-pixels command are not needed.

Closes #1508