### PR TITLE
internal/graphicscommand: fix missing composite mode

### DIFF
--- a/internal/graphicscommand/command.go
+++ b/internal/graphicscommand/command.go
@@ -350,6 +350,8 @@ func (c *drawTrianglesCommand) String() string {
 		mode = "xor"
 	case driver.CompositeModeLighter:
 		mode = "lighter"
+	case driver.CompositeModeMultiply:
+		mode = "multiply"
 	default:
 		panic(fmt.Sprintf("graphicscommand: invalid composite mode: %d", c.mode))
 	}


### PR DESCRIPTION
Using `-tags=ebitendebug` would log the string: 
```
  %!s(PANIC=String method: graphicscommand: invalid composite mode: 13)
```
When using the multiply composite mode. This adds it to the string function.