### PR TITLE
internal/uidriver/glfw: Bug fix: do not execute loop function if init failed

### DIFF
--- a/internal/uidriver/glfw/run_notsinglethread.go
+++ b/internal/uidriver/glfw/run_notsinglethread.go
@@ -43,13 +43,16 @@ func (u *UserInterface) Run(uicontext driver.UIContext) error {
 
 		defer close(ch)
 
-		_ = u.t.Call(func() error {
+		err := u.t.Call(func() error {
 			if err := u.init(); err != nil {
 				ch <- err
-				return nil
+				return err
 			}
 			return nil
 		})
+		if err != nil {
+			return
+		}
 
 		if err := u.loop(); err != nil {
 			ch <- err

--- a/internal/uidriver/glfw/run_notsinglethread.go
+++ b/internal/uidriver/glfw/run_notsinglethread.go
@@ -43,14 +43,10 @@ func (u *UserInterface) Run(uicontext driver.UIContext) error {
 
 		defer close(ch)
 
-		err := u.t.Call(func() error {
-			if err := u.init(); err != nil {
-				ch <- err
-				return err
-			}
-			return nil
-		})
-		if err != nil {
+		if err := u.t.Call(func() error {
+			return u.init()
+		}); err != nil {
+			ch <- err
 			return
 		}
 


### PR DESCRIPTION
In `internal/uidriver/glfw/run_notsinglethread.go`, if the `UserInterface.init()` function returns an error, the `loop` is executed regardless and the error is discarded. This behavior will hide the error returned by `init()` and might trigger some crashes (see #1688 ).

A partial fix was implemented in 6c4edf8605ea83a8c582cd228f230d1dbda213ce , however that commit alone is not enough: the code now is correctly returning the error via the `ch` channel, but it still executes the `loop()` function. This merge request skips `loop()` call if `init()` had an error.