### PR TITLE
Split the concept of device scale and screen scale

### DIFF
--- a/internal/devicescale/devicescale.go
+++ b/internal/devicescale/devicescale.go
@@ -28,9 +28,8 @@ var (
 	screenScaleCache = map[pos]float64{}
 )
 
-// GetAt returns the device scale at (x, y).
+// GetAt returns the device scale at (x, y), i.e. the number of device-dependent pixels per device-independent pixel.
 // x and y are in device-dependent pixels and must be the top-left coordinate of a monitor, or 0,0 to request a "global scale".
-// The device scale maps device dependent pixels to device independent pixels.
 func GetAt(x, y int) float64 {
 	m.Lock()
 	defer m.Unlock()
@@ -48,9 +47,8 @@ func GetAt(x, y int) float64 {
 	return s
 }
 
-// ScreenScaleAt returns the screen scale at (x, y).
+// ScreenScaleAt returns the screen scale at (x, y), i.e. the number of video mode pixels per device-dependent pixel.
 // x and y are in device-dependent pixels and must be the top-left coordinate of a monitor, or 0,0 to request a "global scale".
-// The screen scale maps physical screen pixels to device dependent pixels.
 func ScreenScaleAt(x, y int) float64 {
 	m.Lock()
 	defer m.Unlock()

--- a/internal/devicescale/devicescale.go
+++ b/internal/devicescale/devicescale.go
@@ -23,9 +23,9 @@ type pos struct {
 }
 
 var (
-	m                sync.Mutex
-	cache            = map[pos]float64{}
-	screenScaleCache = map[pos]float64{}
+	m                   sync.Mutex
+	cache               = map[pos]float64{}
+	videoModeScaleCache = map[pos]float64{}
 )
 
 // GetAt returns the device scale at (x, y), i.e. the number of device-dependent pixels per device-independent pixel.
@@ -47,15 +47,15 @@ func GetAt(x, y int) float64 {
 	return s
 }
 
-// ScreenScaleAt returns the screen scale at (x, y), i.e. the number of video mode pixels per device-dependent pixel.
+// VideoModeScaleAt returns the video mode scale scale at (x, y), i.e. the number of video mode pixels per device-dependent pixel.
 // x and y are in device-dependent pixels and must be the top-left coordinate of a monitor, or 0,0 to request a "global scale".
-func ScreenScaleAt(x, y int) float64 {
+func VideoModeScaleAt(x, y int) float64 {
 	m.Lock()
 	defer m.Unlock()
-	if s, ok := screenScaleCache[pos{x, y}]; ok {
+	if s, ok := videoModeScaleCache[pos{x, y}]; ok {
 		return s
 	}
-	s := screenScaleImpl(x, y)
-	screenScaleCache[pos{x, y}] = s
+	s := videoModeScaleImpl(x, y)
+	videoModeScaleCache[pos{x, y}] = s
 	return s
 }

--- a/internal/devicescale/devicescale.go
+++ b/internal/devicescale/devicescale.go
@@ -23,8 +23,9 @@ type pos struct {
 }
 
 var (
-	m     sync.Mutex
-	cache = map[pos]float64{}
+	m                sync.Mutex
+	cache            = map[pos]float64{}
+	screenScaleCache = map[pos]float64{}
 )
 
 // GetAt returns the device scale at (x, y).
@@ -44,5 +45,19 @@ func GetAt(x, y int) float64 {
 	// The only known case is when the application works on macOS, with OpenGL, with a wider screen mode,
 	// and in the fullscreen mode (#1573).
 
+	return s
+}
+
+// ScreenScaleAt returns the screen scale at (x, y).
+// x and y are in device-dependent pixels and must be the top-left coordinate of a monitor, or 0,0 to request a "global scale".
+// The screen scale maps physical screen pixels to device dependent pixels.
+func ScreenScaleAt(x, y int) float64 {
+	m.Lock()
+	defer m.Unlock()
+	if s, ok := screenScaleCache[pos{x, y}]; ok {
+		return s
+	}
+	s := screenScaleImpl(x, y)
+	screenScaleCache[pos{x, y}] = s
 	return s
 }

--- a/internal/devicescale/impl_android.go
+++ b/internal/devicescale/impl_android.go
@@ -103,3 +103,7 @@ func impl(x, y int) float64 {
 	}
 	return s
 }
+
+func screenScaleImpl(x, y int) float64 {
+	return 1
+}

--- a/internal/devicescale/impl_android.go
+++ b/internal/devicescale/impl_android.go
@@ -104,6 +104,6 @@ func impl(x, y int) float64 {
 	return s
 }
 
-func screenScaleImpl(x, y int) float64 {
+func videoModeScaleImpl(x, y int) float64 {
 	return 1
 }

--- a/internal/devicescale/impl_desktop.go
+++ b/internal/devicescale/impl_desktop.go
@@ -33,3 +33,8 @@ func monitorAt(x, y int) *glfw.Monitor {
 	}
 	return monitors[0]
 }
+
+func impl(x, y int) float64 {
+	sx, _ := monitorAt(x, y).GetContentScale()
+	return float64(sx)
+}

--- a/internal/devicescale/impl_ios.go
+++ b/internal/devicescale/impl_ios.go
@@ -31,6 +31,6 @@ func impl(x, y int) float64 {
 	return float64(C.devicePixelRatio())
 }
 
-func screenScaleImpl(x, y int) float64 {
+func videoModeScaleImpl(x, y int) float64 {
 	return 1
 }

--- a/internal/devicescale/impl_ios.go
+++ b/internal/devicescale/impl_ios.go
@@ -30,3 +30,7 @@ import "C"
 func impl(x, y int) float64 {
 	return float64(C.devicePixelRatio())
 }
+
+func screenScaleImpl(x, y int) float64 {
+	return 1
+}

--- a/internal/devicescale/impl_js.go
+++ b/internal/devicescale/impl_js.go
@@ -34,6 +34,6 @@ func impl(x, y int) float64 {
 	return ratio
 }
 
-func screenScaleImpl(x, y int) float64 {
+func videoModeScaleImpl(x, y int) float64 {
 	return 1
 }

--- a/internal/devicescale/impl_js.go
+++ b/internal/devicescale/impl_js.go
@@ -33,3 +33,7 @@ func impl(x, y int) float64 {
 	}
 	return ratio
 }
+
+func screenScaleImpl(x, y int) float64 {
+	return 1
+}

--- a/internal/devicescale/impl_notx.go
+++ b/internal/devicescale/impl_notx.go
@@ -18,6 +18,5 @@
 package devicescale
 
 func screenScaleImpl(x, y int) float64 {
-	sx, _ := monitorAt(x, y).GetContentScale()
-	return float64(sx)
+	return 1.0
 }

--- a/internal/devicescale/impl_notx.go
+++ b/internal/devicescale/impl_notx.go
@@ -17,6 +17,6 @@
 
 package devicescale
 
-func screenScaleImpl(x, y int) float64 {
-	return 1.0
+func videoModeScaleImpl(x, y int) float64 {
+	return 1
 }

--- a/internal/devicescale/impl_notx.go
+++ b/internal/devicescale/impl_notx.go
@@ -17,7 +17,7 @@
 
 package devicescale
 
-func impl(x, y int) float64 {
+func screenScaleImpl(x, y int) float64 {
 	sx, _ := monitorAt(x, y).GetContentScale()
 	return float64(sx)
 }

--- a/internal/devicescale/impl_x.go
+++ b/internal/devicescale/impl_x.go
@@ -27,7 +27,7 @@ import (
 
 func screenScaleImpl(x, y int) float64 {
 	// TODO: if https://github.com/glfw/glfw/issues/1961 gets fixed, this function may need revising.
-	// In case GLFW decides to switch to returning logical pixels, we can just return 1.0.
+	// In case GLFW decides to switch to returning logical pixels, we can just return 1.
 
 	// Note: GLFW currently returns physical pixel sizes,
 	// but we need to predict the window system-side size of the fullscreen window
@@ -42,19 +42,19 @@ func screenScaleImpl(x, y int) float64 {
 		// No X11 connection?
 		// Assume we're on pure Wayland then.
 		// GLFW/Wayland shouldn't be having this issue.
-		return 1.0
+		return 1
 	}
 	if err = randr.Init(xconn); err != nil {
 		// No RANDR extension?
 		// No problem.
-		return 1.0
+		return 1
 	}
 	root := xproto.Setup(xconn).DefaultScreen(xconn).Root
 	res, err := randr.GetScreenResourcesCurrent(xconn, root).Reply()
 	if err != nil {
 		// Likely means RANDR is not working.
 		// No problem.
-		return 1.0
+		return 1
 	}
 	for _, crtc := range res.Crtcs[:res.NumCrtcs] {
 		info, err := randr.GetCrtcInfo(xconn, crtc, res.ConfigTimestamp).Reply()
@@ -78,5 +78,5 @@ func screenScaleImpl(x, y int) float64 {
 		}
 	}
 	// Monitor not known to XRandR. Weird.
-	return 1.0
+	return 1
 }

--- a/internal/devicescale/impl_x.go
+++ b/internal/devicescale/impl_x.go
@@ -25,7 +25,7 @@ import (
 	"github.com/jezek/xgb/xproto"
 )
 
-func screenScaleImpl(x, y int) float64 {
+func videoModeScaleImpl(x, y int) float64 {
 	// TODO: if https://github.com/glfw/glfw/issues/1961 gets fixed, this function may need revising.
 	// In case GLFW decides to switch to returning logical pixels, we can just return 1.
 

--- a/internal/devicescale/impl_x.go
+++ b/internal/devicescale/impl_x.go
@@ -25,7 +25,7 @@ import (
 	"github.com/jezek/xgb/xproto"
 )
 
-func impl(x, y int) float64 {
+func screenScaleImpl(x, y int) float64 {
 	// TODO: if https://github.com/glfw/glfw/issues/1961 gets fixed, this function may need revising.
 	// In case GLFW decides to switch to returning logical pixels, we can just return 1.0.
 
@@ -35,7 +35,6 @@ func impl(x, y int) float64 {
 	// Also at the moment we need this prior to switching to fullscreen, but that might be replacable.
 	// So this function computes the ratio of physical per logical pixels.
 	m := monitorAt(x, y)
-	sx, _ := m.GetContentScale()
 	monitorX, monitorY := m.GetPos()
 	xconn, err := xgb.NewConn()
 	defer xconn.Close()
@@ -43,19 +42,19 @@ func impl(x, y int) float64 {
 		// No X11 connection?
 		// Assume we're on pure Wayland then.
 		// GLFW/Wayland shouldn't be having this issue.
-		return float64(sx)
+		return 1.0
 	}
 	if err = randr.Init(xconn); err != nil {
 		// No RANDR extension?
 		// No problem.
-		return float64(sx)
+		return 1.0
 	}
 	root := xproto.Setup(xconn).DefaultScreen(xconn).Root
 	res, err := randr.GetScreenResourcesCurrent(xconn, root).Reply()
 	if err != nil {
 		// Likely means RANDR is not working.
 		// No problem.
-		return float64(sx)
+		return 1.0
 	}
 	for _, crtc := range res.Crtcs[:res.NumCrtcs] {
 		info, err := randr.GetCrtcInfo(xconn, crtc, res.ConfigTimestamp).Reply()
@@ -75,9 +74,9 @@ func impl(x, y int) float64 {
 			// Return one scale, even though there may be separate X and Y scales.
 			// Return the _larger_ scale, as this would yield a letterboxed display on mismatch, rather than a cut-off one.
 			scale := math.Max(float64(physWidth)/float64(xWidth), float64(physHeight)/float64(xHeight))
-			return float64(sx) * scale
+			return scale
 		}
 	}
 	// Monitor not known to XRandR. Weird.
-	return float64(sx)
+	return 1.0
 }

--- a/internal/uidriver/glfw/input.go
+++ b/internal/uidriver/glfw/input.go
@@ -305,8 +305,8 @@ func (i *Input) update(window *glfw.Window, context driver.UIContext) {
 	cx, cy := window.GetCursorPos()
 	// TODO: This is tricky. Rename the function?
 	s := i.ui.deviceScaleFactor()
-	cx = fromGLFWMonitorPixel(cx, s)
-	cy = fromGLFWMonitorPixel(cy, s)
+	cx = i.ui.fromGLFWPixel(cx)
+	cy = i.ui.fromGLFWPixel(cy)
 	cx, cy = context.AdjustPosition(cx, cy, s)
 
 	// AdjustPosition can return NaN at the initialization.

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -952,9 +952,6 @@ func (u *UserInterface) updateSize() (float64, float64, bool) {
 		w = u.fromGLFWPixel(float64(ww))
 		h = u.fromGLFWPixel(float64(wh))
 	}
-	// On Linux/UNIX, further adjusting is required (#1307).
-	w = u.toFramebufferPixel(w)
-	h = u.toFramebufferPixel(h)
 
 	return w, h, true
 }

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -1649,6 +1649,11 @@ func (u *UserInterface) setWindowTitle(title string) {
 	u.window.SetTitle(title)
 }
 
+// fromGLFWMonitorPixel must be called from the main thread.
+func (u *UserInterface) fromGLFWMonitorPixel(x float64, screenScale float64) float64 {
+	return x / (screenScale * u.deviceScaleFactor())
+}
+
 // fromGLFWPixel must be called from the main thread.
 func (u *UserInterface) fromGLFWPixel(x float64) float64 {
 	return x / u.deviceScaleFactor()

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -190,7 +190,7 @@ func initialize() error {
 	theUI.initMonitor = m
 	v := m.GetVideoMode()
 	mx, my := currentMonitor(w).GetPos()
-	scale := devicescale.ScreenScaleAt(mx, my)
+	scale := devicescale.VideoModeScaleAt(mx, my)
 	theUI.initFullscreenWidthInDP = int(theUI.fromGLFWMonitorPixel(float64(v.Width), scale))
 	theUI.initFullscreenHeightInDP = int(theUI.fromGLFWMonitorPixel(float64(v.Height), scale))
 
@@ -532,7 +532,7 @@ func (u *UserInterface) ScreenSizeInFullscreen() (int, int) {
 		m := currentMonitor(u.window)
 		v := m.GetVideoMode()
 		mx, my := m.GetPos()
-		s := devicescale.ScreenScaleAt(mx, my)
+		s := devicescale.VideoModeScaleAt(mx, my)
 		w = int(u.fromGLFWMonitorPixel(float64(v.Width), s))
 		h = int(u.fromGLFWMonitorPixel(float64(v.Height), s))
 		return nil
@@ -941,7 +941,7 @@ func (u *UserInterface) updateSize() (float64, float64, bool) {
 		v := m.GetVideoMode()
 		ww, wh := v.Width, v.Height
 		mx, my := m.GetPos()
-		s := devicescale.ScreenScaleAt(mx, my)
+		s := devicescale.VideoModeScaleAt(mx, my)
 		w = u.fromGLFWMonitorPixel(float64(ww), s)
 		h = u.fromGLFWMonitorPixel(float64(wh), s)
 	} else {
@@ -1650,8 +1650,8 @@ func (u *UserInterface) setWindowTitle(title string) {
 }
 
 // fromGLFWMonitorPixel must be called from the main thread.
-func (u *UserInterface) fromGLFWMonitorPixel(x float64, screenScale float64) float64 {
-	return x / (screenScale * u.deviceScaleFactor())
+func (u *UserInterface) fromGLFWMonitorPixel(x float64, videoModeScale float64) float64 {
+	return x / (videoModeScale * u.deviceScaleFactor())
 }
 
 // fromGLFWPixel must be called from the main thread.

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -189,9 +189,10 @@ func initialize() error {
 	m := currentMonitor(w)
 	theUI.initMonitor = m
 	v := m.GetVideoMode()
-	scale := devicescale.GetAt(currentMonitor(w).GetPos())
-	theUI.initFullscreenWidthInDP = int(fromGLFWMonitorPixel(float64(v.Width), scale))
-	theUI.initFullscreenHeightInDP = int(fromGLFWMonitorPixel(float64(v.Height), scale))
+	mx, my := currentMonitor(w).GetPos()
+	scale := devicescale.ScreenScaleAt(mx, my)
+	theUI.initFullscreenWidthInDP = int(theUI.fromGLFWMonitorPixel(float64(v.Width), scale))
+	theUI.initFullscreenHeightInDP = int(theUI.fromGLFWMonitorPixel(float64(v.Height), scale))
 
 	// Create system cursors. These cursors are destroyed at glfw.Terminate().
 	glfwSystemCursors[driver.CursorShapeDefault] = nil
@@ -528,10 +529,12 @@ func (u *UserInterface) ScreenSizeInFullscreen() (int, int) {
 
 	var w, h int
 	_ = u.t.Call(func() error {
-		v := currentMonitor(u.window).GetVideoMode()
-		s := u.deviceScaleFactor()
-		w = int(fromGLFWMonitorPixel(float64(v.Width), s))
-		h = int(fromGLFWMonitorPixel(float64(v.Height), s))
+		m := currentMonitor(u.window)
+		v := m.GetVideoMode()
+		mx, my := m.GetPos()
+		s := devicescale.ScreenScaleAt(mx, my)
+		w = int(u.fromGLFWMonitorPixel(float64(v.Width), s))
+		h = int(u.fromGLFWMonitorPixel(float64(v.Height), s))
 		return nil
 	})
 	return w, h
@@ -707,7 +710,7 @@ func (u *UserInterface) SetCursorShape(shape driver.CursorShape) {
 func (u *UserInterface) DeviceScaleFactor() float64 {
 	if !u.isRunning() {
 		// TODO: Use the initWindowPosition. This requires to convert the units correctly (#1575).
-		return devicescale.GetAt(u.initMonitor.GetPos())
+		return u.deviceScaleFactor()
 	}
 
 	f := 0.0
@@ -724,7 +727,8 @@ func (u *UserInterface) deviceScaleFactor() float64 {
 	if u.window != nil {
 		m = currentMonitor(u.window)
 	}
-	return devicescale.GetAt(m.GetPos())
+	mx, my := m.GetPos()
+	return devicescale.GetAt(mx, my)
 }
 
 func init() {
@@ -933,11 +937,13 @@ func (u *UserInterface) updateSize() (float64, float64, bool) {
 
 	var w, h float64
 	if u.isFullscreen() {
-		v := currentMonitor(u.window).GetVideoMode()
+		m := currentMonitor(u.window)
+		v := m.GetVideoMode()
 		ww, wh := v.Width, v.Height
-		s := u.deviceScaleFactor()
-		w = fromGLFWMonitorPixel(float64(ww), s)
-		h = fromGLFWMonitorPixel(float64(wh), s)
+		mx, my := m.GetPos()
+		s := devicescale.ScreenScaleAt(mx, my)
+		w = u.fromGLFWMonitorPixel(float64(ww), s)
+		h = u.fromGLFWMonitorPixel(float64(wh), s)
 	} else {
 		// Instead of u.windowWidth and u.windowHeight, use the actual window size here.
 		// On Windows, the specified size at SetSize and the actual window size might not

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -1648,3 +1648,13 @@ func (u *UserInterface) setWindowTitle(title string) {
 
 	u.window.SetTitle(title)
 }
+
+// fromGLFWPixel must be called from the main thread.
+func (u *UserInterface) fromGLFWPixel(x float64) float64 {
+	return x / u.deviceScaleFactor()
+}
+
+// toGLFWPixel must be called from the main thread.
+func (u *UserInterface) toGLFWPixel(x float64) float64 {
+	return x * u.deviceScaleFactor()
+}

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -1648,18 +1648,3 @@ func (u *UserInterface) setWindowTitle(title string) {
 
 	u.window.SetTitle(title)
 }
-
-// fromGLFWMonitorPixel must be called from the main thread.
-func (u *UserInterface) fromGLFWMonitorPixel(x float64, videoModeScale float64) float64 {
-	return x / (videoModeScale * u.deviceScaleFactor())
-}
-
-// fromGLFWPixel must be called from the main thread.
-func (u *UserInterface) fromGLFWPixel(x float64) float64 {
-	return x / u.deviceScaleFactor()
-}
-
-// toGLFWPixel must be called from the main thread.
-func (u *UserInterface) toGLFWPixel(x float64) float64 {
-	return x * u.deviceScaleFactor()
-}

--- a/internal/uidriver/glfw/ui_darwin.go
+++ b/internal/uidriver/glfw/ui_darwin.go
@@ -83,14 +83,14 @@ import (
 
 // fromGLFWMonitorPixel must be called from the main thread.
 func (u *UserInterface) fromGLFWMonitorPixel(x float64, videoModeScale float64) float64 {
-	// videoModeScale is always 1 on OS X,
+	// videoModeScale is always 1 on macOS,
 	// however leaving the divison in place for consistency.
 	return x / videoModeScale
 }
 
 // fromGLFWPixel must be called from the main thread.
 func (u *UserInterface) fromGLFWPixel(x float64) float64 {
-	// NOTE: On OS X, GLFW exposes the device independent coordinate system.
+	// NOTE: On macOS, GLFW exposes the device independent coordinate system.
 	// Thus, the conversion functions are unnecessary,
 	// however we still need the deviceScaleFactor internally
 	// so we can create and maintain a HiDPI frame buffer.

--- a/internal/uidriver/glfw/ui_darwin.go
+++ b/internal/uidriver/glfw/ui_darwin.go
@@ -81,6 +81,27 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/internal/glfw"
 )
 
+// fromGLFWMonitorPixel must be called from the main thread.
+func (u *UserInterface) fromGLFWMonitorPixel(x float64, videoModeScale float64) float64 {
+	// videoModeScale is always 1 on OS X,
+	// however leaving the divison in place for consistency.
+	return x / videoModeScale
+}
+
+// fromGLFWPixel must be called from the main thread.
+func (u *UserInterface) fromGLFWPixel(x float64) float64 {
+	// NOTE: On OS X, GLFW exposes the device independent coordinate system.
+	// Thus, the conversion functions are unnecessary,
+	// however we still need the deviceScaleFactor internally
+	// so we can create and maintain a HiDPI frame buffer.
+	return x
+}
+
+// toGLFWPixel must be called from the main thread.
+func (u *UserInterface) toGLFWPixel(x float64) float64 {
+	return x
+}
+
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	return x, y
 }

--- a/internal/uidriver/glfw/ui_darwin.go
+++ b/internal/uidriver/glfw/ui_darwin.go
@@ -81,16 +81,17 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/internal/glfw"
 )
 
-func fromGLFWMonitorPixel(x float64, deviceScale float64) float64 {
+func (u *UserInterface) fromGLFWMonitorPixel(x float64, deviceScale float64) float64 {
+	// TODO what is the actual unit here?
 	return x
 }
 
 func (u *UserInterface) fromGLFWPixel(x float64) float64 {
-	return x
+	return x / u.deviceScaleFactor()
 }
 
 func (u *UserInterface) toGLFWPixel(x float64) float64 {
-	return x
+	return x * u.deviceScaleFactor()
 }
 
 func (u *UserInterface) toFramebufferPixel(x float64) float64 {

--- a/internal/uidriver/glfw/ui_darwin.go
+++ b/internal/uidriver/glfw/ui_darwin.go
@@ -81,11 +81,6 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/internal/glfw"
 )
 
-func (u *UserInterface) fromGLFWMonitorPixel(x float64, deviceScale float64) float64 {
-	// TODO what is the actual unit here?
-	return x
-}
-
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	return x, y
 }

--- a/internal/uidriver/glfw/ui_darwin.go
+++ b/internal/uidriver/glfw/ui_darwin.go
@@ -94,10 +94,6 @@ func (u *UserInterface) toGLFWPixel(x float64) float64 {
 	return x * u.deviceScaleFactor()
 }
 
-func (u *UserInterface) toFramebufferPixel(x float64) float64 {
-	return x
-}
-
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	return x, y
 }

--- a/internal/uidriver/glfw/ui_darwin.go
+++ b/internal/uidriver/glfw/ui_darwin.go
@@ -86,14 +86,6 @@ func (u *UserInterface) fromGLFWMonitorPixel(x float64, deviceScale float64) flo
 	return x
 }
 
-func (u *UserInterface) fromGLFWPixel(x float64) float64 {
-	return x / u.deviceScaleFactor()
-}
-
-func (u *UserInterface) toGLFWPixel(x float64) float64 {
-	return x * u.deviceScaleFactor()
-}
-
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	return x, y
 }

--- a/internal/uidriver/glfw/ui_unix.go
+++ b/internal/uidriver/glfw/ui_unix.go
@@ -19,17 +19,9 @@
 package glfw
 
 import (
-	"math"
-
 	"github.com/hajimehoshi/ebiten/v2/internal/driver"
 	"github.com/hajimehoshi/ebiten/v2/internal/glfw"
 )
-
-// fromGLFWMonitorPixel must be called from the main thread.
-func (u *UserInterface) fromGLFWMonitorPixel(x float64, screenScale float64) float64 {
-	// deviceScale is sometimes an unnice value (e.g., 1.502361). Use math.Ceil to clean the vaule.
-	return math.Ceil(x / (screenScale * u.deviceScaleFactor()))
-}
 
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	return x, y

--- a/internal/uidriver/glfw/ui_unix.go
+++ b/internal/uidriver/glfw/ui_unix.go
@@ -31,16 +31,6 @@ func (u *UserInterface) fromGLFWMonitorPixel(x float64, screenScale float64) flo
 	return math.Ceil(x / (screenScale * u.deviceScaleFactor()))
 }
 
-// fromGLFWPixel must be called from the main thread.
-func (u *UserInterface) fromGLFWPixel(x float64) float64 {
-	return x / u.deviceScaleFactor()
-}
-
-// toGLFWPixel must be called from the main thread.
-func (u *UserInterface) toGLFWPixel(x float64) float64 {
-	return x * u.deviceScaleFactor()
-}
-
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	return x, y
 }

--- a/internal/uidriver/glfw/ui_unix.go
+++ b/internal/uidriver/glfw/ui_unix.go
@@ -23,6 +23,21 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/internal/glfw"
 )
 
+// fromGLFWMonitorPixel must be called from the main thread.
+func (u *UserInterface) fromGLFWMonitorPixel(x float64, videoModeScale float64) float64 {
+	return x / (videoModeScale * u.deviceScaleFactor())
+}
+
+// fromGLFWPixel must be called from the main thread.
+func (u *UserInterface) fromGLFWPixel(x float64) float64 {
+	return x / u.deviceScaleFactor()
+}
+
+// toGLFWPixel must be called from the main thread.
+func (u *UserInterface) toGLFWPixel(x float64) float64 {
+	return x * u.deviceScaleFactor()
+}
+
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	return x, y
 }

--- a/internal/uidriver/glfw/ui_unix.go
+++ b/internal/uidriver/glfw/ui_unix.go
@@ -41,11 +41,6 @@ func (u *UserInterface) toGLFWPixel(x float64) float64 {
 	return x * u.deviceScaleFactor()
 }
 
-// toFramebufferPixel must be called from the main thread.
-func (u *UserInterface) toFramebufferPixel(x float64) float64 {
-	return x
-}
-
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	return x, y
 }

--- a/internal/uidriver/glfw/ui_unix.go
+++ b/internal/uidriver/glfw/ui_unix.go
@@ -26,30 +26,24 @@ import (
 )
 
 // fromGLFWMonitorPixel must be called from the main thread.
-func fromGLFWMonitorPixel(x float64, deviceScale float64) float64 {
-	// deviceScaleFactor is sometimes an unnice value (e.g., 1.502361). Use math.Ceil to clean the vaule.
-	return math.Ceil(x / deviceScale)
+func (u *UserInterface) fromGLFWMonitorPixel(x float64, screenScale float64) float64 {
+	// deviceScale is sometimes an unnice value (e.g., 1.502361). Use math.Ceil to clean the vaule.
+	return math.Ceil(x / (screenScale * u.deviceScaleFactor()))
 }
 
 // fromGLFWPixel must be called from the main thread.
 func (u *UserInterface) fromGLFWPixel(x float64) float64 {
-	// deviceScaleFactor() is a scale by desktop environment (e.g., Cinnamon), while GetContentScale() is X's scale.
-	// They are different things and then need to be treated in different ways (#1350).
-	s, _ := currentMonitor(u.window).GetContentScale()
-	return x / float64(s)
+	return x / u.deviceScaleFactor()
 }
 
 // toGLFWPixel must be called from the main thread.
 func (u *UserInterface) toGLFWPixel(x float64) float64 {
-	s, _ := currentMonitor(u.window).GetContentScale()
-	return x * float64(s)
+	return x * u.deviceScaleFactor()
 }
 
 // toFramebufferPixel must be called from the main thread.
 func (u *UserInterface) toFramebufferPixel(x float64) float64 {
-	s, _ := currentMonitor(u.window).GetContentScale()
-	// deviceScaleFactor is sometimes an unnice value (e.g., 1.502361). Use math.Ceil to clean the vaule.
-	return math.Ceil(x * float64(s) / u.deviceScaleFactor())
+	return x
 }
 
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {

--- a/internal/uidriver/glfw/ui_windows.go
+++ b/internal/uidriver/glfw/ui_windows.go
@@ -113,11 +113,6 @@ func (u *UserInterface) toGLFWPixel(x float64) float64 {
 	return x * u.deviceScaleFactor()
 }
 
-// toFramebufferPixel must be called from the main thread.
-func (u *UserInterface) toFramebufferPixel(x float64) float64 {
-	return x
-}
-
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	mx, my := currentMonitor(u.window).GetPos()
 	// As the video width/height might be wrong,

--- a/internal/uidriver/glfw/ui_windows.go
+++ b/internal/uidriver/glfw/ui_windows.go
@@ -98,11 +98,6 @@ func getMonitorInfoW(hMonitor uintptr, lpmi *monitorInfo) error {
 	return nil
 }
 
-// fromGLFWMonitorPixel must be called from the main thread.
-func (u *UserInterface) fromGLFWMonitorPixel(x float64, screenScale float64) float64 {
-	return x / (screenScale * u.deviceScaleFactor())
-}
-
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	mx, my := currentMonitor(u.window).GetPos()
 	// As the video width/height might be wrong,

--- a/internal/uidriver/glfw/ui_windows.go
+++ b/internal/uidriver/glfw/ui_windows.go
@@ -99,8 +99,8 @@ func getMonitorInfoW(hMonitor uintptr, lpmi *monitorInfo) error {
 }
 
 // fromGLFWMonitorPixel must be called from the main thread.
-func fromGLFWMonitorPixel(x float64, deviceScale float64) float64 {
-	return x / deviceScale
+func (u *UserInterface) fromGLFWMonitorPixel(x float64, screenScale float64) float64 {
+	return x / (screenScale * u.deviceScaleFactor())
 }
 
 // fromGLFWPixel must be called from the main thread.

--- a/internal/uidriver/glfw/ui_windows.go
+++ b/internal/uidriver/glfw/ui_windows.go
@@ -103,16 +103,6 @@ func (u *UserInterface) fromGLFWMonitorPixel(x float64, screenScale float64) flo
 	return x / (screenScale * u.deviceScaleFactor())
 }
 
-// fromGLFWPixel must be called from the main thread.
-func (u *UserInterface) fromGLFWPixel(x float64) float64 {
-	return x / u.deviceScaleFactor()
-}
-
-// toGLFWPixel must be called from the main thread.
-func (u *UserInterface) toGLFWPixel(x float64) float64 {
-	return x * u.deviceScaleFactor()
-}
-
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	mx, my := currentMonitor(u.window).GetPos()
 	// As the video width/height might be wrong,

--- a/internal/uidriver/glfw/ui_windows.go
+++ b/internal/uidriver/glfw/ui_windows.go
@@ -98,6 +98,21 @@ func getMonitorInfoW(hMonitor uintptr, lpmi *monitorInfo) error {
 	return nil
 }
 
+// fromGLFWMonitorPixel must be called from the main thread.
+func (u *UserInterface) fromGLFWMonitorPixel(x float64, videoModeScale float64) float64 {
+	return x / (videoModeScale * u.deviceScaleFactor())
+}
+
+// fromGLFWPixel must be called from the main thread.
+func (u *UserInterface) fromGLFWPixel(x float64) float64 {
+	return x / u.deviceScaleFactor()
+}
+
+// toGLFWPixel must be called from the main thread.
+func (u *UserInterface) toGLFWPixel(x float64) float64 {
+	return x * u.deviceScaleFactor()
+}
+
 func (u *UserInterface) adjustWindowPosition(x, y int) (int, int) {
 	mx, my := currentMonitor(u.window).GetPos()
 	// As the video width/height might be wrong,


### PR DESCRIPTION
Fully fixes wrong dpi handling on X11 (#1774).

We now have two scale factors:

- Device scale: what GLFW calls content scale; maps window system device dependent pixels (as used for window sizes, mouse positions, frame buffers etc.) to device independent pixels (96dpi standard size).
- Screen scale: maps GLFW screen resolutions to window system device dependent pixels. Only actually is different from one on X11.

This also allows for unifying the OS dependent GLFW pixel scale conversion functions into OS independent ones in a single place.

TEST FOCUSES (will do my own round of it as well using a "weird" setup where both scales and their product aren't one):
- OS X - I am unsure about the new implementation there given the old one was very different and had a screen scale of 1. I strongly suspect it is the old one that was wrong, but if not, backing out 1a048cc will fix it.
- General - in examples/windowsize, verify that "Screen size in fullscreen" is the correct size in device _independent_ pixels (i.e. changes when changing display dpi, and at 96dpi it should be equal to the actual framebuffer resolution).
- General - in examples/windowsize, verify the initial window size is 480x360 window system pixels in device _independent_ pixels (i.e. scaled by display dpi).
- General - examples/fullscreen should always have the rotating thing in the center
- General - examples/paint should have cursor position match up with what it draws