### PR TITLE
Fix a wrong conversion function usage for converting mouse positions.

### DIFF
--- a/internal/uidriver/glfw/input.go
+++ b/internal/uidriver/glfw/input.go
@@ -304,8 +304,8 @@ func (i *Input) update(window *glfw.Window, context driver.UIContext) {
 	cx, cy := window.GetCursorPos()
 	// TODO: This is tricky. Rename the function?
 	s := i.ui.deviceScaleFactor()
-	cx = fromGLFWMonitorPixel(cx, s)
-	cy = fromGLFWMonitorPixel(cy, s)
+	cx = i.ui.fromGLFWPixel(cx)
+	cy = i.ui.fromGLFWPixel(cy)
 	cx, cy = context.AdjustPosition(cx, cy, s)
 
 	// AdjustPosition can return NaN at the initialization.


### PR DESCRIPTION
The function used was one for video mode to window system conversion -
however the intent was converting window system to device independent pixel,
as GLFW returns window system coordinates for mouse pointers.

This is part of fixing #1774.