### PR TITLE
Fallback to simpler logic when trying to get DPI from monitor and failing

### DIFF
--- a/internal/devicescale/impl_windows.go
+++ b/internal/devicescale/impl_windows.go
@@ -240,12 +240,14 @@ func impl(x, y int) float64 {
 	// do this with Cgo. Use MonitorFromRect instead.
 	m, err := monitorFromRect(&lprc, monitorDefaultToNearest)
 	if err != nil {
+		// monitorFromRect can fail in some environments (#1612)
 		return getFromLogPixelSx()
 	}
 
 	dpiX := uint32(0)
 	dpiY := uint32(0) // Passing dpiY is needed even though this is not used, or GetDpiForMonitor returns an error.
 	if err := getDpiForMonitor(m, mdtEffectiveDpi, &dpiX, &dpiY); err != nil {
+		// getDpiForMonitor can fail in some environments (#1612)
 		return getFromLogPixelSx()
 	}
 	runtime.KeepAlive(dpiY)

--- a/internal/devicescale/impl_windows.go
+++ b/internal/devicescale/impl_windows.go
@@ -240,13 +240,13 @@ func impl(x, y int) float64 {
 	// do this with Cgo. Use MonitorFromRect instead.
 	m, err := monitorFromRect(&lprc, monitorDefaultToNearest)
 	if err != nil {
-		panic(err)
+		return getFromLogPixelSx()
 	}
 
 	dpiX := uint32(0)
 	dpiY := uint32(0) // Passing dpiY is needed even though this is not used, or GetDpiForMonitor returns an error.
 	if err := getDpiForMonitor(m, mdtEffectiveDpi, &dpiX, &dpiY); err != nil {
-		panic(err)
+		return getFromLogPixelSx()
 	}
 	runtime.KeepAlive(dpiY)
 


### PR DESCRIPTION
This fixes a crash on at least one of my customer's machines. I don't have access to the machine, so I don't know why it's failing.

Instead of crashing, just falls back to other DPI.