### PR TITLE
Issue 1824 - Remove dot imports from tests - Remove dot imports

### DIFF
--- a/audio/audio_test.go
+++ b/audio/audio_test.go
@@ -20,17 +20,17 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/hajimehoshi/ebiten/v2/audio"
+	"github.com/hajimehoshi/ebiten/v2/audio"
 )
 
-var context *Context
+var context *audio.Context
 
 func setup() {
-	context = NewContext(44100)
+	context = audio.NewContext(44100)
 }
 
 func teardown() {
-	ResetContextForTesting()
+	audio.ResetContextForTesting()
 	context = nil
 }
 
@@ -39,14 +39,14 @@ func TestGC(t *testing.T) {
 	setup()
 	defer teardown()
 
-	p, _ := NewPlayer(context, bytes.NewReader(make([]byte, 4)))
-	got := PlayersNumForTesting()
+	p, _ := audio.NewPlayer(context, bytes.NewReader(make([]byte, 4)))
+	got := audio.PlayersNumForTesting()
 	if want := 0; got != want {
 		t.Errorf("PlayersNum(): got: %d, want: %d", got, want)
 	}
 
 	p.Play()
-	got = PlayersNumForTesting()
+	got = audio.PlayersNumForTesting()
 	if want := 1; got != want {
 		t.Errorf("PlayersNum() after Play: got: %d, want: %d", got, want)
 	}
@@ -56,11 +56,11 @@ func TestGC(t *testing.T) {
 	runtime.GC()
 
 	for i := 0; i < 10; i++ {
-		got = PlayersNumForTesting()
+		got = audio.PlayersNumForTesting()
 		if want := 0; got == want {
 			return
 		}
-		if err := UpdateForTesting(); err != nil {
+		if err := audio.UpdateForTesting(); err != nil {
 			t.Error(err)
 		}
 		// 200[ms] should be enough all the bytes are consumed.
@@ -76,24 +76,24 @@ func TestSameSourcePlayers(t *testing.T) {
 	defer teardown()
 
 	src := bytes.NewReader(make([]byte, 4))
-	p0, err := NewPlayer(context, src)
+	p0, err := audio.NewPlayer(context, src)
 	if err != nil {
 		t.Fatal(err)
 	}
-	p1, err := NewPlayer(context, src)
+	p1, err := audio.NewPlayer(context, src)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// As the player does not play yet, error doesn't happen.
-	if err := UpdateForTesting(); err != nil {
+	if err := audio.UpdateForTesting(); err != nil {
 		t.Error(err)
 	}
 
 	p0.Play()
 	p1.Play()
 
-	if err := UpdateForTesting(); err == nil {
+	if err := audio.UpdateForTesting(); err == nil {
 		t.Errorf("got: nil, want: an error")
 	}
 }
@@ -103,7 +103,7 @@ func TestPauseBeforeInit(t *testing.T) {
 	defer teardown()
 
 	src := bytes.NewReader(make([]byte, 4))
-	p, err := NewPlayer(context, src)
+	p, err := audio.NewPlayer(context, src)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestPauseBeforeInit(t *testing.T) {
 	p.Pause()
 	p.Play()
 
-	if err := UpdateForTesting(); err != nil {
+	if err := audio.UpdateForTesting(); err != nil {
 		t.Error(err)
 	}
 }

--- a/audio/internal/convert/float32_test.go
+++ b/audio/internal/convert/float32_test.go
@@ -20,7 +20,7 @@ import (
 	"math"
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2/audio/internal/convert"
+	"github.com/hajimehoshi/ebiten/v2/audio/internal/convert"
 )
 
 type f32reader struct {
@@ -37,7 +37,7 @@ func (f *f32reader) Read(buf []float32) (int, error) {
 	return n, nil
 }
 
-func newFloat32Reader(data []float32) Float32Reader {
+func newFloat32Reader(data []float32) convert.Float32Reader {
 	return &f32reader{data: data}
 }
 
@@ -82,7 +82,7 @@ func TestFloat32Reader(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		r := NewReaderFromFloat32Reader(newFloat32Reader(c.In))
+		r := convert.NewReaderFromFloat32Reader(newFloat32Reader(c.In))
 
 		got := []byte{}
 		for {

--- a/audio/internal/convert/resampling_test.go
+++ b/audio/internal/convert/resampling_test.go
@@ -20,7 +20,7 @@ import (
 	"math"
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2/audio/internal/convert"
+	"github.com/hajimehoshi/ebiten/v2/audio/internal/convert"
 )
 
 func soundAt(timeInSecond float64) float64 {
@@ -69,7 +69,7 @@ func TestResampling(t *testing.T) {
 	}
 	for _, c := range cases {
 		inB := newSoundBytes(c.In)
-		outS := NewResampling(bytes.NewReader(inB), int64(len(inB)), c.In, c.Out)
+		outS := convert.NewResampling(bytes.NewReader(inB), int64(len(inB)), c.In, c.Out)
 		gotB, err := ioutil.ReadAll(outS)
 		if err != nil {
 			t.Fatal(err)

--- a/audio/loop_test.go
+++ b/audio/loop_test.go
@@ -20,7 +20,7 @@ import (
 	"math"
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2/audio"
+	"github.com/hajimehoshi/ebiten/v2/audio"
 )
 
 func TestInfiniteLoop(t *testing.T) {
@@ -32,7 +32,7 @@ func TestInfiniteLoop(t *testing.T) {
 	for i := range src {
 		src[i] = indexToByte(i)
 	}
-	l := NewInfiniteLoop(bytes.NewReader(src), int64(len(src)))
+	l := audio.NewInfiniteLoop(bytes.NewReader(src), int64(len(src)))
 
 	buf := make([]byte, len(src)*4)
 	if _, err := io.ReadFull(l, buf); err != nil {
@@ -94,8 +94,8 @@ func TestInfiniteLoopWithIntro(t *testing.T) {
 	for i := range src {
 		src[i] = indexToByte(i)
 	}
-	srcInf := NewInfiniteLoop(bytes.NewReader(src), srcLength)
-	l := NewInfiniteLoopWithIntro(srcInf, introLength, loopLength)
+	srcInf := audio.NewInfiniteLoop(bytes.NewReader(src), srcLength)
+	l := audio.NewInfiniteLoopWithIntro(srcInf, introLength, loopLength)
 
 	buf := make([]byte, srcLength*4)
 	if _, err := io.ReadFull(l, buf); err != nil {
@@ -151,7 +151,7 @@ func TestInfiniteLoopWithIntro(t *testing.T) {
 
 func TestInfiniteLoopWithIncompleteSize(t *testing.T) {
 	// s1 should work as if 4092 is given.
-	s1 := NewInfiniteLoop(bytes.NewReader(make([]byte, 4096)), 4095)
+	s1 := audio.NewInfiniteLoop(bytes.NewReader(make([]byte, 4096)), 4095)
 	n1, err := s1.Seek(4093, io.SeekStart)
 	if err != nil {
 		t.Error(err)
@@ -161,7 +161,7 @@ func TestInfiniteLoopWithIncompleteSize(t *testing.T) {
 	}
 
 	// s2 should work as if 2044 and 2044 are given.
-	s2 := NewInfiniteLoopWithIntro(bytes.NewReader(make([]byte, 4096)), 2047, 2046)
+	s2 := audio.NewInfiniteLoopWithIntro(bytes.NewReader(make([]byte, 4096)), 2047, 2046)
 	n2, err := s2.Seek(4093, io.SeekStart)
 	if err != nil {
 		t.Error(err)

--- a/audio/vorbis/vorbis_test.go
+++ b/audio/vorbis/vorbis_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/jfreymuth/oggvorbis"
 
 	"github.com/hajimehoshi/ebiten/v2/audio"
-	. "github.com/hajimehoshi/ebiten/v2/audio/vorbis"
+	"github.com/hajimehoshi/ebiten/v2/audio/vorbis"
 )
 
 var audioContext = audio.NewContext(44100)
@@ -29,7 +29,7 @@ var audioContext = audio.NewContext(44100)
 func TestMono(t *testing.T) {
 	bs := test_mono_ogg
 
-	s, err := DecodeWithSampleRate(audioContext.SampleRate(), bytes.NewReader(bs))
+	s, err := vorbis.DecodeWithSampleRate(audioContext.SampleRate(), bytes.NewReader(bs))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestMono(t *testing.T) {
 func TestTooShort(t *testing.T) {
 	bs := test_tooshort_ogg
 
-	s, err := DecodeWithSampleRate(audioContext.SampleRate(), bytes.NewReader(bs))
+	s, err := vorbis.DecodeWithSampleRate(audioContext.SampleRate(), bytes.NewReader(bs))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/colorm_test.go
+++ b/colorm_test.go
@@ -19,13 +19,13 @@ import (
 	"math"
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2"
 )
 
 func TestColorMInit(t *testing.T) {
-	var m ColorM
-	for i := 0; i < ColorMDim-1; i++ {
-		for j := 0; j < ColorMDim; j++ {
+	var m ebiten.ColorM
+	for i := 0; i < ebiten.ColorMDim-1; i++ {
+		for j := 0; j < ebiten.ColorMDim; j++ {
 			got := m.Element(i, j)
 			want := 0.0
 			if i == j {
@@ -38,8 +38,8 @@ func TestColorMInit(t *testing.T) {
 	}
 
 	m.SetElement(0, 0, 1)
-	for i := 0; i < ColorMDim-1; i++ {
-		for j := 0; j < ColorMDim; j++ {
+	for i := 0; i < ebiten.ColorMDim-1; i++ {
+		for j := 0; j < ebiten.ColorMDim; j++ {
 			got := m.Element(i, j)
 			want := 0.0
 			if i == j {
@@ -53,7 +53,7 @@ func TestColorMInit(t *testing.T) {
 }
 
 func TestColorMAssign(t *testing.T) {
-	m := ColorM{}
+	m := ebiten.ColorM{}
 	m.SetElement(0, 0, 1)
 	m2 := m
 	m.SetElement(0, 0, 0)
@@ -71,7 +71,7 @@ func TestColorMTranslate(t *testing.T) {
 		{0, 0, 1, 0, 2.5},
 		{0, 0, 0, 1, 3.5},
 	}
-	m := ColorM{}
+	m := ebiten.ColorM{}
 	m.Translate(0.5, 1.5, 2.5, 3.5)
 	for i := 0; i < 4; i++ {
 		for j := 0; j < 5; j++ {
@@ -91,7 +91,7 @@ func TestColorMScale(t *testing.T) {
 		{0, 0, 2.5, 0, 0},
 		{0, 0, 0, 3.5, 0},
 	}
-	m := ColorM{}
+	m := ebiten.ColorM{}
 	m.Scale(0.5, 1.5, 2.5, 3.5)
 	for i := 0; i < 4; i++ {
 		for j := 0; j < 5; j++ {
@@ -111,7 +111,7 @@ func TestColorMTranslateAndScale(t *testing.T) {
 		{0, 0, 1, 0, 0},
 		{0, 0, 0, 0.5, 0.5},
 	}
-	m := ColorM{}
+	m := ebiten.ColorM{}
 	m.Translate(0, 0, 0, 1)
 	m.Scale(1, 1, 1, 0.5)
 	for i := 0; i < 4; i++ {
@@ -132,7 +132,7 @@ func TestColorMMonochrome(t *testing.T) {
 		{0.2990, 0.5870, 0.1140, 0, 0},
 		{0, 0, 0, 1, 0},
 	}
-	m := ColorM{}
+	m := ebiten.ColorM{}
 	m.ChangeHSV(0, 0, 1)
 	for i := 0; i < 4; i++ {
 		for j := 0; j < 5; j++ {
@@ -152,7 +152,7 @@ func TestColorMConcatSelf(t *testing.T) {
 		{30, 43, 51, 39, 34},
 		{25, 37, 39, 46, 36},
 	}
-	m := ColorM{}
+	m := ebiten.ColorM{}
 	for i := 0; i < 4; i++ {
 		for j := 0; j < 5; j++ {
 			m.SetElement(i, j, float64((i+j)%5+1))
@@ -178,23 +178,23 @@ func absDiffU32(x, y uint32) uint32 {
 }
 
 func TestColorMApply(t *testing.T) {
-	mono := ColorM{}
+	mono := ebiten.ColorM{}
 	mono.ChangeHSV(0, 0, 1)
 
-	shiny := ColorM{}
+	shiny := ebiten.ColorM{}
 	shiny.Translate(1, 1, 1, 0)
 
-	shift := ColorM{}
+	shift := ebiten.ColorM{}
 	shift.Translate(0.5, 0.5, 0.5, 0.5)
 
 	cases := []struct {
-		ColorM ColorM
+		ColorM ebiten.ColorM
 		In     color.Color
 		Out    color.Color
 		Delta  uint32
 	}{
 		{
-			ColorM: ColorM{},
+			ColorM: ebiten.ColorM{},
 			In:     color.RGBA{1, 2, 3, 4},
 			Out:    color.RGBA{1, 2, 3, 4},
 			Delta:  0x101,
@@ -237,7 +237,7 @@ func TestColorMApply(t *testing.T) {
 
 // #1765
 func TestColorMConcat(t *testing.T) {
-	var a, b ColorM
+	var a, b ebiten.ColorM
 	a.SetElement(1, 2, -1)
 	a.Concat(b)
 	if got, want := a.Element(1, 2), -1.0; got != want {

--- a/examples/2048/2048/tile_test.go
+++ b/examples/2048/2048/tile_test.go
@@ -15,7 +15,7 @@
 package twenty48_test
 
 import (
-	twenty48 "github.com/hajimehoshi/ebiten/v2/examples/2048/2048"
+	"github.com/hajimehoshi/ebiten/v2/examples/2048/2048"
 
 	"fmt"
 	"testing"

--- a/examples/2048/2048/tile_test.go
+++ b/examples/2048/2048/tile_test.go
@@ -15,28 +15,28 @@
 package twenty48_test
 
 import (
-	example2048 "github.com/hajimehoshi/ebiten/v2/examples/2048/2048"
+	twenty48 "github.com/hajimehoshi/ebiten/v2/examples/2048/2048"
 
 	"fmt"
 	"testing"
 )
 
-func cellsToTiles(cells []int, size int) map[*example2048.Tile]struct{} {
-	tiles := map[*example2048.Tile]struct{}{}
+func cellsToTiles(cells []int, size int) map[*twenty48.Tile]struct{} {
+	tiles := map[*twenty48.Tile]struct{}{}
 	for j := 0; j < size; j++ {
 		for i := 0; i < size; i++ {
 			c := cells[i+j*size]
 			if c == 0 {
 				continue
 			}
-			t := example2048.NewTile(c, i, j)
+			t := twenty48.NewTile(c, i, j)
 			tiles[t] = struct{}{}
 		}
 	}
 	return tiles
 }
 
-func tilesToCells(tiles map[*example2048.Tile]struct{}, size int) ([]int, []int) {
+func tilesToCells(tiles map[*twenty48.Tile]struct{}, size int) ([]int, []int) {
 	cells := make([]int, size*size)
 	nextCells := make([]int, size*size)
 	for t := range tiles {
@@ -58,12 +58,12 @@ func tilesToCells(tiles map[*example2048.Tile]struct{}, size int) ([]int, []int)
 func TestMoveTiles(t *testing.T) {
 	const size = 4
 	testCases := []struct {
-		Dir   example2048.Dir
+		Dir   twenty48.Dir
 		Input []int
 		Want  []int
 	}{
 		{
-			Dir: example2048.DirUp,
+			Dir: twenty48.DirUp,
 			Input: []int{
 				0, 0, 0, 0,
 				0, 0, 0, 0,
@@ -78,7 +78,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: example2048.DirRight,
+			Dir: twenty48.DirRight,
 			Input: []int{
 				2, 0, 0, 0,
 				0, 2, 0, 0,
@@ -93,7 +93,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: example2048.DirUp,
+			Dir: twenty48.DirUp,
 			Input: []int{
 				2, 0, 0, 0,
 				0, 2, 0, 0,
@@ -108,7 +108,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: example2048.DirLeft,
+			Dir: twenty48.DirLeft,
 			Input: []int{
 				0, 2, 2, 2,
 				0, 0, 0, 0,
@@ -123,7 +123,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: example2048.DirRight,
+			Dir: twenty48.DirRight,
 			Input: []int{
 				0, 0, 0, 2,
 				0, 0, 2, 2,
@@ -138,7 +138,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: example2048.DirLeft,
+			Dir: twenty48.DirLeft,
 			Input: []int{
 				0, 0, 0, 2,
 				0, 0, 2, 2,
@@ -153,7 +153,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: example2048.DirRight,
+			Dir: twenty48.DirRight,
 			Input: []int{
 				4, 8, 8, 4,
 				8, 8, 4, 4,
@@ -168,7 +168,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: example2048.DirDown,
+			Dir: twenty48.DirDown,
 			Input: []int{
 				4, 8, 8, 4,
 				8, 8, 4, 4,
@@ -183,7 +183,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: example2048.DirLeft,
+			Dir: twenty48.DirLeft,
 			Input: []int{
 				4, 8, 8, 4,
 				8, 8, 4, 4,
@@ -198,7 +198,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: example2048.DirUp,
+			Dir: twenty48.DirUp,
 			Input: []int{
 				4, 8, 8, 4,
 				8, 8, 4, 4,
@@ -213,7 +213,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: example2048.DirUp,
+			Dir: twenty48.DirUp,
 			Input: []int{
 				2, 4, 2, 4,
 				4, 2, 4, 2,
@@ -231,7 +231,7 @@ func TestMoveTiles(t *testing.T) {
 	for _, test := range testCases {
 		want, _ := tilesToCells(cellsToTiles(test.Want, size), size)
 		tiles := cellsToTiles(test.Input, size)
-		moved := example2048.MoveTiles(tiles, size, test.Dir)
+		moved := twenty48.MoveTiles(tiles, size, test.Dir)
 		input, got := tilesToCells(tiles, size)
 		if !moved {
 			got = input

--- a/examples/2048/2048/tile_test.go
+++ b/examples/2048/2048/tile_test.go
@@ -15,28 +15,28 @@
 package twenty48_test
 
 import (
-	. "github.com/hajimehoshi/ebiten/v2/examples/2048/2048"
+	example2048 "github.com/hajimehoshi/ebiten/v2/examples/2048/2048"
 
 	"fmt"
 	"testing"
 )
 
-func cellsToTiles(cells []int, size int) map[*Tile]struct{} {
-	tiles := map[*Tile]struct{}{}
+func cellsToTiles(cells []int, size int) map[*example2048.Tile]struct{} {
+	tiles := map[*example2048.Tile]struct{}{}
 	for j := 0; j < size; j++ {
 		for i := 0; i < size; i++ {
 			c := cells[i+j*size]
 			if c == 0 {
 				continue
 			}
-			t := NewTile(c, i, j)
+			t := example2048.NewTile(c, i, j)
 			tiles[t] = struct{}{}
 		}
 	}
 	return tiles
 }
 
-func tilesToCells(tiles map[*Tile]struct{}, size int) ([]int, []int) {
+func tilesToCells(tiles map[*example2048.Tile]struct{}, size int) ([]int, []int) {
 	cells := make([]int, size*size)
 	nextCells := make([]int, size*size)
 	for t := range tiles {
@@ -58,12 +58,12 @@ func tilesToCells(tiles map[*Tile]struct{}, size int) ([]int, []int) {
 func TestMoveTiles(t *testing.T) {
 	const size = 4
 	testCases := []struct {
-		Dir   Dir
+		Dir   example2048.Dir
 		Input []int
 		Want  []int
 	}{
 		{
-			Dir: DirUp,
+			Dir: example2048.DirUp,
 			Input: []int{
 				0, 0, 0, 0,
 				0, 0, 0, 0,
@@ -78,7 +78,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: DirRight,
+			Dir: example2048.DirRight,
 			Input: []int{
 				2, 0, 0, 0,
 				0, 2, 0, 0,
@@ -93,7 +93,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: DirUp,
+			Dir: example2048.DirUp,
 			Input: []int{
 				2, 0, 0, 0,
 				0, 2, 0, 0,
@@ -108,7 +108,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: DirLeft,
+			Dir: example2048.DirLeft,
 			Input: []int{
 				0, 2, 2, 2,
 				0, 0, 0, 0,
@@ -123,7 +123,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: DirRight,
+			Dir: example2048.DirRight,
 			Input: []int{
 				0, 0, 0, 2,
 				0, 0, 2, 2,
@@ -138,7 +138,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: DirLeft,
+			Dir: example2048.DirLeft,
 			Input: []int{
 				0, 0, 0, 2,
 				0, 0, 2, 2,
@@ -153,7 +153,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: DirRight,
+			Dir: example2048.DirRight,
 			Input: []int{
 				4, 8, 8, 4,
 				8, 8, 4, 4,
@@ -168,7 +168,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: DirDown,
+			Dir: example2048.DirDown,
 			Input: []int{
 				4, 8, 8, 4,
 				8, 8, 4, 4,
@@ -183,7 +183,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: DirLeft,
+			Dir: example2048.DirLeft,
 			Input: []int{
 				4, 8, 8, 4,
 				8, 8, 4, 4,
@@ -198,7 +198,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: DirUp,
+			Dir: example2048.DirUp,
 			Input: []int{
 				4, 8, 8, 4,
 				8, 8, 4, 4,
@@ -213,7 +213,7 @@ func TestMoveTiles(t *testing.T) {
 			},
 		},
 		{
-			Dir: DirUp,
+			Dir: example2048.DirUp,
 			Input: []int{
 				2, 4, 2, 4,
 				4, 2, 4, 2,
@@ -231,7 +231,7 @@ func TestMoveTiles(t *testing.T) {
 	for _, test := range testCases {
 		want, _ := tilesToCells(cellsToTiles(test.Want, size), size)
 		tiles := cellsToTiles(test.Input, size)
-		moved := MoveTiles(tiles, size, test.Dir)
+		moved := example2048.MoveTiles(tiles, size, test.Dir)
 		input, got := tilesToCells(tiles, size)
 		if !moved {
 			got = input

--- a/geom_test.go
+++ b/geom_test.go
@@ -19,13 +19,13 @@ import (
 	"math"
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2"
 )
 
 func TestGeoMInit(t *testing.T) {
-	var m GeoM
-	for i := 0; i < GeoMDim-1; i++ {
-		for j := 0; j < GeoMDim; j++ {
+	var m ebiten.GeoM
+	for i := 0; i < ebiten.GeoMDim-1; i++ {
+		for j := 0; j < ebiten.GeoMDim; j++ {
 			got := m.Element(i, j)
 			want := 0.0
 			if i == j {
@@ -39,7 +39,7 @@ func TestGeoMInit(t *testing.T) {
 }
 
 func TestGeoMAssign(t *testing.T) {
-	m := GeoM{}
+	m := ebiten.GeoM{}
 	m.SetElement(0, 0, 1)
 	m2 := m
 	m.SetElement(0, 0, 0)
@@ -51,9 +51,9 @@ func TestGeoMAssign(t *testing.T) {
 }
 
 func TestGeoMConcat(t *testing.T) {
-	matrix1 := GeoM{}
+	matrix1 := ebiten.GeoM{}
 	matrix1.Scale(2, 2)
-	matrix2 := GeoM{}
+	matrix2 := ebiten.GeoM{}
 	matrix2.Translate(1, 1)
 
 	matrix3 := matrix1
@@ -93,7 +93,7 @@ func TestGeoMConcat(t *testing.T) {
 }
 
 func TestGeoMConcatSelf(t *testing.T) {
-	m := GeoM{}
+	m := ebiten.GeoM{}
 	m.SetElement(0, 0, 1)
 	m.SetElement(0, 1, 2)
 	m.SetElement(0, 2, 3)
@@ -117,7 +117,7 @@ func TestGeoMConcatSelf(t *testing.T) {
 	}
 }
 
-func geoMToString(g GeoM) string {
+func geoMToString(g ebiten.GeoM) string {
 	a := g.Element(0, 0)
 	b := g.Element(0, 1)
 	c := g.Element(1, 0)
@@ -128,26 +128,26 @@ func geoMToString(g GeoM) string {
 }
 
 func TestGeoMApply(t *testing.T) {
-	trans := GeoM{}
+	trans := ebiten.GeoM{}
 	trans.Translate(1, 2)
 
-	scale := GeoM{}
+	scale := ebiten.GeoM{}
 	scale.Scale(1.5, 2.5)
 
-	cpx := GeoM{}
+	cpx := ebiten.GeoM{}
 	cpx.Rotate(math.Pi)
 	cpx.Scale(1.5, 2.5)
 	cpx.Translate(-2, -3)
 
 	cases := []struct {
-		GeoM GeoM
+		GeoM ebiten.GeoM
 		InX  float64
 		InY  float64
 		OutX float64
 		OutY float64
 	}{
 		{
-			GeoM: GeoM{},
+			GeoM: ebiten.GeoM{},
 			InX:  3.14159,
 			InY:  2.81828,
 			OutX: 3.14159,
@@ -187,30 +187,30 @@ func TestGeoMApply(t *testing.T) {
 }
 
 func TestGeoMIsInvert(t *testing.T) {
-	zero := GeoM{}
+	zero := ebiten.GeoM{}
 	zero.Scale(0, 0)
 
-	trans := GeoM{}
+	trans := ebiten.GeoM{}
 	trans.Translate(1, 2)
 
-	scale := GeoM{}
+	scale := ebiten.GeoM{}
 	scale.Scale(1.5, 2.5)
 
-	cpx := GeoM{}
+	cpx := ebiten.GeoM{}
 	cpx.Rotate(math.Pi)
 	cpx.Scale(1.5, 2.5)
 	cpx.Translate(-2, -3)
 
-	cpx2 := GeoM{}
+	cpx2 := ebiten.GeoM{}
 	cpx2.Scale(2, 3)
 	cpx2.Rotate(0.234)
 	cpx2.Translate(100, 100)
 
-	skew := GeoM{}
+	skew := ebiten.GeoM{}
 	skew.Skew(1, 1)
 
 	cases := []struct {
-		GeoM       GeoM
+		GeoM       ebiten.GeoM
 		Invertible bool
 	}{
 		{
@@ -218,7 +218,7 @@ func TestGeoMIsInvert(t *testing.T) {
 			Invertible: false,
 		},
 		{
-			GeoM:       GeoM{},
+			GeoM:       ebiten.GeoM{},
 			Invertible: true,
 		},
 		{
@@ -286,8 +286,8 @@ func TestGeoMIsInvert(t *testing.T) {
 	}
 }
 
-func newGeoM(a, b, c, d, tx, ty float64) GeoM {
-	outp := GeoM{}
+func newGeoM(a, b, c, d, tx, ty float64) ebiten.GeoM {
+	outp := ebiten.GeoM{}
 	outp.SetElement(0, 0, a)
 	outp.SetElement(0, 1, b)
 	outp.SetElement(0, 2, tx)
@@ -298,7 +298,7 @@ func newGeoM(a, b, c, d, tx, ty float64) GeoM {
 }
 
 func TestGeomSkew(t *testing.T) {
-	testSkew := func(skewX, skewY float64, input, expected GeoM) {
+	testSkew := func(skewX, skewY float64, input, expected ebiten.GeoM) {
 		input.Skew(skewX, skewY)
 		for i := 0; i < 2; i++ {
 			for j := 0; j < 3; j++ {
@@ -313,15 +313,15 @@ func TestGeomSkew(t *testing.T) {
 	}
 	// skewX = 0.25
 	expectedX := newGeoM(1, math.Tan(0.25), math.Tan(0), 1, 0, 0)
-	testSkew(0.25, 0, GeoM{}, expectedX)
+	testSkew(0.25, 0, ebiten.GeoM{}, expectedX)
 
 	// skewY = 0.25
 	expectedY := newGeoM(1, math.Tan(0), math.Tan(0.5), 1, 0, 0)
-	testSkew(0, 0.5, GeoM{}, expectedY)
+	testSkew(0, 0.5, ebiten.GeoM{}, expectedY)
 
 	// skewX, skewY = 0.3, 0.8
 	expectedXY := newGeoM(1, math.Tan(0.3), math.Tan(0.8), 1, 0, 0)
-	testSkew(0.3, 0.8, GeoM{}, expectedXY)
+	testSkew(0.3, 0.8, ebiten.GeoM{}, expectedXY)
 
 	// skewX, skewY = 0.4, -1.8 ; b, c = 2, 3
 	expectedOffDiag := newGeoM(1+3*math.Tan(0.4), 2+math.Tan(0.4), 3+math.Tan(-1.8), 1+2*math.Tan(-1.8), 0, 0)
@@ -336,13 +336,13 @@ func TestGeomSkew(t *testing.T) {
 
 func TestGeoMEquals(t *testing.T) {
 	tests := []struct {
-		a    GeoM
-		b    GeoM
+		a    ebiten.GeoM
+		b    ebiten.GeoM
 		want bool
 	}{
 		{
-			a:    GeoM{},
-			b:    GeoM{},
+			a:    ebiten.GeoM{},
+			b:    ebiten.GeoM{},
 			want: true,
 		},
 		{
@@ -366,9 +366,9 @@ func TestGeoMEquals(t *testing.T) {
 }
 
 func BenchmarkGeoM(b *testing.B) {
-	var m GeoM
+	var m ebiten.GeoM
 	for i := 0; i < b.N; i++ {
-		m = GeoM{}
+		m = ebiten.GeoM{}
 		m.Translate(10, 20)
 		m.Scale(2, 3)
 		m.Rotate(math.Pi / 2)

--- a/image_test.go
+++ b/image_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/examples/resources/images"
 	"github.com/hajimehoshi/ebiten/v2/internal/graphics"
 	t "github.com/hajimehoshi/ebiten/v2/internal/testing"
@@ -53,17 +53,17 @@ func skipTooSlowTests(t *testing.T) bool {
 }
 
 func TestMain(m *testing.M) {
-	PanicOnErrorAtImageAt()
+	ebiten.PanicOnErrorAtImageAt()
 	t.MainWithRunLoop(m)
 }
 
-func openEbitenImage() (*Image, image.Image, error) {
+func openEbitenImage() (*ebiten.Image, image.Image, error) {
 	img, _, err := image.Decode(bytes.NewReader(images.Ebiten_png))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	eimg := NewImageFromImage(img)
+	eimg := ebiten.NewImageFromImage(img)
 	return eimg, img, nil
 }
 
@@ -124,19 +124,19 @@ func TestImageComposition(t *testing.T) {
 
 	w, h := img1.Bounds().Size().X, img1.Bounds().Size().Y
 
-	img2 := NewImage(w, h)
-	img3 := NewImage(w, h)
+	img2 := ebiten.NewImage(w, h)
+	img3 := ebiten.NewImage(w, h)
 
 	img2.Fill(img2Color)
 	img3.Fill(img3Color)
-	img_12_3 := NewImage(w, h)
+	img_12_3 := ebiten.NewImage(w, h)
 	img2.DrawImage(img1, nil)
 	img3.DrawImage(img2, nil)
 	img_12_3.DrawImage(img3, nil)
 
 	img2.Fill(img2Color)
 	img3.Fill(img3Color)
-	img_1_23 := NewImage(w, h)
+	img_1_23 := ebiten.NewImage(w, h)
 	img3.DrawImage(img2, nil)
 	img3.DrawImage(img1, nil)
 	img_1_23.DrawImage(img3, nil)
@@ -181,8 +181,8 @@ func TestImageScale(t *testing.T) {
 			return
 		}
 		w, h := img0.Size()
-		img1 := NewImage(w*scale, h*scale)
-		op := &DrawImageOptions{}
+		img1 := ebiten.NewImage(w*scale, h*scale)
+		op := &ebiten.DrawImageOptions{}
 		op.GeoM.Scale(float64(scale), float64(scale))
 
 		img1.DrawImage(img0, op)
@@ -206,8 +206,8 @@ func TestImage90DegreeRotate(t *testing.T) {
 		return
 	}
 	w, h := img0.Size()
-	img1 := NewImage(h, w)
-	op := &DrawImageOptions{}
+	img1 := ebiten.NewImage(h, w)
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Rotate(math.Pi / 2)
 	op.GeoM.Translate(float64(h), 0)
 	img1.DrawImage(img0, op)
@@ -230,8 +230,8 @@ func TestImageDotByDotInversion(t *testing.T) {
 		return
 	}
 	w, h := img0.Size()
-	img1 := NewImage(w, h)
-	op := &DrawImageOptions{}
+	img1 := ebiten.NewImage(w, h)
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Rotate(math.Pi)
 	op.GeoM.Translate(float64(w), float64(h))
 	img1.DrawImage(img0, op)
@@ -249,7 +249,7 @@ func TestImageDotByDotInversion(t *testing.T) {
 
 func TestImageReplacePixels(t *testing.T) {
 	// Create a dummy image so that the shared texture is used and origImg's position is shfited.
-	dummyImg := NewImageFromImage(image.NewRGBA(image.Rect(0, 0, 16, 16)))
+	dummyImg := ebiten.NewImageFromImage(image.NewRGBA(image.Rect(0, 0, 16, 16)))
 	defer dummyImg.Dispose()
 
 	_, origImg, err := openEbitenImage()
@@ -262,7 +262,7 @@ func TestImageReplacePixels(t *testing.T) {
 	draw.Draw(img, img.Bounds(), origImg, image.ZP, draw.Src)
 
 	size := img.Bounds().Size()
-	img0 := NewImage(size.X, size.Y)
+	img0 := ebiten.NewImage(size.X, size.Y)
 
 	img0.ReplacePixels(img.Pix)
 	for j := 0; j < img0.Bounds().Size().Y; j++ {
@@ -302,13 +302,13 @@ func TestImageReplacePixelsNil(t *testing.T) {
 		}
 	}()
 
-	img := NewImage(16, 16)
+	img := ebiten.NewImage(16, 16)
 	img.Fill(color.White)
 	img.ReplacePixels(nil)
 }
 
 func TestImageDispose(t *testing.T) {
-	img := NewImage(16, 16)
+	img := ebiten.NewImage(16, 16)
 	img.Fill(color.White)
 	img.Dispose()
 
@@ -336,10 +336,10 @@ func TestImageCompositeModeLighter(t *testing.T) {
 	}
 
 	w, h := img0.Size()
-	img1 := NewImage(w, h)
+	img1 := ebiten.NewImage(w, h)
 	img1.Fill(color.RGBA{0x01, 0x02, 0x03, 0x04})
-	op := &DrawImageOptions{}
-	op.CompositeMode = CompositeModeLighter
+	op := &ebiten.DrawImageOptions{}
+	op.CompositeMode = ebiten.CompositeModeLighter
 	img1.DrawImage(img0, op)
 	for j := 0; j < img1.Bounds().Size().Y; j++ {
 		for i := 0; i < img1.Bounds().Size().X; i++ {
@@ -362,7 +362,7 @@ func TestNewImageFromEbitenImage(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
-	_ = NewImageFromImage(img)
+	_ = ebiten.NewImageFromImage(img)
 }
 
 func TestNewImageFromSubImage(t *testing.T) {
@@ -373,7 +373,7 @@ func TestNewImageFromSubImage(t *testing.T) {
 	}
 	w, h := img.Bounds().Dx(), img.Bounds().Dy()
 	subImg := img.(*image.NRGBA).SubImage(image.Rect(1, 1, w-1, h-1))
-	eimg := NewImageFromImage(subImg)
+	eimg := ebiten.NewImageFromImage(subImg)
 	sw, sh := subImg.Bounds().Dx(), subImg.Bounds().Dy()
 	w2, h2 := eimg.Size()
 	if w2 != sw {
@@ -403,7 +403,7 @@ func (c *mutableRGBA) RGBA() (r, g, b, a uint32) {
 
 func TestImageFill(t *testing.T) {
 	w, h := 10, 10
-	img := NewImage(w, h)
+	img := ebiten.NewImage(w, h)
 	clr := &mutableRGBA{0x80, 0x80, 0x80, 0x80}
 	img.Fill(clr)
 	clr.r = 0
@@ -421,7 +421,7 @@ func TestImageFill(t *testing.T) {
 // Issue #740
 func TestImageClear(t *testing.T) {
 	const w, h = 128, 256
-	img := NewImage(w, h)
+	img := ebiten.NewImage(w, h)
 	img.Fill(color.White)
 	for j := 0; j < h; j++ {
 		for i := 0; i < w; i++ {
@@ -461,7 +461,7 @@ func TestImageEdge(t *testing.T) {
 		img1Width  = 32
 		img1Height = 32
 	)
-	img0 := NewImage(img0Width, img0Height)
+	img0 := ebiten.NewImage(img0Width, img0Height)
 	pixels := make([]uint8, 4*img0Width*img0Height)
 	for j := 0; j < img0Height; j++ {
 		for i := 0; i < img0Width; i++ {
@@ -473,7 +473,7 @@ func TestImageEdge(t *testing.T) {
 		}
 	}
 	img0.ReplacePixels(pixels)
-	img1 := NewImage(img1Width, img1Height)
+	img1 := ebiten.NewImage(img1Width, img1Height)
 	red := color.RGBA{0xff, 0, 0, 0xff}
 	transparent := color.RGBA{0, 0, 0, 0}
 
@@ -487,29 +487,29 @@ func TestImageEdge(t *testing.T) {
 	}
 
 	for _, s := range []float64{1, 0.5, 0.25} {
-		for _, f := range []Filter{FilterNearest, FilterLinear} {
+		for _, f := range []ebiten.Filter{ebiten.FilterNearest, ebiten.FilterLinear} {
 			for _, a := range angles {
 				for _, testDrawTriangles := range []bool{false, true} {
 					img1.Clear()
 					w, h := img0.Size()
 					b := img0.Bounds()
-					var geo GeoM
+					var geo ebiten.GeoM
 					geo.Translate(-float64(w)/2, -float64(h)/2)
 					geo.Scale(s, s)
 					geo.Rotate(a)
 					geo.Translate(img1Width/2, img1Height/2)
 					if !testDrawTriangles {
-						op := &DrawImageOptions{}
+						op := &ebiten.DrawImageOptions{}
 						op.GeoM = geo
 						op.Filter = f
 						img1.DrawImage(img0, op)
 					} else {
-						op := &DrawTrianglesOptions{}
+						op := &ebiten.DrawTrianglesOptions{}
 						dx0, dy0 := geo.Apply(0, 0)
 						dx1, dy1 := geo.Apply(float64(w), 0)
 						dx2, dy2 := geo.Apply(0, float64(h))
 						dx3, dy3 := geo.Apply(float64(w), float64(h))
-						vs := []Vertex{
+						vs := []ebiten.Vertex{
 							{
 								DstX:   float32(dx0),
 								DstY:   float32(dy0),
@@ -564,11 +564,11 @@ func TestImageEdge(t *testing.T) {
 							}
 							allTransparent = false
 							switch f {
-							case FilterNearest:
+							case ebiten.FilterNearest:
 								if c == red {
 									continue
 								}
-							case FilterLinear:
+							case ebiten.FilterLinear:
 								if _, g, b, _ := c.RGBA(); g == 0 && b == 0 {
 									continue
 								}
@@ -593,12 +593,12 @@ func TestImageTooManyFill(t *testing.T) {
 		return uint8((17*index + 0x40) % 256)
 	}
 
-	src := NewImage(1, 1)
-	dst := NewImage(width, 1)
+	src := ebiten.NewImage(1, 1)
+	dst := ebiten.NewImage(width, 1)
 	for i := 0; i < width; i++ {
 		c := indexToColor(i)
 		src.Fill(color.RGBA{c, c, c, 0xff})
-		op := &DrawImageOptions{}
+		op := &ebiten.DrawImageOptions{}
 		op.GeoM.Translate(float64(i), 0)
 		dst.DrawImage(src, op)
 	}
@@ -614,16 +614,16 @@ func TestImageTooManyFill(t *testing.T) {
 }
 
 func BenchmarkDrawImage(b *testing.B) {
-	img0 := NewImage(16, 16)
-	img1 := NewImage(16, 16)
-	op := &DrawImageOptions{}
+	img0 := ebiten.NewImage(16, 16)
+	img1 := ebiten.NewImage(16, 16)
+	op := &ebiten.DrawImageOptions{}
 	for i := 0; i < b.N; i++ {
 		img0.DrawImage(img1, op)
 	}
 }
 
 func TestImageLinearGradiation(t *testing.T) {
-	img0 := NewImage(2, 2)
+	img0 := ebiten.NewImage(2, 2)
 	img0.ReplacePixels([]byte{
 		0xff, 0x00, 0x00, 0xff,
 		0x00, 0xff, 0x00, 0xff,
@@ -632,11 +632,11 @@ func TestImageLinearGradiation(t *testing.T) {
 	})
 
 	const w, h = 32, 32
-	img1 := NewImage(w, h)
-	op := &DrawImageOptions{}
+	img1 := ebiten.NewImage(w, h)
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(w, h)
 	op.GeoM.Translate(-w/4, -h/4)
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	img1.DrawImage(img0, op)
 
 	for j := 1; j < h-1; j++ {
@@ -650,8 +650,8 @@ func TestImageLinearGradiation(t *testing.T) {
 }
 
 func TestImageOutside(t *testing.T) {
-	src := NewImage(5, 10) // internal texture size is 8x16.
-	dst := NewImage(4, 4)
+	src := ebiten.NewImage(5, 10) // internal texture size is 8x16.
+	dst := ebiten.NewImage(4, 4)
 	src.Fill(color.RGBA{0xff, 0, 0, 0xff})
 
 	cases := []struct {
@@ -672,12 +672,12 @@ func TestImageOutside(t *testing.T) {
 	for _, c := range cases {
 		dst.Clear()
 
-		op := &DrawImageOptions{}
+		op := &ebiten.DrawImageOptions{}
 		op.GeoM.Translate(0, 0)
 		dst.DrawImage(src.SubImage(image.Rectangle{
 			Min: image.Pt(c.X, c.Y),
 			Max: image.Pt(c.X+c.Width, c.Y+c.Height),
-		}).(*Image), op)
+		}).(*ebiten.Image), op)
 
 		for j := 0; j < 4; j++ {
 			for i := 0; i < 4; i++ {
@@ -692,16 +692,16 @@ func TestImageOutside(t *testing.T) {
 }
 
 func TestImageOutsideUpperLeft(t *testing.T) {
-	src := NewImage(4, 4)
-	dst1 := NewImage(16, 16)
-	dst2 := NewImage(16, 16)
+	src := ebiten.NewImage(4, 4)
+	dst1 := ebiten.NewImage(16, 16)
+	dst2 := ebiten.NewImage(16, 16)
 	src.Fill(color.RGBA{0xff, 0, 0, 0xff})
 
-	op := &DrawImageOptions{}
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Rotate(math.Pi / 4)
-	dst1.DrawImage(src.SubImage(image.Rect(-4, -4, 8, 8)).(*Image), op)
+	dst1.DrawImage(src.SubImage(image.Rect(-4, -4, 8, 8)).(*ebiten.Image), op)
 
-	op = &DrawImageOptions{}
+	op = &ebiten.DrawImageOptions{}
 	op.GeoM.Rotate(math.Pi / 4)
 	dst2.DrawImage(src, op)
 
@@ -721,7 +721,7 @@ func TestImageSize(t *testing.T) {
 		w = 17
 		h = 31
 	)
-	img := NewImage(w, h)
+	img := ebiten.NewImage(w, h)
 	gotW, gotH := img.Size()
 	if gotW != w {
 		t.Errorf("got: %d, want: %d", gotW, w)
@@ -732,8 +732,8 @@ func TestImageSize(t *testing.T) {
 }
 
 func TestImageSize1(t *testing.T) {
-	src := NewImage(1, 1)
-	dst := NewImage(1, 1)
+	src := ebiten.NewImage(1, 1)
+	dst := ebiten.NewImage(1, 1)
 	src.Fill(color.White)
 	dst.DrawImage(src, nil)
 	got := src.At(0, 0).(color.RGBA)
@@ -745,8 +745,8 @@ func TestImageSize1(t *testing.T) {
 
 // TODO: Enable this test again. This test fails after #1217 is fixed.
 func Skip_TestImageSize4096(t *testing.T) {
-	src := NewImage(4096, 4096)
-	dst := NewImage(4096, 4096)
+	src := ebiten.NewImage(4096, 4096)
+	dst := ebiten.NewImage(4096, 4096)
 	pix := make([]byte, 4096*4096*4)
 	for i := 0; i < 4096; i++ {
 		j := 4095
@@ -791,7 +791,7 @@ func TestImageCopy(t *testing.T) {
 		}
 	}()
 
-	img0 := NewImage(256, 256)
+	img0 := ebiten.NewImage(256, 256)
 	img1 := *img0
 	img1.Fill(color.Transparent)
 }
@@ -804,10 +804,10 @@ func TestImageStretch(t *testing.T) {
 
 	const w = 16
 
-	dst := NewImage(w, maxImageSize)
+	dst := ebiten.NewImage(w, maxImageSize)
 loop:
 	for h := 1; h <= 32; h++ {
-		src := NewImage(w+2, h+2)
+		src := ebiten.NewImage(w+2, h+2)
 
 		pix := make([]byte, 4*(w+2)*(h+2))
 		for i := 0; i < (w+2)*(h+2); i++ {
@@ -819,9 +819,9 @@ loop:
 		_, dh := dst.Size()
 		for i := 0; i < dh; {
 			dst.Clear()
-			op := &DrawImageOptions{}
+			op := &ebiten.DrawImageOptions{}
 			op.GeoM.Scale(1, float64(i)/float64(h))
-			dst.DrawImage(src.SubImage(image.Rect(1, 1, w+1, h+1)).(*Image), op)
+			dst.DrawImage(src.SubImage(image.Rect(1, 1, w+1, h+1)).(*ebiten.Image), op)
 			for j := -1; j <= 1; j++ {
 				if i+j < 0 {
 					continue
@@ -854,12 +854,12 @@ func TestImageSprites(t *testing.T) {
 		height = 512
 	)
 
-	src := NewImage(4, 4)
+	src := ebiten.NewImage(4, 4)
 	src.Fill(color.RGBA{0xff, 0xff, 0xff, 0xff})
-	dst := NewImage(width, height)
+	dst := ebiten.NewImage(width, height)
 	for j := 0; j < height/4; j++ {
 		for i := 0; i < width/4; i++ {
-			op := &DrawImageOptions{}
+			op := &ebiten.DrawImageOptions{}
 			op.GeoM.Translate(float64(i*4), float64(j*4))
 			dst.DrawImage(src, op)
 		}
@@ -885,29 +885,29 @@ func Disabled_TestImageMipmap(t *testing.T) {
 	}
 	w, h := src.Size()
 
-	l1 := NewImage(w/2, h/2)
-	op := &DrawImageOptions{}
+	l1 := ebiten.NewImage(w/2, h/2)
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(1/2.0, 1/2.0)
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	l1.DrawImage(src, op)
 
 	l1w, l1h := l1.Size()
-	l2 := NewImage(l1w/2, l1h/2)
-	op = &DrawImageOptions{}
+	l2 := ebiten.NewImage(l1w/2, l1h/2)
+	op = &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(1/2.0, 1/2.0)
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	l2.DrawImage(l1, op)
 
-	gotDst := NewImage(w, h)
-	op = &DrawImageOptions{}
+	gotDst := ebiten.NewImage(w, h)
+	op = &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(1/5.0, 1/5.0)
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	gotDst.DrawImage(src, op)
 
-	wantDst := NewImage(w, h)
-	op = &DrawImageOptions{}
+	wantDst := ebiten.NewImage(w, h)
+	op = &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(4.0/5.0, 4.0/5.0)
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	wantDst.DrawImage(l2, op)
 
 	for j := 0; j < h; j++ {
@@ -930,31 +930,31 @@ func Disabled_TestImageMipmapNegativeDet(t *testing.T) {
 	}
 	w, h := src.Size()
 
-	l1 := NewImage(w/2, h/2)
-	op := &DrawImageOptions{}
+	l1 := ebiten.NewImage(w/2, h/2)
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(1/2.0, 1/2.0)
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	l1.DrawImage(src, op)
 
 	l1w, l1h := l1.Size()
-	l2 := NewImage(l1w/2, l1h/2)
-	op = &DrawImageOptions{}
+	l2 := ebiten.NewImage(l1w/2, l1h/2)
+	op = &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(1/2.0, 1/2.0)
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	l2.DrawImage(l1, op)
 
-	gotDst := NewImage(w, h)
-	op = &DrawImageOptions{}
+	gotDst := ebiten.NewImage(w, h)
+	op = &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(-1/5.0, -1/5.0)
 	op.GeoM.Translate(float64(w), float64(h))
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	gotDst.DrawImage(src, op)
 
-	wantDst := NewImage(w, h)
-	op = &DrawImageOptions{}
+	wantDst := ebiten.NewImage(w, h)
+	op = &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(-4.0/5.0, -4.0/5.0)
 	op.GeoM.Translate(float64(w), float64(h))
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	wantDst.DrawImage(l2, op)
 
 	allZero := true
@@ -978,8 +978,8 @@ func Disabled_TestImageMipmapNegativeDet(t *testing.T) {
 
 // Issue #710
 func TestImageMipmapColor(t *testing.T) {
-	img0 := NewImage(256, 256)
-	img1 := NewImage(128, 128)
+	img0 := ebiten.NewImage(256, 256)
+	img1 := ebiten.NewImage(128, 128)
 	img1.Fill(color.White)
 
 	for i := 0; i < 8; i++ {
@@ -987,8 +987,8 @@ func TestImageMipmapColor(t *testing.T) {
 
 		s := 1 - float64(i)/8
 
-		op := &DrawImageOptions{}
-		op.Filter = FilterLinear
+		op := &ebiten.DrawImageOptions{}
+		op.Filter = ebiten.FilterLinear
 		op.GeoM.Scale(s, s)
 		op.ColorM.Scale(1, 1, 0, 1)
 		img0.DrawImage(img1, op)
@@ -1008,20 +1008,20 @@ func TestImageMipmapColor(t *testing.T) {
 
 // Issue #725
 func TestImageMiamapAndDrawTriangle(t *testing.T) {
-	img0 := NewImage(32, 32)
-	img1 := NewImage(128, 128)
-	img2 := NewImage(128, 128)
+	img0 := ebiten.NewImage(32, 32)
+	img1 := ebiten.NewImage(128, 128)
+	img2 := ebiten.NewImage(128, 128)
 
 	// Fill img1 red and create img1's mipmap
 	img1.Fill(color.RGBA{0xff, 0, 0, 0xff})
-	op := &DrawImageOptions{}
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(0.25, 0.25)
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	img0.DrawImage(img1, op)
 
 	// Call DrawTriangle on img1 and fill it with green
 	img2.Fill(color.RGBA{0, 0xff, 0, 0xff})
-	vs := []Vertex{
+	vs := []ebiten.Vertex{
 		{
 			DstX:   0,
 			DstY:   0,
@@ -1067,9 +1067,9 @@ func TestImageMiamapAndDrawTriangle(t *testing.T) {
 
 	// Draw img1 (green) again. Confirm mipmap is correctly updated.
 	img0.Clear()
-	op = &DrawImageOptions{}
+	op = &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(0.25, 0.25)
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	img0.DrawImage(img1, op)
 
 	w, h := img0.Size()
@@ -1084,7 +1084,7 @@ func TestImageMiamapAndDrawTriangle(t *testing.T) {
 }
 
 func TestImageSubImageAt(t *testing.T) {
-	img := NewImage(16, 16)
+	img := ebiten.NewImage(16, 16)
 	img.Fill(color.RGBA{0xff, 0, 0, 0xff})
 
 	got := img.SubImage(image.Rect(1, 1, 16, 16)).At(0, 0).(color.RGBA)
@@ -1101,10 +1101,10 @@ func TestImageSubImageAt(t *testing.T) {
 }
 
 func TestImageSubImageSize(t *testing.T) {
-	img := NewImage(16, 16)
+	img := ebiten.NewImage(16, 16)
 	img.Fill(color.RGBA{0xff, 0, 0, 0xff})
 
-	got, _ := img.SubImage(image.Rect(1, 1, 16, 16)).(*Image).Size()
+	got, _ := img.SubImage(image.Rect(1, 1, 16, 16)).(*ebiten.Image).Size()
 	want := 15
 	if got != want {
 		t.Errorf("got: %v, want: %v", got, want)
@@ -1113,8 +1113,8 @@ func TestImageSubImageSize(t *testing.T) {
 
 func TestImageDrawImmediately(t *testing.T) {
 	const w, h = 16, 16
-	img0 := NewImage(w, h)
-	img1 := NewImage(w, h)
+	img0 := ebiten.NewImage(w, h)
+	img1 := ebiten.NewImage(w, h)
 	// Do not manipulate img0 here.
 
 	img0.Fill(color.RGBA{0xff, 0, 0, 0xff})
@@ -1145,8 +1145,8 @@ func TestImageDrawImmediately(t *testing.T) {
 func TestImageLinearFilterGlitch(t *testing.T) {
 	const w, h = 200, 12
 	const scale = 1.2
-	src := NewImage(w, h)
-	dst := NewImage(int(math.Floor(w*scale)), h)
+	src := ebiten.NewImage(w, h)
+	dst := ebiten.NewImage(int(math.Floor(w*scale)), h)
 
 	pix := make([]byte, 4*w*h)
 	for j := 0; j < h; j++ {
@@ -1167,8 +1167,8 @@ func TestImageLinearFilterGlitch(t *testing.T) {
 	}
 	src.ReplacePixels(pix)
 
-	for _, f := range []Filter{FilterNearest, FilterLinear} {
-		op := &DrawImageOptions{}
+	for _, f := range []ebiten.Filter{ebiten.FilterNearest, ebiten.FilterLinear} {
+		op := &ebiten.DrawImageOptions{}
 		op.GeoM.Scale(scale, 1)
 		op.Filter = f
 		dst.DrawImage(src, op)
@@ -1194,8 +1194,8 @@ func TestImageLinearFilterGlitch(t *testing.T) {
 // Issue #1212
 func TestImageLinearFilterGlitch2(t *testing.T) {
 	const w, h = 100, 100
-	src := NewImage(w, h)
-	dst := NewImage(w, h)
+	src := ebiten.NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
 
 	idx := 0
 	pix := make([]byte, 4*w*h)
@@ -1217,8 +1217,8 @@ func TestImageLinearFilterGlitch2(t *testing.T) {
 	}
 	src.ReplacePixels(pix)
 
-	op := &DrawImageOptions{}
-	op.Filter = FilterLinear
+	op := &ebiten.DrawImageOptions{}
+	op.Filter = ebiten.FilterLinear
 	dst.DrawImage(src, op)
 
 	for j := 0; j < h; j++ {
@@ -1239,8 +1239,8 @@ func TestImageLinearFilterGlitch2(t *testing.T) {
 
 func TestImageAddressRepeat(t *testing.T) {
 	const w, h = 16, 16
-	src := NewImage(w, h)
-	dst := NewImage(w, h)
+	src := ebiten.NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
 	pix := make([]byte, 4*w*h)
 	for j := 0; j < h; j++ {
 		for i := 0; i < w; i++ {
@@ -1260,7 +1260,7 @@ func TestImageAddressRepeat(t *testing.T) {
 	}
 	src.ReplacePixels(pix)
 
-	vs := []Vertex{
+	vs := []ebiten.Vertex{
 		{
 			DstX:   0,
 			DstY:   0,
@@ -1303,9 +1303,9 @@ func TestImageAddressRepeat(t *testing.T) {
 		},
 	}
 	is := []uint16{0, 1, 2, 1, 2, 3}
-	op := &DrawTrianglesOptions{}
-	op.Address = AddressRepeat
-	dst.DrawTriangles(vs, is, src.SubImage(image.Rect(4, 4, 8, 8)).(*Image), op)
+	op := &ebiten.DrawTrianglesOptions{}
+	op.Address = ebiten.AddressRepeat
+	dst.DrawTriangles(vs, is, src.SubImage(image.Rect(4, 4, 8, 8)).(*ebiten.Image), op)
 
 	for j := 0; j < h; j++ {
 		for i := 0; i < w; i++ {
@@ -1320,7 +1320,7 @@ func TestImageAddressRepeat(t *testing.T) {
 
 func TestImageReplacePixelsAfterClear(t *testing.T) {
 	const w, h = 256, 256
-	img := NewImage(w, h)
+	img := ebiten.NewImage(w, h)
 	img.ReplacePixels(make([]byte, 4*w*h))
 	// Clear used to call DrawImage to clear the image, which was the cause of crash. It is because after
 	// DrawImage is called, ReplacePixels for a region is forbidden.
@@ -1338,7 +1338,7 @@ func TestImageSet(t *testing.T) {
 	}
 
 	const w, h = 16, 16
-	img := NewImage(w, h)
+	img := ebiten.NewImage(w, h)
 	colors := map[Pt]color.RGBA{
 		{1, 2}:   {3, 4, 5, 6},
 		{7, 8}:   {9, 10, 11, 12},
@@ -1370,8 +1370,8 @@ func TestImageSetAndDraw(t *testing.T) {
 	}
 
 	const w, h = 16, 16
-	src := NewImage(w, h)
-	dst := NewImage(w, h)
+	src := ebiten.NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
 	colors := map[Pt]color.RGBA{
 		{1, 2}:   {3, 4, 5, 6},
 		{7, 8}:   {9, 10, 11, 12},
@@ -1405,9 +1405,9 @@ func TestImageSetAndDraw(t *testing.T) {
 		src.Set(p.X, p.Y, c)
 		dst.Set(p.X+1, p.Y+1, c)
 	}
-	op := &DrawImageOptions{}
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(2, 2)
-	dst.DrawImage(src.SubImage(image.Rect(2, 2, w-2, h-2)).(*Image), op)
+	dst.DrawImage(src.SubImage(image.Rect(2, 2, w-2, h-2)).(*ebiten.Image), op)
 	for j := 0; j < h; j++ {
 		for i := 0; i < w; i++ {
 			got := dst.At(i, j).(color.RGBA)
@@ -1429,10 +1429,10 @@ func TestImageSetAndDraw(t *testing.T) {
 
 func TestImageAlphaOnBlack(t *testing.T) {
 	const w, h = 16, 16
-	src0 := NewImage(w, h)
-	src1 := NewImage(w, h)
-	dst0 := NewImage(w, h)
-	dst1 := NewImage(w, h)
+	src0 := ebiten.NewImage(w, h)
+	src1 := ebiten.NewImage(w, h)
+	dst0 := ebiten.NewImage(w, h)
+	dst1 := ebiten.NewImage(w, h)
 
 	pix0 := make([]byte, 4*w*h)
 	for j := 0; j < h; j++ {
@@ -1468,9 +1468,9 @@ func TestImageAlphaOnBlack(t *testing.T) {
 	dst0.Fill(color.Black)
 	dst1.Fill(color.Black)
 
-	op := &DrawImageOptions{}
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(0.5, 0.5)
-	op.Filter = FilterLinear
+	op.Filter = ebiten.FilterLinear
 	dst0.DrawImage(src0, op)
 	dst1.DrawImage(src1, op)
 
@@ -1494,8 +1494,8 @@ func TestImageAlphaOnBlack(t *testing.T) {
 
 func TestImageDrawTrianglesWithSubImage(t *testing.T) {
 	const w, h = 16, 16
-	src := NewImage(w, h)
-	dst := NewImage(w, h)
+	src := ebiten.NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
 
 	pix := make([]byte, 4*w*h)
 	for j := 0; j < h; j++ {
@@ -1515,7 +1515,7 @@ func TestImageDrawTrianglesWithSubImage(t *testing.T) {
 	}
 	src.ReplacePixels(pix)
 
-	vs := []Vertex{
+	vs := []ebiten.Vertex{
 		{
 			DstX:   0,
 			DstY:   0,
@@ -1558,9 +1558,9 @@ func TestImageDrawTrianglesWithSubImage(t *testing.T) {
 		},
 	}
 	is := []uint16{0, 1, 2, 1, 2, 3}
-	op := &DrawTrianglesOptions{}
-	op.Address = AddressClampToZero
-	dst.DrawTriangles(vs, is, src.SubImage(image.Rect(4, 4, 8, 8)).(*Image), op)
+	op := &ebiten.DrawTrianglesOptions{}
+	op.Address = ebiten.AddressClampToZero
+	dst.DrawTriangles(vs, is, src.SubImage(image.Rect(4, 4, 8, 8)).(*ebiten.Image), op)
 
 	for j := 0; j < h; j++ {
 		for i := 0; i < w; i++ {
@@ -1578,7 +1578,7 @@ func TestImageDrawTrianglesWithSubImage(t *testing.T) {
 
 // Issue #823
 func TestImageAtAfterDisposingSubImage(t *testing.T) {
-	img := NewImage(16, 16)
+	img := ebiten.NewImage(16, 16)
 	img.Set(0, 0, color.White)
 	img.SubImage(image.Rect(0, 0, 16, 16))
 	runtime.GC()
@@ -1595,7 +1595,7 @@ func TestImageAtAfterDisposingSubImage(t *testing.T) {
 	}
 
 	img.Set(0, 1, color.White)
-	sub := img.SubImage(image.Rect(0, 0, 16, 16)).(*Image)
+	sub := img.SubImage(image.Rect(0, 0, 16, 16)).(*ebiten.Image)
 	sub.Dispose()
 
 	got = img.At(0, 1)
@@ -1609,10 +1609,10 @@ func TestImageAtAfterDisposingSubImage(t *testing.T) {
 }
 
 func TestImageSubImageSubImage(t *testing.T) {
-	img := NewImage(16, 16)
+	img := ebiten.NewImage(16, 16)
 	img.Fill(color.White)
-	sub0 := img.SubImage(image.Rect(0, 0, 12, 12)).(*Image)
-	sub1 := sub0.SubImage(image.Rect(4, 4, 16, 16)).(*Image)
+	sub0 := img.SubImage(image.Rect(0, 0, 12, 12)).(*ebiten.Image)
+	sub1 := sub0.SubImage(image.Rect(4, 4, 16, 16)).(*ebiten.Image)
 	cases := []struct {
 		X     int
 		Y     int
@@ -1646,14 +1646,14 @@ func TestImageSubImageSubImage(t *testing.T) {
 // Issue #839
 func TestImageTooSmallMipmap(t *testing.T) {
 	const w, h = 16, 16
-	src := NewImage(w, h)
-	dst := NewImage(w, h)
+	src := ebiten.NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
 
 	src.Fill(color.White)
-	op := &DrawImageOptions{}
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(1, 0.24)
-	op.Filter = FilterLinear
-	dst.DrawImage(src.SubImage(image.Rect(5, 0, 6, 16)).(*Image), op)
+	op.Filter = ebiten.FilterLinear
+	dst.DrawImage(src.SubImage(image.Rect(5, 0, 6, 16)).(*ebiten.Image), op)
 	got := dst.At(0, 0).(color.RGBA)
 	want := color.RGBA{0xff, 0xff, 0xff, 0xff}
 	if got != want {
@@ -1663,12 +1663,12 @@ func TestImageTooSmallMipmap(t *testing.T) {
 
 func TestImageZeroSizedMipmap(t *testing.T) {
 	const w, h = 16, 16
-	src := NewImage(w, h)
-	dst := NewImage(w, h)
+	src := ebiten.NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
 
-	op := &DrawImageOptions{}
-	op.Filter = FilterLinear
-	dst.DrawImage(src.SubImage(image.ZR).(*Image), op)
+	op := &ebiten.DrawImageOptions{}
+	op.Filter = ebiten.FilterLinear
+	dst.DrawImage(src.SubImage(image.ZR).(*ebiten.Image), op)
 }
 
 // Issue #898
@@ -1678,13 +1678,13 @@ func TestImageFillingAndEdges(t *testing.T) {
 		dstw, dsth = 256, 16
 	)
 
-	src := NewImage(srcw, srch)
-	dst := NewImage(dstw, dsth)
+	src := ebiten.NewImage(srcw, srch)
+	dst := ebiten.NewImage(dstw, dsth)
 
 	src.Fill(color.White)
 	dst.Fill(color.Black)
 
-	op := &DrawImageOptions{}
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(float64(dstw-2)/float64(srcw), float64(dsth-2)/float64(srch))
 	op.GeoM.Translate(1, 1)
 	dst.DrawImage(src, op)
@@ -1705,12 +1705,12 @@ func TestImageFillingAndEdges(t *testing.T) {
 
 func TestImageDrawTrianglesAndMutateArgs(t *testing.T) {
 	const w, h = 16, 16
-	dst := NewImage(w, h)
-	src := NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
+	src := ebiten.NewImage(w, h)
 	clr := color.RGBA{0xff, 0, 0, 0xff}
 	src.Fill(clr)
 
-	vs := []Vertex{
+	vs := []ebiten.Vertex{
 		{
 			DstX:   0,
 			DstY:   0,
@@ -1770,7 +1770,7 @@ func TestImageDrawTrianglesAndMutateArgs(t *testing.T) {
 }
 
 func TestImageReplacePixelsOnSubImage(t *testing.T) {
-	dst := NewImage(17, 31)
+	dst := ebiten.NewImage(17, 31)
 	dst.Fill(color.RGBA{0xff, 0, 0, 0xff})
 
 	pix0 := make([]byte, 4*5*3)
@@ -1785,7 +1785,7 @@ func TestImageReplacePixelsOnSubImage(t *testing.T) {
 		}
 	}
 	r0 := image.Rect(4, 5, 9, 8)
-	dst.SubImage(r0).(*Image).ReplacePixels(pix0)
+	dst.SubImage(r0).(*ebiten.Image).ReplacePixels(pix0)
 
 	pix1 := make([]byte, 4*5*3)
 	idx = 0
@@ -1799,7 +1799,7 @@ func TestImageReplacePixelsOnSubImage(t *testing.T) {
 		}
 	}
 	r1 := image.Rect(11, 10, 16, 13)
-	dst.SubImage(r1).(*Image).ReplacePixels(pix1)
+	dst.SubImage(r1).(*ebiten.Image).ReplacePixels(pix1)
 
 	for j := 0; j < 31; j++ {
 		for i := 0; i < 17; i++ {
@@ -1821,12 +1821,12 @@ func TestImageReplacePixelsOnSubImage(t *testing.T) {
 
 func TestImageDrawTrianglesWithColorM(t *testing.T) {
 	const w, h = 16, 16
-	dst0 := NewImage(w, h)
-	dst1 := NewImage(w, h)
-	src := NewImage(w, h)
+	dst0 := ebiten.NewImage(w, h)
+	dst1 := ebiten.NewImage(w, h)
+	src := ebiten.NewImage(w, h)
 	src.Fill(color.White)
 
-	vs0 := []Vertex{
+	vs0 := []ebiten.Vertex{
 		{
 			DstX:   0,
 			DstY:   0,
@@ -1868,12 +1868,12 @@ func TestImageDrawTrianglesWithColorM(t *testing.T) {
 			ColorA: 1,
 		},
 	}
-	op := &DrawTrianglesOptions{}
+	op := &ebiten.DrawTrianglesOptions{}
 	op.ColorM.Scale(0.2, 0.4, 0.6, 0.8)
 	is := []uint16{0, 1, 2, 1, 2, 3}
 	dst0.DrawTriangles(vs0, is, src, op)
 
-	vs1 := []Vertex{
+	vs1 := []ebiten.Vertex{
 		{
 			DstX:   0,
 			DstY:   0,
@@ -1930,7 +1930,7 @@ func TestImageDrawTrianglesWithColorM(t *testing.T) {
 
 // Issue #1137
 func TestImageDrawOver(t *testing.T) {
-	dst := NewImage(320, 240)
+	dst := ebiten.NewImage(320, 240)
 	src := image.NewUniform(color.RGBA{0xff, 0, 0, 0xff})
 	// This must not cause infinite-loop.
 	draw.Draw(dst, dst.Bounds(), src, image.ZP, draw.Over)
@@ -1952,8 +1952,8 @@ func TestImageDrawDisposedImage(t *testing.T) {
 		}
 	}()
 
-	dst := NewImage(16, 16)
-	src := NewImage(16, 16)
+	dst := ebiten.NewImage(16, 16)
+	src := ebiten.NewImage(16, 16)
 	src.Dispose()
 	dst.DrawImage(src, nil)
 }
@@ -1965,17 +1965,17 @@ func TestImageDrawTrianglesDisposedImage(t *testing.T) {
 		}
 	}()
 
-	dst := NewImage(16, 16)
-	src := NewImage(16, 16)
+	dst := ebiten.NewImage(16, 16)
+	src := ebiten.NewImage(16, 16)
 	src.Dispose()
-	vs := make([]Vertex, 4)
+	vs := make([]ebiten.Vertex, 4)
 	is := []uint16{0, 1, 2, 1, 2, 3}
 	dst.DrawTriangles(vs, is, src, nil)
 }
 
 // #1137
 func BenchmarkImageDrawOver(b *testing.B) {
-	dst := NewImage(16, 16)
+	dst := ebiten.NewImage(16, 16)
 	src := image.NewUniform(color.Black)
 	for n := 0; n < b.N; n++ {
 		draw.Draw(dst, dst.Bounds(), src, image.ZP, draw.Over)
@@ -1989,11 +1989,11 @@ func TestImageFloatTranslate(t *testing.T) {
 	for s := 2; s <= 8; s++ {
 		s := s
 		t.Run(fmt.Sprintf("scale%d", s), func(t *testing.T) {
-			check := func(src *Image) {
-				dst := NewImage(w*(s+1), h*(s+1))
+			check := func(src *ebiten.Image) {
+				dst := ebiten.NewImage(w*(s+1), h*(s+1))
 				dst.Fill(color.RGBA{0xff, 0, 0, 0xff})
 
-				op := &DrawImageOptions{}
+				op := &ebiten.DrawImageOptions{}
 				op.GeoM.Scale(float64(s), float64(s))
 				op.GeoM.Translate(0, 0.501)
 				dst.DrawImage(src, op)
@@ -2014,7 +2014,7 @@ func TestImageFloatTranslate(t *testing.T) {
 			}
 
 			t.Run("image", func(t *testing.T) {
-				src := NewImage(w, h)
+				src := ebiten.NewImage(w, h)
 				pix := make([]byte, 4*w*h)
 				for j := 0; j < h; j++ {
 					for i := 0; i < w; i++ {
@@ -2027,7 +2027,7 @@ func TestImageFloatTranslate(t *testing.T) {
 			})
 
 			t.Run("subimage", func(t *testing.T) {
-				src := NewImage(w*s, h*s)
+				src := ebiten.NewImage(w*s, h*s)
 				pix := make([]byte, 4*(w*s)*(h*s))
 				for j := 0; j < h*s; j++ {
 					for i := 0; i < w*s; i++ {
@@ -2036,7 +2036,7 @@ func TestImageFloatTranslate(t *testing.T) {
 					}
 				}
 				src.ReplacePixels(pix)
-				check(src.SubImage(image.Rect(0, 0, w, h)).(*Image))
+				check(src.SubImage(image.Rect(0, 0, w, h)).(*ebiten.Image))
 			})
 		})
 	}
@@ -2045,13 +2045,13 @@ func TestImageFloatTranslate(t *testing.T) {
 // Issue #1213
 func TestImageColorMCopy(t *testing.T) {
 	const w, h = 16, 16
-	dst := NewImage(w, h)
-	src := NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
+	src := ebiten.NewImage(w, h)
 
 	for k := 0; k < 256; k++ {
-		op := &DrawImageOptions{}
+		op := &ebiten.DrawImageOptions{}
 		op.ColorM.Translate(1, 1, 1, float64(k)/0xff)
-		op.CompositeMode = CompositeModeCopy
+		op.CompositeMode = ebiten.CompositeModeCopy
 		dst.DrawImage(src, op)
 
 		for j := 0; j < h; j++ {
@@ -2069,8 +2069,8 @@ func TestImageColorMCopy(t *testing.T) {
 // TODO: Do we have to guarantee this behavior? See #1222
 func TestImageReplacePixelsAndModifyPixels(t *testing.T) {
 	const w, h = 16, 16
-	dst := NewImage(w, h)
-	src := NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
+	src := ebiten.NewImage(w, h)
 
 	pix := make([]byte, 4*w*h)
 	for j := 0; j < h; j++ {
@@ -2112,14 +2112,14 @@ func TestImageReplacePixelsAndModifyPixels(t *testing.T) {
 
 func TestImageCompositeModeMultiply(t *testing.T) {
 	const w, h = 16, 16
-	dst := NewImage(w, h)
-	src := NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
+	src := ebiten.NewImage(w, h)
 
 	dst.Fill(color.RGBA{0x10, 0x20, 0x30, 0x40})
 	src.Fill(color.RGBA{0x50, 0x60, 0x70, 0x80})
 
-	op := &DrawImageOptions{}
-	op.CompositeMode = CompositeModeMultiply
+	op := &ebiten.DrawImageOptions{}
+	op.CompositeMode = ebiten.CompositeModeMultiply
 	dst.DrawImage(src, op)
 
 	for j := 0; j < h; j++ {
@@ -2141,41 +2141,41 @@ func TestImageCompositeModeMultiply(t *testing.T) {
 // Issue #1269
 func TestImageZeroTriangle(t *testing.T) {
 	const w, h = 16, 16
-	dst := NewImage(w, h)
-	src := NewImage(1, 1)
+	dst := ebiten.NewImage(w, h)
+	src := ebiten.NewImage(1, 1)
 
-	vs := []Vertex{}
+	vs := []ebiten.Vertex{}
 	is := []uint16{}
 	dst.DrawTriangles(vs, is, src, nil)
 }
 
 // Issue #1398
 func TestImageDrawImageTooBigScale(t *testing.T) {
-	dst := NewImage(1, 1)
-	src := NewImage(1, 1)
+	dst := ebiten.NewImage(1, 1)
+	src := ebiten.NewImage(1, 1)
 
-	op := &DrawImageOptions{}
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(1e20, 1e20)
 	dst.DrawImage(src, op)
 }
 
 // Issue #1398
 func TestImageDrawImageTooSmallScale(t *testing.T) {
-	dst := NewImage(1, 1)
-	src := NewImage(1, 1)
+	dst := ebiten.NewImage(1, 1)
+	src := ebiten.NewImage(1, 1)
 
-	op := &DrawImageOptions{}
-	op.Filter = FilterLinear
+	op := &ebiten.DrawImageOptions{}
+	op.Filter = ebiten.FilterLinear
 	op.GeoM.Scale(1e-10, 1e-10)
 	dst.DrawImage(src, op)
 }
 
 // Issue #1399
 func TestImageDrawImageCannotAllocateImageForMipmap(t *testing.T) {
-	dst := NewImage(1, 1)
-	src := NewImage(maxImageSize, maxImageSize)
+	dst := ebiten.NewImage(1, 1)
+	src := ebiten.NewImage(maxImageSize, maxImageSize)
 
-	op := &DrawImageOptions{}
+	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(64, 64)
 	dst.DrawImage(src, op)
 	dst.At(0, 0)
@@ -2188,7 +2188,7 @@ func TestImageNewImageWithZeroSize(t *testing.T) {
 		}
 	}()
 
-	_ = NewImage(0, 1)
+	_ = ebiten.NewImage(0, 1)
 }
 
 func TestImageNewImageFromImageWithZeroSize(t *testing.T) {
@@ -2199,7 +2199,7 @@ func TestImageNewImageFromImageWithZeroSize(t *testing.T) {
 	}()
 
 	img := image.NewRGBA(image.Rect(0, 0, 0, 1))
-	_ = NewImageFromImage(img)
+	_ = ebiten.NewImageFromImage(img)
 }
 
 func TestImageClip(t *testing.T) {
@@ -2207,13 +2207,13 @@ func TestImageClip(t *testing.T) {
 		w = 16
 		h = 16
 	)
-	dst := NewImage(w, h)
-	src := NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
+	src := ebiten.NewImage(w, h)
 
 	dst.Fill(color.RGBA{0xff, 0, 0, 0xff})
 	src.Fill(color.RGBA{0, 0xff, 0, 0xff})
 
-	dst.SubImage(image.Rect(4, 5, 12, 14)).(*Image).DrawImage(src, nil)
+	dst.SubImage(image.Rect(4, 5, 12, 14)).(*ebiten.Image).DrawImage(src, nil)
 	for j := 0; j < h; j++ {
 		for i := 0; i < w; i++ {
 			got := dst.At(i, j).(color.RGBA)
@@ -2230,7 +2230,7 @@ func TestImageClip(t *testing.T) {
 
 // Issue #1691
 func TestImageSubImageFill(t *testing.T) {
-	dst := NewImage(3, 3).SubImage(image.Rect(1, 1, 2, 2)).(*Image)
+	dst := ebiten.NewImage(3, 3).SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
 	dst.Fill(color.White)
 	for j := 0; j < 3; j++ {
 		for i := 0; i < 3; i++ {
@@ -2245,7 +2245,7 @@ func TestImageSubImageFill(t *testing.T) {
 		}
 	}
 
-	dst = NewImage(17, 31).SubImage(image.Rect(3, 4, 8, 10)).(*Image)
+	dst = ebiten.NewImage(17, 31).SubImage(image.Rect(3, 4, 8, 10)).(*ebiten.Image)
 	dst.Fill(color.White)
 	for j := 0; j < 31; j++ {
 		for i := 0; i < 17; i++ {
@@ -2262,11 +2262,11 @@ func TestImageSubImageFill(t *testing.T) {
 }
 
 func TestImageEvenOdd(t *testing.T) {
-	emptyImage := NewImage(3, 3)
+	emptyImage := ebiten.NewImage(3, 3)
 	emptyImage.Fill(color.White)
-	emptySubImage := emptyImage.SubImage(image.Rect(1, 1, 2, 2)).(*Image)
+	emptySubImage := emptyImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
 
-	vs0 := []Vertex{
+	vs0 := []ebiten.Vertex{
 		{
 			DstX: 1, DstY: 1, SrcX: 1, SrcY: 1,
 			ColorR: 1, ColorG: 0, ColorB: 0, ColorA: 1,
@@ -2286,7 +2286,7 @@ func TestImageEvenOdd(t *testing.T) {
 	}
 	is0 := []uint16{0, 1, 2, 1, 2, 3}
 
-	vs1 := []Vertex{
+	vs1 := []ebiten.Vertex{
 		{
 			DstX: 2, DstY: 2, SrcX: 1, SrcY: 1,
 			ColorR: 0, ColorG: 1, ColorB: 0, ColorA: 1,
@@ -2306,7 +2306,7 @@ func TestImageEvenOdd(t *testing.T) {
 	}
 	is1 := []uint16{4, 5, 6, 5, 6, 7}
 
-	vs2 := []Vertex{
+	vs2 := []ebiten.Vertex{
 		{
 			DstX: 3, DstY: 3, SrcX: 1, SrcY: 1,
 			ColorR: 0, ColorG: 0, ColorB: 1, ColorA: 1,
@@ -2327,9 +2327,9 @@ func TestImageEvenOdd(t *testing.T) {
 	is2 := []uint16{8, 9, 10, 9, 10, 11}
 
 	// Draw all the vertices once. The even-odd rule is applied for all the vertices once.
-	dst := NewImage(16, 16)
-	op := &DrawTrianglesOptions{
-		FillRule: EvenOdd,
+	dst := ebiten.NewImage(16, 16)
+	op := &ebiten.DrawTrianglesOptions{
+		FillRule: ebiten.EvenOdd,
 	}
 	dst.DrawTriangles(append(append(vs0, vs1...), vs2...), append(append(is0, is1...), is2...), emptySubImage, op)
 	for j := 0; j < 16; j++ {
@@ -2429,10 +2429,10 @@ func TestImageEvenOdd(t *testing.T) {
 // #1658
 func BenchmarkColorMScale(b *testing.B) {
 	r := rand.Float64
-	dst := NewImage(16, 16)
-	src := NewImage(16, 16)
+	dst := ebiten.NewImage(16, 16)
+	src := ebiten.NewImage(16, 16)
 	for n := 0; n < b.N; n++ {
-		op := &DrawImageOptions{}
+		op := &ebiten.DrawImageOptions{}
 		op.ColorM.Scale(r(), r(), r(), r())
 		dst.DrawImage(src, op)
 	}

--- a/imagetobytes_test.go
+++ b/imagetobytes_test.go
@@ -21,7 +21,7 @@ import (
 	"image/color/palette"
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2"
 )
 
 func TestImageToBytes(t *testing.T) {
@@ -93,7 +93,7 @@ func TestImageToBytes(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		got := ImageToBytes(c.In)
+		got := ebiten.ImageToBytes(c.In)
 		want := c.Out
 		if !bytes.Equal(got, want) {
 			t.Errorf("Test %d: got: %v, want: %v", i, got, want)
@@ -105,7 +105,7 @@ func BenchmarkImageToBytesRGBA(b *testing.B) {
 	img := image.NewRGBA(image.Rect(0, 0, 4096, 4096))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ImageToBytes(img)
+		ebiten.ImageToBytes(img)
 	}
 }
 
@@ -113,7 +113,7 @@ func BenchmarkImageToBytesNRGBA(b *testing.B) {
 	img := image.NewNRGBA(image.Rect(0, 0, 4096, 4096))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ImageToBytes(img)
+		ebiten.ImageToBytes(img)
 	}
 }
 
@@ -121,6 +121,6 @@ func BenchmarkImageToBytesPaletted(b *testing.B) {
 	img := image.NewPaletted(image.Rect(0, 0, 4096, 4096), palette.Plan9)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ImageToBytes(img)
+		ebiten.ImageToBytes(img)
 	}
 }

--- a/internal/affine/colorm_test.go
+++ b/internal/affine/colorm_test.go
@@ -19,25 +19,25 @@ import (
 	"math/rand"
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2/internal/affine"
+	"github.com/hajimehoshi/ebiten/v2/internal/affine"
 )
 
 func TestColorMScale(t *testing.T) {
 	cases := []struct {
-		In  ColorM
-		Out ColorM
+		In  affine.ColorM
+		Out affine.ColorM
 	}{
 		{
-			ColorMIdentity{},
-			ColorMIdentity{}.Scale(0.25, 0.5, 0.75, 1),
+			affine.ColorMIdentity{},
+			affine.ColorMIdentity{}.Scale(0.25, 0.5, 0.75, 1),
 		},
 		{
-			ColorMIdentity{}.Scale(0.5, 0.5, 0.5, 0.8),
-			ColorMIdentity{}.Scale(0.125, 0.25, 0.375, 0.8),
+			affine.ColorMIdentity{}.Scale(0.5, 0.5, 0.5, 0.8),
+			affine.ColorMIdentity{}.Scale(0.125, 0.25, 0.375, 0.8),
 		},
 		{
-			ColorMIdentity{}.Translate(0, 0, 0, 0),
-			ColorMIdentity{}.Scale(0.25, 0.5, 0.75, 1),
+			affine.ColorMIdentity{}.Translate(0, 0, 0, 0),
+			affine.ColorMIdentity{}.Scale(0.25, 0.5, 0.75, 1),
 		},
 	}
 	for _, c := range cases {
@@ -51,51 +51,51 @@ func TestColorMScale(t *testing.T) {
 
 func TestColorMScaleOnly(t *testing.T) {
 	cases := []struct {
-		In  ColorM
+		In  affine.ColorM
 		Out bool
 	}{
 		{
-			ColorMIdentity{},
+			affine.ColorMIdentity{},
 			true,
 		},
 		{
-			ColorMIdentity{}.Translate(0, 0, 0, 0),
+			affine.ColorMIdentity{}.Translate(0, 0, 0, 0),
 			true,
 		},
 		{
-			ColorMIdentity{}.Translate(1, 0, 0, 0),
+			affine.ColorMIdentity{}.Translate(1, 0, 0, 0),
 			false,
 		},
 		{
-			ColorMIdentity{}.Translate(0, 0, 0, -1),
+			affine.ColorMIdentity{}.Translate(0, 0, 0, -1),
 			false,
 		},
 		{
-			ColorMIdentity{}.Scale(1, 1, 1, 1),
+			affine.ColorMIdentity{}.Scale(1, 1, 1, 1),
 			true,
 		},
 		{
-			ColorMIdentity{}.Scale(0, 0, 0, 0),
+			affine.ColorMIdentity{}.Scale(0, 0, 0, 0),
 			true,
 		},
 		{
-			ColorMIdentity{}.Scale(0.1, 0.2, 0.3, 0.4),
+			affine.ColorMIdentity{}.Scale(0.1, 0.2, 0.3, 0.4),
 			true,
 		},
 		{
-			ColorMIdentity{}.Scale(0.1, 0.2, 0.3, 0.4).Translate(1, 0, 0, 0),
+			affine.ColorMIdentity{}.Scale(0.1, 0.2, 0.3, 0.4).Translate(1, 0, 0, 0),
 			false,
 		},
 		{
-			ChangeHSV(ColorMIdentity{}, math.Pi/2, 0.5, 0.5),
+			affine.ChangeHSV(affine.ColorMIdentity{}, math.Pi/2, 0.5, 0.5),
 			false,
 		},
 		{
-			ColorMSetElement(ColorMIdentity{}, 0, 0, 2),
+			affine.ColorMSetElement(affine.ColorMIdentity{}, 0, 0, 2),
 			true,
 		},
 		{
-			ColorMSetElement(ColorMIdentity{}, 0, 1, 2),
+			affine.ColorMSetElement(affine.ColorMIdentity{}, 0, 1, 2),
 			false,
 		},
 	}
@@ -109,22 +109,22 @@ func TestColorMScaleOnly(t *testing.T) {
 }
 
 func TestColorMIsInvertible(t *testing.T) {
-	var m ColorM = ColorMIdentity{}
-	m = ColorMSetElement(m, 1, 0, .5)
-	m = ColorMSetElement(m, 1, 1, .5)
-	m = ColorMSetElement(m, 1, 2, .5)
-	m = ColorMSetElement(m, 1, 3, .5)
-	m = ColorMSetElement(m, 1, 4, .5)
+	var m affine.ColorM = affine.ColorMIdentity{}
+	m = affine.ColorMSetElement(m, 1, 0, .5)
+	m = affine.ColorMSetElement(m, 1, 1, .5)
+	m = affine.ColorMSetElement(m, 1, 2, .5)
+	m = affine.ColorMSetElement(m, 1, 3, .5)
+	m = affine.ColorMSetElement(m, 1, 4, .5)
 
-	var cidentity ColorM = ColorMIdentity{}
-	var cinvalid ColorM = ColorMIdentity{}
-	cinvalid = ColorMSetElement(cinvalid, 0, 0, 0)
-	cinvalid = ColorMSetElement(cinvalid, 1, 1, 0)
-	cinvalid = ColorMSetElement(cinvalid, 2, 2, 0)
-	cinvalid = ColorMSetElement(cinvalid, 3, 3, 0)
+	var cidentity affine.ColorM = affine.ColorMIdentity{}
+	var cinvalid affine.ColorM = affine.ColorMIdentity{}
+	cinvalid = affine.ColorMSetElement(cinvalid, 0, 0, 0)
+	cinvalid = affine.ColorMSetElement(cinvalid, 1, 1, 0)
+	cinvalid = affine.ColorMSetElement(cinvalid, 2, 2, 0)
+	cinvalid = affine.ColorMSetElement(cinvalid, 3, 3, 0)
 
 	cases := []struct {
-		In  ColorM
+		In  affine.ColorM
 		Out bool
 	}{
 		{
@@ -149,11 +149,11 @@ func TestColorMIsInvertible(t *testing.T) {
 	}
 }
 
-func arrayToColorM(es [4][5]float32) ColorM {
-	var a ColorM = ColorMIdentity{}
+func arrayToColorM(es [4][5]float32) affine.ColorM {
+	var a affine.ColorM = affine.ColorMIdentity{}
 	for j := 0; j < 5; j++ {
 		for i := 0; i < 4; i++ {
-			a = ColorMSetElement(a, i, j, es[i][j])
+			a = affine.ColorMSetElement(a, i, j, es[i][j])
 		}
 	}
 	return a
@@ -166,7 +166,7 @@ func abs(x float32) float32 {
 	return x
 }
 
-func equalWithDelta(a, b ColorM, delta float32) bool {
+func equalWithDelta(a, b affine.ColorM, delta float32) bool {
 	for j := 0; j < 5; j++ {
 		for i := 0; i < 4; i++ {
 			ea := a.At(i, j)
@@ -181,12 +181,12 @@ func equalWithDelta(a, b ColorM, delta float32) bool {
 
 func TestColorMInvert(t *testing.T) {
 	cases := []struct {
-		In  ColorM
-		Out ColorM
+		In  affine.ColorM
+		Out affine.ColorM
 	}{
 		{
-			In:  ColorMIdentity{},
-			Out: ColorMIdentity{},
+			In:  affine.ColorMIdentity{},
+			Out: affine.ColorMIdentity{},
 		},
 		{
 			In: arrayToColorM([4][5]float32{
@@ -203,7 +203,7 @@ func TestColorMInvert(t *testing.T) {
 			}),
 		},
 		{
-			In: ColorMIdentity{}.Scale(1, 2, 4, 8),
+			In: affine.ColorMIdentity{}.Scale(1, 2, 4, 8),
 			Out: arrayToColorM([4][5]float32{
 				{1, 0, 0, 0, 0},
 				{0, 0.5, 0, 0, 0},
@@ -252,7 +252,7 @@ func BenchmarkColorMInvert(b *testing.B) {
 	r := rand.Float32
 
 	b.StopTimer()
-	var m ColorM = ColorMIdentity{}
+	var m affine.ColorM = affine.ColorMIdentity{}
 	for m.IsIdentity() || !m.IsInvertible() {
 		m = arrayToColorM([4][5]float32{
 			{r(), r(), r(), r(), r() * 10},
@@ -270,24 +270,24 @@ func BenchmarkColorMInvert(b *testing.B) {
 
 func TestColorMConcat(t *testing.T) {
 	cases := []struct {
-		In0 ColorM
-		In1 ColorM
-		Out ColorM
+		In0 affine.ColorM
+		In1 affine.ColorM
+		Out affine.ColorM
 	}{
 		{
-			ColorMIdentity{},
-			ColorMIdentity{},
-			ColorMIdentity{},
+			affine.ColorMIdentity{},
+			affine.ColorMIdentity{},
+			affine.ColorMIdentity{},
 		},
 		{
-			ColorMIdentity{}.Scale(1, 2, 3, 4),
-			ColorMIdentity{}.Scale(5, 6, 7, 8),
-			ColorMIdentity{}.Scale(5, 12, 21, 32),
+			affine.ColorMIdentity{}.Scale(1, 2, 3, 4),
+			affine.ColorMIdentity{}.Scale(5, 6, 7, 8),
+			affine.ColorMIdentity{}.Scale(5, 12, 21, 32),
 		},
 		{
-			ColorMIdentity{}.Scale(5, 6, 7, 8),
-			ColorMIdentity{}.Scale(1, 2, 3, 4),
-			ColorMIdentity{}.Scale(5, 12, 21, 32),
+			affine.ColorMIdentity{}.Scale(5, 6, 7, 8),
+			affine.ColorMIdentity{}.Scale(1, 2, 3, 4),
+			affine.ColorMIdentity{}.Scale(5, 12, 21, 32),
 		},
 		{
 			arrayToColorM([4][5]float32{
@@ -296,7 +296,7 @@ func TestColorMConcat(t *testing.T) {
 				{4, 5, 1, 2, 3},
 				{3, 4, 5, 1, 2},
 			}),
-			ColorMIdentity{}.Scale(1, 2, 3, 4),
+			affine.ColorMIdentity{}.Scale(1, 2, 3, 4),
 			arrayToColorM([4][5]float32{
 				{1, 2, 3, 4, 5},
 				{10, 2, 4, 6, 8},
@@ -305,7 +305,7 @@ func TestColorMConcat(t *testing.T) {
 			}),
 		},
 		{
-			ColorMIdentity{}.Scale(1, 2, 3, 4),
+			affine.ColorMIdentity{}.Scale(1, 2, 3, 4),
 			arrayToColorM([4][5]float32{
 				{1, 2, 3, 4, 5},
 				{5, 1, 2, 3, 4},

--- a/internal/atlas/image_test.go
+++ b/internal/atlas/image_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/hajimehoshi/ebiten/v2/internal/affine"
-	. "github.com/hajimehoshi/ebiten/v2/internal/atlas"
+	"github.com/hajimehoshi/ebiten/v2/internal/atlas"
 	"github.com/hajimehoshi/ebiten/v2/internal/driver"
 	"github.com/hajimehoshi/ebiten/v2/internal/graphics"
 	t "github.com/hajimehoshi/ebiten/v2/internal/testing"
@@ -32,8 +32,8 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	SetImageSizeForTesting(minImageSizeForTesting, maxImageSizeForTesting)
-	defer ResetImageSizeForTesting()
+	atlas.SetImageSizeForTesting(minImageSizeForTesting, maxImageSizeForTesting)
+	defer atlas.ResetImageSizeForTesting()
 	t.MainWithRunLoop(m)
 }
 
@@ -59,22 +59,22 @@ const bigSize = 2049
 func TestEnsureIsolated(t *testing.T) {
 	// Create img1 and img2 with this size so that the next images are allocated
 	// with non-upper-left location.
-	img1 := NewImage(bigSize, 100)
+	img1 := atlas.NewImage(bigSize, 100)
 	defer img1.MarkDisposed()
 	// Ensure img1's region is allocated.
 	img1.ReplacePixels(make([]byte, 4*bigSize*100))
 
-	img2 := NewImage(100, bigSize)
+	img2 := atlas.NewImage(100, bigSize)
 	defer img2.MarkDisposed()
 	img2.ReplacePixels(make([]byte, 4*100*bigSize))
 
 	const size = 32
 
-	img3 := NewImage(size/2, size/2)
+	img3 := atlas.NewImage(size/2, size/2)
 	defer img3.MarkDisposed()
 	img3.ReplacePixels(make([]byte, (size/2)*(size/2)*4))
 
-	img4 := NewImage(size, size)
+	img4 := atlas.NewImage(size, size)
 	defer img4.MarkDisposed()
 
 	pix := make([]byte, size*size*4)
@@ -103,7 +103,7 @@ func TestEnsureIsolated(t *testing.T) {
 		Width:  size,
 		Height: size,
 	}
-	img4.DrawTriangles([graphics.ShaderImageNum]*Image{img3}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	img4.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{img3}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 	want := false
 	if got := img4.IsOnAtlasForTesting(); got != want {
 		t.Errorf("got: %v, want: %v", got, want)
@@ -133,24 +133,24 @@ func TestEnsureIsolated(t *testing.T) {
 
 	// Check further drawing doesn't cause panic.
 	// This bug was fixed by 03dcd948.
-	img4.DrawTriangles([graphics.ShaderImageNum]*Image{img3}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	img4.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{img3}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 }
 
 func TestReputOnAtlas(t *testing.T) {
 	const size = 16
 
-	img0 := NewImage(size, size)
+	img0 := atlas.NewImage(size, size)
 	defer img0.MarkDisposed()
 	img0.ReplacePixels(make([]byte, 4*size*size))
 
-	img1 := NewImage(size, size)
+	img1 := atlas.NewImage(size, size)
 	defer img1.MarkDisposed()
 	img1.ReplacePixels(make([]byte, 4*size*size))
 	if got, want := img1.IsOnAtlasForTesting(), true; got != want {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 
-	img2 := NewImage(size, size)
+	img2 := atlas.NewImage(size, size)
 	defer img2.MarkDisposed()
 	pix := make([]byte, 4*size*size)
 	for j := 0; j < size; j++ {
@@ -163,7 +163,7 @@ func TestReputOnAtlas(t *testing.T) {
 	}
 	img2.ReplacePixels(pix)
 
-	img3 := NewImage(size, size)
+	img3 := atlas.NewImage(size, size)
 	img3.SetVolatile(true)
 	defer img3.MarkDisposed()
 	img1.ReplacePixels(make([]byte, 4*size*size))
@@ -180,7 +180,7 @@ func TestReputOnAtlas(t *testing.T) {
 		Width:  size,
 		Height: size,
 	}
-	img1.DrawTriangles([graphics.ShaderImageNum]*Image{img2}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	img1.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{img2}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 	if got, want := img1.IsOnAtlasForTesting(), false; got != want {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
@@ -188,16 +188,16 @@ func TestReputOnAtlas(t *testing.T) {
 	// Use img1 as a render source.
 	// Use the doubled count since img1 was on a texture atlas and became an isolated image once.
 	// Then, img1 requires longer time to recover to be on a textur atlas again.
-	for i := 0; i < BaseCountToPutOnAtlas*2; i++ {
-		if err := PutImagesOnAtlasForTesting(); err != nil {
+	for i := 0; i < atlas.BaseCountToPutOnAtlas*2; i++ {
+		if err := atlas.PutImagesOnAtlasForTesting(); err != nil {
 			t.Fatal(err)
 		}
-		img0.DrawTriangles([graphics.ShaderImageNum]*Image{img1}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+		img0.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{img1}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 		if got, want := img1.IsOnAtlasForTesting(), false; got != want {
 			t.Errorf("got: %v, want: %v", got, want)
 		}
 	}
-	if err := PutImagesOnAtlasForTesting(); err != nil {
+	if err := atlas.PutImagesOnAtlasForTesting(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -220,7 +220,7 @@ func TestReputOnAtlas(t *testing.T) {
 	}
 
 	// img1 is on an atlas again.
-	img0.DrawTriangles([graphics.ShaderImageNum]*Image{img1}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	img0.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{img1}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 	if got, want := img1.IsOnAtlasForTesting(), true; got != want {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
@@ -244,39 +244,39 @@ func TestReputOnAtlas(t *testing.T) {
 	}
 
 	// Use img1 as a render target again.
-	img1.DrawTriangles([graphics.ShaderImageNum]*Image{img2}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	img1.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{img2}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 	if got, want := img1.IsOnAtlasForTesting(), false; got != want {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 
 	// Use img1 as a render source, but call ReplacePixels.
 	// Now use 4x count as img1 became an isolated image again.
-	for i := 0; i < BaseCountToPutOnAtlas*4; i++ {
-		if err := PutImagesOnAtlasForTesting(); err != nil {
+	for i := 0; i < atlas.BaseCountToPutOnAtlas*4; i++ {
+		if err := atlas.PutImagesOnAtlasForTesting(); err != nil {
 			t.Fatal(err)
 		}
 		img1.ReplacePixels(make([]byte, 4*size*size))
-		img0.DrawTriangles([graphics.ShaderImageNum]*Image{img1}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+		img0.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{img1}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 		if got, want := img1.IsOnAtlasForTesting(), false; got != want {
 			t.Errorf("got: %v, want: %v", got, want)
 		}
 	}
-	if err := PutImagesOnAtlasForTesting(); err != nil {
+	if err := atlas.PutImagesOnAtlasForTesting(); err != nil {
 		t.Fatal(err)
 	}
 
 	// img1 is not on an atlas due to ReplacePixels.
-	img0.DrawTriangles([graphics.ShaderImageNum]*Image{img1}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	img0.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{img1}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 	if got, want := img1.IsOnAtlasForTesting(), false; got != want {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 
 	// Use img3 as a render source. As img3 is volatile, img3 is never on an atlas.
-	for i := 0; i < BaseCountToPutOnAtlas*2; i++ {
-		if err := PutImagesOnAtlasForTesting(); err != nil {
+	for i := 0; i < atlas.BaseCountToPutOnAtlas*2; i++ {
+		if err := atlas.PutImagesOnAtlasForTesting(); err != nil {
 			t.Fatal(err)
 		}
-		img0.DrawTriangles([graphics.ShaderImageNum]*Image{img3}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+		img0.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{img3}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 		if got, want := img3.IsOnAtlasForTesting(), false; got != want {
 			t.Errorf("got: %v, want: %v", got, want)
 		}
@@ -287,7 +287,7 @@ func TestReputOnAtlas(t *testing.T) {
 
 func TestExtend(t *testing.T) {
 	const w0, h0 = 100, 100
-	img0 := NewImage(w0, h0)
+	img0 := atlas.NewImage(w0, h0)
 	defer img0.MarkDisposed()
 
 	p0 := make([]byte, 4*w0*h0)
@@ -300,7 +300,7 @@ func TestExtend(t *testing.T) {
 	img0.ReplacePixels(p0)
 
 	const w1, h1 = minImageSizeForTesting + 1, 100
-	img1 := NewImage(w1, h1)
+	img1 := atlas.NewImage(w1, h1)
 	defer img1.MarkDisposed()
 
 	p1 := make([]byte, 4*w1*h1)
@@ -354,9 +354,9 @@ func TestExtend(t *testing.T) {
 
 func TestReplacePixelsAfterDrawTriangles(t *testing.T) {
 	const w, h = 256, 256
-	src := NewImage(w, h)
+	src := atlas.NewImage(w, h)
 	defer src.MarkDisposed()
-	dst := NewImage(w, h)
+	dst := atlas.NewImage(w, h)
 	defer dst.MarkDisposed()
 
 	pix := make([]byte, 4*w*h)
@@ -376,7 +376,7 @@ func TestReplacePixelsAfterDrawTriangles(t *testing.T) {
 		Width:  w,
 		Height: h,
 	}
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{src}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	dst.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{src}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 	dst.ReplacePixels(pix)
 
 	pix, err := dst.Pixels(0, 0, w, h)
@@ -402,9 +402,9 @@ func TestReplacePixelsAfterDrawTriangles(t *testing.T) {
 // Issue #887
 func TestSmallImages(t *testing.T) {
 	const w, h = 4, 8
-	src := NewImage(w, h)
+	src := atlas.NewImage(w, h)
 	defer src.MarkDisposed()
-	dst := NewImage(w, h)
+	dst := atlas.NewImage(w, h)
 	defer dst.MarkDisposed()
 
 	pix := make([]byte, 4*w*h)
@@ -424,7 +424,7 @@ func TestSmallImages(t *testing.T) {
 		Width:  w,
 		Height: h,
 	}
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{src}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeSourceOver, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	dst.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{src}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeSourceOver, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 
 	pix, err := dst.Pixels(0, 0, w, h)
 	if err != nil {
@@ -447,11 +447,11 @@ func TestSmallImages(t *testing.T) {
 // Issue #887
 func TestLongImages(t *testing.T) {
 	const w, h = 1, 6
-	src := NewImage(w, h)
+	src := atlas.NewImage(w, h)
 	defer src.MarkDisposed()
 
 	const dstW, dstH = 256, 256
-	dst := NewImage(dstW, dstH)
+	dst := atlas.NewImage(dstW, dstH)
 	defer dst.MarkDisposed()
 
 	pix := make([]byte, 4*w*h)
@@ -472,7 +472,7 @@ func TestLongImages(t *testing.T) {
 		Width:  dstW,
 		Height: dstH,
 	}
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{src}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeSourceOver, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	dst.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{src}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeSourceOver, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 
 	pix, err := dst.Pixels(0, 0, dstW, dstH)
 	if err != nil {
@@ -495,11 +495,11 @@ func TestLongImages(t *testing.T) {
 func TestDisposeImmediately(t *testing.T) {
 	// This tests restorable.Image.ClearPixels is called but ReplacePixels is not called.
 
-	img0 := NewImage(16, 16)
+	img0 := atlas.NewImage(16, 16)
 	img0.EnsureIsolatedForTesting()
 	defer img0.MarkDisposed()
 
-	img1 := NewImage(16, 16)
+	img1 := atlas.NewImage(16, 16)
 	img1.EnsureIsolatedForTesting()
 	defer img1.MarkDisposed()
 
@@ -508,12 +508,12 @@ func TestDisposeImmediately(t *testing.T) {
 
 // Issue #1028
 func TestExtendWithBigImage(t *testing.T) {
-	img0 := NewImage(1, 1)
+	img0 := atlas.NewImage(1, 1)
 	defer img0.MarkDisposed()
 
 	img0.ReplacePixels(make([]byte, 4*1*1))
 
-	img1 := NewImage(minImageSizeForTesting+1, minImageSizeForTesting+1)
+	img1 := atlas.NewImage(minImageSizeForTesting+1, minImageSizeForTesting+1)
 	defer img1.MarkDisposed()
 
 	img1.ReplacePixels(make([]byte, 4*(minImageSizeForTesting+1)*(minImageSizeForTesting+1)))
@@ -522,8 +522,8 @@ func TestExtendWithBigImage(t *testing.T) {
 // Issue #1217
 func TestMaxImageSize(t *testing.T) {
 	// This tests that a too-big image is allocated correctly.
-	s := maxImageSizeForTesting - 2*PaddingSize
-	img := NewImage(s, s)
+	s := maxImageSizeForTesting - 2*atlas.PaddingSize
+	img := atlas.NewImage(s, s)
 	defer img.MarkDisposed()
 	img.ReplacePixels(make([]byte, 4*s*s))
 }
@@ -536,7 +536,7 @@ func Disable_TestMinImageSize(t *testing.T) {
 	// This tests that extending a backend works correctly.
 	// Though the image size is minimum size of the backend, extending the backend happens due to the paddings.
 	s := minImageSizeForTesting
-	img := NewImage(s, s)
+	img := atlas.NewImage(s, s)
 	defer img.MarkDisposed()
 	img.ReplacePixels(make([]byte, 4*s*s))
 }
@@ -545,11 +545,11 @@ func Disable_TestMinImageSize(t *testing.T) {
 func TestDisposedAndReputOnAtlas(t *testing.T) {
 	const size = 16
 
-	src := NewImage(size, size)
+	src := atlas.NewImage(size, size)
 	defer src.MarkDisposed()
-	src2 := NewImage(size, size)
+	src2 := atlas.NewImage(size, size)
 	defer src2.MarkDisposed()
-	dst := NewImage(size, size)
+	dst := atlas.NewImage(size, size)
 	defer dst.MarkDisposed()
 
 	// Use src as a render target so that src is not on an atlas.
@@ -561,17 +561,17 @@ func TestDisposedAndReputOnAtlas(t *testing.T) {
 		Width:  size,
 		Height: size,
 	}
-	src.DrawTriangles([graphics.ShaderImageNum]*Image{src2}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	src.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{src2}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 	if got, want := src.IsOnAtlasForTesting(), false; got != want {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 
 	// Use src as a render source.
-	for i := 0; i < BaseCountToPutOnAtlas/2; i++ {
-		if err := PutImagesOnAtlasForTesting(); err != nil {
+	for i := 0; i < atlas.BaseCountToPutOnAtlas/2; i++ {
+		if err := atlas.PutImagesOnAtlasForTesting(); err != nil {
 			t.Fatal(err)
 		}
-		dst.DrawTriangles([graphics.ShaderImageNum]*Image{src}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+		dst.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{src}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 		if got, want := src.IsOnAtlasForTesting(), false; got != want {
 			t.Errorf("got: %v, want: %v", got, want)
 		}
@@ -581,10 +581,10 @@ func TestDisposedAndReputOnAtlas(t *testing.T) {
 	src.MarkDisposed()
 
 	// Force to dispose the image.
-	ResolveDeferredForTesting()
+	atlas.ResolveDeferredForTesting()
 
 	// Confirm that PutImagesOnAtlasForTesting doesn't panic.
-	if err := PutImagesOnAtlasForTesting(); err != nil {
+	if err := atlas.PutImagesOnAtlasForTesting(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -593,11 +593,11 @@ func TestDisposedAndReputOnAtlas(t *testing.T) {
 func TestImageIsNotReputOnAtlasWithoutUsingAsSource(t *testing.T) {
 	const size = 16
 
-	src := NewImage(size, size)
+	src := atlas.NewImage(size, size)
 	defer src.MarkDisposed()
-	src2 := NewImage(size, size)
+	src2 := atlas.NewImage(size, size)
 	defer src2.MarkDisposed()
-	dst := NewImage(size, size)
+	dst := atlas.NewImage(size, size)
 	defer dst.MarkDisposed()
 
 	// Use src as a render target so that src is not on an atlas.
@@ -611,15 +611,15 @@ func TestImageIsNotReputOnAtlasWithoutUsingAsSource(t *testing.T) {
 	}
 
 	// Use src2 as a rendering target, and make src2 an independent image.
-	src2.DrawTriangles([graphics.ShaderImageNum]*Image{src}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	src2.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{src}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 	if got, want := src2.IsOnAtlasForTesting(), false; got != want {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 
 	// Update the count without using src2 as a rendering source.
 	// This should not affect whether src2 is on an atlas or not.
-	for i := 0; i < BaseCountToPutOnAtlas; i++ {
-		if err := PutImagesOnAtlasForTesting(); err != nil {
+	for i := 0; i < atlas.BaseCountToPutOnAtlas; i++ {
+		if err := atlas.PutImagesOnAtlasForTesting(); err != nil {
 			t.Fatal(err)
 		}
 		if got, want := src2.IsOnAtlasForTesting(), false; got != want {
@@ -628,17 +628,17 @@ func TestImageIsNotReputOnAtlasWithoutUsingAsSource(t *testing.T) {
 	}
 
 	// Update the count with using src2 as a rendering source.
-	for i := 0; i < BaseCountToPutOnAtlas; i++ {
-		if err := PutImagesOnAtlasForTesting(); err != nil {
+	for i := 0; i < atlas.BaseCountToPutOnAtlas; i++ {
+		if err := atlas.PutImagesOnAtlasForTesting(); err != nil {
 			t.Fatal(err)
 		}
-		dst.DrawTriangles([graphics.ShaderImageNum]*Image{src2}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+		dst.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{src2}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 		if got, want := src2.IsOnAtlasForTesting(), false; got != want {
 			t.Errorf("got: %v, want: %v", got, want)
 		}
 	}
 
-	if err := PutImagesOnAtlasForTesting(); err != nil {
+	if err := atlas.PutImagesOnAtlasForTesting(); err != nil {
 		t.Fatal(err)
 	}
 	if got, want := src2.IsOnAtlasForTesting(), true; got != want {

--- a/internal/atlas/shader_test.go
+++ b/internal/atlas/shader_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/hajimehoshi/ebiten/v2/internal/affine"
-	. "github.com/hajimehoshi/ebiten/v2/internal/atlas"
+	"github.com/hajimehoshi/ebiten/v2/internal/atlas"
 	"github.com/hajimehoshi/ebiten/v2/internal/driver"
 	"github.com/hajimehoshi/ebiten/v2/internal/graphics"
 	etesting "github.com/hajimehoshi/ebiten/v2/internal/testing"
@@ -28,7 +28,7 @@ import (
 func TestShaderFillTwice(t *testing.T) {
 	const w, h = 1, 1
 
-	dst := NewImage(w, h)
+	dst := atlas.NewImage(w, h)
 
 	vs := quadVertices(w, h, 0, 0, 1)
 	is := graphics.QuadIndices()
@@ -39,14 +39,14 @@ func TestShaderFillTwice(t *testing.T) {
 		Height: h,
 	}
 	p0 := etesting.ShaderProgramFill(0xff, 0xff, 0xff, 0xff)
-	s0 := NewShader(&p0)
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, s0, nil, false)
+	s0 := atlas.NewShader(&p0)
+	dst.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, s0, nil, false)
 
 	// Vertices must be recreated (#1755)
 	vs = quadVertices(w, h, 0, 0, 1)
 	p1 := etesting.ShaderProgramFill(0x80, 0x80, 0x80, 0xff)
-	s1 := NewShader(&p1)
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, s1, nil, false)
+	s1 := atlas.NewShader(&p1)
+	dst.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, s1, nil, false)
 
 	pix, err := dst.Pixels(0, 0, w, h)
 	if err != nil {
@@ -60,10 +60,10 @@ func TestShaderFillTwice(t *testing.T) {
 func TestImageDrawTwice(t *testing.T) {
 	const w, h = 1, 1
 
-	dst := NewImage(w, h)
-	src0 := NewImage(w, h)
+	dst := atlas.NewImage(w, h)
+	src0 := atlas.NewImage(w, h)
 	src0.ReplacePixels([]byte{0xff, 0xff, 0xff, 0xff})
-	src1 := NewImage(w, h)
+	src1 := atlas.NewImage(w, h)
 	src1.ReplacePixels([]byte{0x80, 0x80, 0x80, 0xff})
 
 	vs := quadVertices(w, h, 0, 0, 1)
@@ -74,11 +74,11 @@ func TestImageDrawTwice(t *testing.T) {
 		Width:  w,
 		Height: h,
 	}
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{src0}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	dst.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{src0}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 
 	// Vertices must be recreated (#1755)
 	vs = quadVertices(w, h, 0, 0, 1)
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{src1}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
+	dst.DrawTriangles([graphics.ShaderImageNum]*atlas.Image{src1}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, [graphics.ShaderImageNum - 1][2]float32{}, nil, nil, false)
 
 	pix, err := dst.Pixels(0, 0, w, h)
 	if err != nil {

--- a/internal/graphics/math_test.go
+++ b/internal/graphics/math_test.go
@@ -17,7 +17,7 @@ package graphics_test
 import (
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2/internal/graphics"
+	"github.com/hajimehoshi/ebiten/v2/internal/graphics"
 )
 
 func TestInternalImageSize(t *testing.T) {
@@ -31,7 +31,7 @@ func TestInternalImageSize(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		got := InternalImageSize(testCase.arg)
+		got := graphics.InternalImageSize(testCase.arg)
 		wanted := testCase.expected
 		if wanted != got {
 			t.Errorf("Clp(%d) = %d, wanted %d", testCase.arg, got, wanted)

--- a/internal/graphicscommand/image_test.go
+++ b/internal/graphicscommand/image_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/internal/affine"
 	"github.com/hajimehoshi/ebiten/v2/internal/driver"
 	"github.com/hajimehoshi/ebiten/v2/internal/graphics"
-	. "github.com/hajimehoshi/ebiten/v2/internal/graphicscommand"
+	"github.com/hajimehoshi/ebiten/v2/internal/graphicscommand"
 	etesting "github.com/hajimehoshi/ebiten/v2/internal/testing"
 )
 
@@ -40,8 +40,8 @@ func quadVertices(w, h float32) []float32 {
 
 func TestClear(t *testing.T) {
 	const w, h = 1024, 1024
-	src := NewImage(w/2, h/2)
-	dst := NewImage(w, h)
+	src := graphicscommand.NewImage(w/2, h/2)
+	dst := graphicscommand.NewImage(w, h)
 
 	vs := quadVertices(w/2, h/2)
 	is := graphics.QuadIndices()
@@ -51,7 +51,7 @@ func TestClear(t *testing.T) {
 		Width:  w,
 		Height: h,
 	}
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{src}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeClear, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, nil, nil, false)
+	dst.DrawTriangles([graphics.ShaderImageNum]*graphicscommand.Image{src}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeClear, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, nil, nil, false)
 
 	pix, err := dst.Pixels()
 	if err != nil {
@@ -71,9 +71,9 @@ func TestClear(t *testing.T) {
 
 func TestReplacePixelsPartAfterDrawTriangles(t *testing.T) {
 	const w, h = 32, 32
-	clr := NewImage(w, h)
-	src := NewImage(w/2, h/2)
-	dst := NewImage(w, h)
+	clr := graphicscommand.NewImage(w, h)
+	src := graphicscommand.NewImage(w/2, h/2)
+	dst := graphicscommand.NewImage(w, h)
 	vs := quadVertices(w/2, h/2)
 	is := graphics.QuadIndices()
 	dr := driver.Region{
@@ -82,8 +82,8 @@ func TestReplacePixelsPartAfterDrawTriangles(t *testing.T) {
 		Width:  w,
 		Height: h,
 	}
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{clr}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeClear, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, nil, nil, false)
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{src}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeSourceOver, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, nil, nil, false)
+	dst.DrawTriangles([graphics.ShaderImageNum]*graphicscommand.Image{clr}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeClear, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, nil, nil, false)
+	dst.DrawTriangles([graphics.ShaderImageNum]*graphicscommand.Image{src}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeSourceOver, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, nil, nil, false)
 	dst.ReplacePixels(make([]byte, 4), 0, 0, 1, 1)
 
 	// TODO: Check the result.
@@ -91,8 +91,8 @@ func TestReplacePixelsPartAfterDrawTriangles(t *testing.T) {
 
 func TestShader(t *testing.T) {
 	const w, h = 16, 16
-	clr := NewImage(w, h)
-	dst := NewImage(w, h)
+	clr := graphicscommand.NewImage(w, h)
+	dst := graphicscommand.NewImage(w, h)
 	vs := quadVertices(w, h)
 	is := graphics.QuadIndices()
 	dr := driver.Region{
@@ -101,11 +101,11 @@ func TestShader(t *testing.T) {
 		Width:  w,
 		Height: h,
 	}
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{clr}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeClear, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, nil, nil, false)
+	dst.DrawTriangles([graphics.ShaderImageNum]*graphicscommand.Image{clr}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeClear, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, nil, nil, false)
 
 	ir := etesting.ShaderProgramFill(0xff, 0, 0, 0xff)
-	s := NewShader(&ir)
-	dst.DrawTriangles([graphics.ShaderImageNum]*Image{}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeSourceOver, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, s, nil, false)
+	s := graphicscommand.NewShader(&ir)
+	dst.DrawTriangles([graphics.ShaderImageNum]*graphicscommand.Image{}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeSourceOver, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, s, nil, false)
 
 	pix, err := dst.Pixels()
 	if err != nil {

--- a/internal/packing/packing_test.go
+++ b/internal/packing/packing_test.go
@@ -17,7 +17,7 @@ package packing_test
 import (
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2/internal/packing"
+	"github.com/hajimehoshi/ebiten/v2/internal/packing"
 )
 
 func TestPage(t *testing.T) {
@@ -211,8 +211,8 @@ func TestPage(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		p := NewPage(1024, 1024)
-		nodes := []*Node{}
+		p := packing.NewPage(1024, 1024)
+		nodes := []*packing.Node{}
 		nnodes := 0
 		for i, in := range c.In {
 			if in.FreeNodeID == -1 {
@@ -254,7 +254,7 @@ func TestPage(t *testing.T) {
 }
 
 func TestExtend(t *testing.T) {
-	p := NewPage(1024, 4096)
+	p := packing.NewPage(1024, 4096)
 	s := p.Size()
 	p.Alloc(s/2, s/2)
 	p.Extend(1)
@@ -289,7 +289,7 @@ func TestExtend(t *testing.T) {
 }
 
 func TestExtend2(t *testing.T) {
-	p := NewPage(1024, 4096)
+	p := packing.NewPage(1024, 4096)
 	s := p.Size()
 	p.Alloc(s/2, s/2)
 	n1 := p.Alloc(s/2, s/2)
@@ -331,7 +331,7 @@ func TestExtend2(t *testing.T) {
 
 // Issue #1454
 func TestExtendTooMuch(t *testing.T) {
-	p := NewPage(1024, 4096)
+	p := packing.NewPage(1024, 4096)
 	p.Alloc(1, 1)
 	if got, want := p.Extend(3), false; got != want {
 		t.Errorf("got: %t, want: %t", got, want)
@@ -339,7 +339,7 @@ func TestExtendTooMuch(t *testing.T) {
 }
 
 func TestExtendWithoutAllocation(t *testing.T) {
-	p := NewPage(1024, 4096)
+	p := packing.NewPage(1024, 4096)
 
 	if got, want := p.Extend(2), true; got != want {
 		t.Errorf("got: %t, want: %t", got, want)

--- a/internal/restorable/shader_test.go
+++ b/internal/restorable/shader_test.go
@@ -21,12 +21,12 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/internal/affine"
 	"github.com/hajimehoshi/ebiten/v2/internal/driver"
 	"github.com/hajimehoshi/ebiten/v2/internal/graphics"
-	. "github.com/hajimehoshi/ebiten/v2/internal/restorable"
+	"github.com/hajimehoshi/ebiten/v2/internal/restorable"
 	etesting "github.com/hajimehoshi/ebiten/v2/internal/testing"
 )
 
-func clearImage(img *Image, w, h int) {
-	emptyImage := NewImage(3, 3)
+func clearImage(img *restorable.Image, w, h int) {
+	emptyImage := restorable.NewImage(3, 3)
 	defer emptyImage.Dispose()
 
 	dx0 := float32(0)
@@ -50,27 +50,27 @@ func clearImage(img *Image, w, h int) {
 		Width:  float32(w),
 		Height: float32(h),
 	}
-	img.DrawTriangles([graphics.ShaderImageNum]*Image{emptyImage}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeClear, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, nil, nil, false)
+	img.DrawTriangles([graphics.ShaderImageNum]*restorable.Image{emptyImage}, [graphics.ShaderImageNum - 1][2]float32{}, vs, is, affine.ColorMIdentity{}, driver.CompositeModeClear, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, nil, nil, false)
 }
 
 func TestShader(t *testing.T) {
-	img := NewImage(1, 1)
+	img := restorable.NewImage(1, 1)
 	defer img.Dispose()
 
 	ir := etesting.ShaderProgramFill(0xff, 0, 0, 0xff)
-	s := NewShader(&ir)
+	s := restorable.NewShader(&ir)
 	dr := driver.Region{
 		X:      0,
 		Y:      0,
 		Width:  1,
 		Height: 1,
 	}
-	img.DrawTriangles([graphics.ShaderImageNum]*Image{}, [graphics.ShaderImageNum - 1][2]float32{}, quadVertices(1, 1, 0, 0), graphics.QuadIndices(), nil, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, s, nil, false)
+	img.DrawTriangles([graphics.ShaderImageNum]*restorable.Image{}, [graphics.ShaderImageNum - 1][2]float32{}, quadVertices(1, 1, 0, 0), graphics.QuadIndices(), nil, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, s, nil, false)
 
-	if err := ResolveStaleImages(); err != nil {
+	if err := restorable.ResolveStaleImages(); err != nil {
 		t.Fatal(err)
 	}
-	if err := RestoreIfNeeded(); err != nil {
+	if err := restorable.RestoreIfNeeded(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -83,9 +83,9 @@ func TestShader(t *testing.T) {
 
 func TestShaderChain(t *testing.T) {
 	const num = 10
-	imgs := []*Image{}
+	imgs := []*restorable.Image{}
 	for i := 0; i < num; i++ {
-		img := NewImage(1, 1)
+		img := restorable.NewImage(1, 1)
 		defer img.Dispose()
 		imgs = append(imgs, img)
 	}
@@ -93,7 +93,7 @@ func TestShaderChain(t *testing.T) {
 	imgs[0].ReplacePixels([]byte{0xff, 0, 0, 0xff}, 0, 0, 1, 1)
 
 	ir := etesting.ShaderProgramImages(1)
-	s := NewShader(&ir)
+	s := restorable.NewShader(&ir)
 	for i := 0; i < num-1; i++ {
 		dr := driver.Region{
 			X:      0,
@@ -101,13 +101,13 @@ func TestShaderChain(t *testing.T) {
 			Width:  1,
 			Height: 1,
 		}
-		imgs[i+1].DrawTriangles([graphics.ShaderImageNum]*Image{imgs[i]}, [graphics.ShaderImageNum - 1][2]float32{}, quadVertices(1, 1, 0, 0), graphics.QuadIndices(), nil, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, s, nil, false)
+		imgs[i+1].DrawTriangles([graphics.ShaderImageNum]*restorable.Image{imgs[i]}, [graphics.ShaderImageNum - 1][2]float32{}, quadVertices(1, 1, 0, 0), graphics.QuadIndices(), nil, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, s, nil, false)
 	}
 
-	if err := ResolveStaleImages(); err != nil {
+	if err := restorable.ResolveStaleImages(); err != nil {
 		t.Fatal(err)
 	}
-	if err := RestoreIfNeeded(); err != nil {
+	if err := restorable.RestoreIfNeeded(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -121,18 +121,18 @@ func TestShaderChain(t *testing.T) {
 }
 
 func TestShaderMultipleSources(t *testing.T) {
-	var srcs [graphics.ShaderImageNum]*Image
+	var srcs [graphics.ShaderImageNum]*restorable.Image
 	for i := range srcs {
-		srcs[i] = NewImage(1, 1)
+		srcs[i] = restorable.NewImage(1, 1)
 	}
 	srcs[0].ReplacePixels([]byte{0x40, 0, 0, 0xff}, 0, 0, 1, 1)
 	srcs[1].ReplacePixels([]byte{0, 0x80, 0, 0xff}, 0, 0, 1, 1)
 	srcs[2].ReplacePixels([]byte{0, 0, 0xc0, 0xff}, 0, 0, 1, 1)
 
-	dst := NewImage(1, 1)
+	dst := restorable.NewImage(1, 1)
 
 	ir := etesting.ShaderProgramImages(3)
-	s := NewShader(&ir)
+	s := restorable.NewShader(&ir)
 	var offsets [graphics.ShaderImageNum - 1][2]float32
 	dr := driver.Region{
 		X:      0,
@@ -145,10 +145,10 @@ func TestShaderMultipleSources(t *testing.T) {
 	// Clear one of the sources after DrawTriangles. dst should not be affected.
 	clearImage(srcs[0], 1, 1)
 
-	if err := ResolveStaleImages(); err != nil {
+	if err := restorable.ResolveStaleImages(); err != nil {
 		t.Fatal(err)
 	}
-	if err := RestoreIfNeeded(); err != nil {
+	if err := restorable.RestoreIfNeeded(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -160,18 +160,18 @@ func TestShaderMultipleSources(t *testing.T) {
 }
 
 func TestShaderMultipleSourcesOnOneTexture(t *testing.T) {
-	src := NewImage(3, 1)
+	src := restorable.NewImage(3, 1)
 	src.ReplacePixels([]byte{
 		0x40, 0, 0, 0xff,
 		0, 0x80, 0, 0xff,
 		0, 0, 0xc0, 0xff,
 	}, 0, 0, 3, 1)
-	srcs := [graphics.ShaderImageNum]*Image{src, src, src}
+	srcs := [graphics.ShaderImageNum]*restorable.Image{src, src, src}
 
-	dst := NewImage(1, 1)
+	dst := restorable.NewImage(1, 1)
 
 	ir := etesting.ShaderProgramImages(3)
-	s := NewShader(&ir)
+	s := restorable.NewShader(&ir)
 	offsets := [graphics.ShaderImageNum - 1][2]float32{
 		{1, 0},
 		{2, 0},
@@ -187,10 +187,10 @@ func TestShaderMultipleSourcesOnOneTexture(t *testing.T) {
 	// Clear one of the sources after DrawTriangles. dst should not be affected.
 	clearImage(srcs[0], 3, 1)
 
-	if err := ResolveStaleImages(); err != nil {
+	if err := restorable.ResolveStaleImages(); err != nil {
 		t.Fatal(err)
 	}
-	if err := RestoreIfNeeded(); err != nil {
+	if err := restorable.RestoreIfNeeded(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -202,27 +202,27 @@ func TestShaderMultipleSourcesOnOneTexture(t *testing.T) {
 }
 
 func TestShaderDispose(t *testing.T) {
-	img := NewImage(1, 1)
+	img := restorable.NewImage(1, 1)
 	defer img.Dispose()
 
 	ir := etesting.ShaderProgramFill(0xff, 0, 0, 0xff)
-	s := NewShader(&ir)
+	s := restorable.NewShader(&ir)
 	dr := driver.Region{
 		X:      0,
 		Y:      0,
 		Width:  1,
 		Height: 1,
 	}
-	img.DrawTriangles([graphics.ShaderImageNum]*Image{}, [graphics.ShaderImageNum - 1][2]float32{}, quadVertices(1, 1, 0, 0), graphics.QuadIndices(), nil, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, s, nil, false)
+	img.DrawTriangles([graphics.ShaderImageNum]*restorable.Image{}, [graphics.ShaderImageNum - 1][2]float32{}, quadVertices(1, 1, 0, 0), graphics.QuadIndices(), nil, driver.CompositeModeCopy, driver.FilterNearest, driver.AddressUnsafe, dr, driver.Region{}, s, nil, false)
 
 	// Dispose the shader. This should invalidates all the images using this shader i.e., all the images become
 	// stale.
 	s.Dispose()
 
-	if err := ResolveStaleImages(); err != nil {
+	if err := restorable.ResolveStaleImages(); err != nil {
 		t.Fatal(err)
 	}
-	if err := RestoreIfNeeded(); err != nil {
+	if err := restorable.RestoreIfNeeded(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2/internal/shader"
+	"github.com/hajimehoshi/ebiten/v2/internal/shader"
 	"github.com/hajimehoshi/ebiten/v2/internal/shaderir/glsl"
 	"github.com/hajimehoshi/ebiten/v2/internal/shaderir/metal"
 )
@@ -150,7 +150,7 @@ func TestCompile(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			s, err := Compile(fset, f, "Vertex", "Fragment", 0)
+			s, err := shader.Compile(fset, f, "Vertex", "Fragment", 0)
 			if err != nil {
 				t.Error(err)
 				return

--- a/internal/shaderir/ir_test.go
+++ b/internal/shaderir/ir_test.go
@@ -18,59 +18,59 @@ import (
 	"go/constant"
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2/internal/shaderir"
+	"github.com/hajimehoshi/ebiten/v2/internal/shaderir"
 	"github.com/hajimehoshi/ebiten/v2/internal/shaderir/glsl"
 	"github.com/hajimehoshi/ebiten/v2/internal/shaderir/metal"
 )
 
-func block(localVars []Type, offset int, stmts ...Stmt) *Block {
-	return &Block{
+func block(localVars []shaderir.Type, offset int, stmts ...shaderir.Stmt) *shaderir.Block {
+	return &shaderir.Block{
 		LocalVars:           localVars,
 		LocalVarIndexOffset: offset,
 		Stmts:               stmts,
 	}
 }
 
-func exprStmt(expr Expr) Stmt {
-	return Stmt{
-		Type:  ExprStmt,
-		Exprs: []Expr{expr},
+func exprStmt(expr shaderir.Expr) shaderir.Stmt {
+	return shaderir.Stmt{
+		Type:  shaderir.ExprStmt,
+		Exprs: []shaderir.Expr{expr},
 	}
 }
 
-func blockStmt(block *Block) Stmt {
-	return Stmt{
-		Type:   BlockStmt,
-		Blocks: []*Block{block},
+func blockStmt(block *shaderir.Block) shaderir.Stmt {
+	return shaderir.Stmt{
+		Type:   shaderir.BlockStmt,
+		Blocks: []*shaderir.Block{block},
 	}
 }
 
-func returnStmt(expr Expr) Stmt {
-	return Stmt{
-		Type:  Return,
-		Exprs: []Expr{expr},
+func returnStmt(expr shaderir.Expr) shaderir.Stmt {
+	return shaderir.Stmt{
+		Type:  shaderir.Return,
+		Exprs: []shaderir.Expr{expr},
 	}
 }
 
-func assignStmt(lhs Expr, rhs Expr) Stmt {
-	return Stmt{
-		Type:  Assign,
-		Exprs: []Expr{lhs, rhs},
+func assignStmt(lhs shaderir.Expr, rhs shaderir.Expr) shaderir.Stmt {
+	return shaderir.Stmt{
+		Type:  shaderir.Assign,
+		Exprs: []shaderir.Expr{lhs, rhs},
 	}
 }
 
-func ifStmt(cond Expr, block *Block, elseBlock *Block) Stmt {
-	return Stmt{
-		Type:   If,
-		Exprs:  []Expr{cond},
-		Blocks: []*Block{block, elseBlock},
+func ifStmt(cond shaderir.Expr, block *shaderir.Block, elseBlock *shaderir.Block) shaderir.Stmt {
+	return shaderir.Stmt{
+		Type:   shaderir.If,
+		Exprs:  []shaderir.Expr{cond},
+		Blocks: []*shaderir.Block{block, elseBlock},
 	}
 }
 
-func forStmt(t Type, index, init, end int, op Op, delta int, block *Block) Stmt {
-	return Stmt{
-		Type:        For,
-		Blocks:      []*Block{block},
+func forStmt(t shaderir.Type, index, init, end int, op shaderir.Op, delta int, block *shaderir.Block) shaderir.Stmt {
+	return shaderir.Stmt{
+		Type:        shaderir.For,
+		Blocks:      []*shaderir.Block{block},
 		ForVarType:  t,
 		ForVarIndex: index,
 		ForInit:     constant.MakeInt64(int64(init)),
@@ -80,74 +80,74 @@ func forStmt(t Type, index, init, end int, op Op, delta int, block *Block) Stmt 
 	}
 }
 
-func floatExpr(value float32) Expr {
-	return Expr{
-		Type:  NumberExpr,
+func floatExpr(value float32) shaderir.Expr {
+	return shaderir.Expr{
+		Type:  shaderir.NumberExpr,
 		Const: constant.MakeFloat64(float64(value)),
 	}
 }
 
-func uniformVariableExpr(index int) Expr {
-	return Expr{
-		Type:  UniformVariable,
+func uniformVariableExpr(index int) shaderir.Expr {
+	return shaderir.Expr{
+		Type:  shaderir.UniformVariable,
 		Index: index,
 	}
 }
 
-func localVariableExpr(index int) Expr {
-	return Expr{
-		Type:  LocalVariable,
+func localVariableExpr(index int) shaderir.Expr {
+	return shaderir.Expr{
+		Type:  shaderir.LocalVariable,
 		Index: index,
 	}
 }
 
-func builtinFuncExpr(f BuiltinFunc) Expr {
-	return Expr{
-		Type:        BuiltinFuncExpr,
+func builtinFuncExpr(f shaderir.BuiltinFunc) shaderir.Expr {
+	return shaderir.Expr{
+		Type:        shaderir.BuiltinFuncExpr,
 		BuiltinFunc: f,
 	}
 }
 
-func swizzlingExpr(swizzling string) Expr {
-	return Expr{
-		Type:      SwizzlingExpr,
+func swizzlingExpr(swizzling string) shaderir.Expr {
+	return shaderir.Expr{
+		Type:      shaderir.SwizzlingExpr,
 		Swizzling: swizzling,
 	}
 }
 
-func functionExpr(index int) Expr {
-	return Expr{
-		Type:  FunctionExpr,
+func functionExpr(index int) shaderir.Expr {
+	return shaderir.Expr{
+		Type:  shaderir.FunctionExpr,
 		Index: index,
 	}
 }
 
-func binaryExpr(op Op, exprs ...Expr) Expr {
-	return Expr{
-		Type:  Binary,
+func binaryExpr(op shaderir.Op, exprs ...shaderir.Expr) shaderir.Expr {
+	return shaderir.Expr{
+		Type:  shaderir.Binary,
 		Op:    op,
 		Exprs: exprs,
 	}
 }
 
-func selectionExpr(cond, a, b Expr) Expr {
-	return Expr{
-		Type:  Selection,
-		Exprs: []Expr{cond, a, b},
+func selectionExpr(cond, a, b shaderir.Expr) shaderir.Expr {
+	return shaderir.Expr{
+		Type:  shaderir.Selection,
+		Exprs: []shaderir.Expr{cond, a, b},
 	}
 }
 
-func callExpr(callee Expr, args ...Expr) Expr {
-	return Expr{
-		Type:  Call,
-		Exprs: append([]Expr{callee}, args...),
+func callExpr(callee shaderir.Expr, args ...shaderir.Expr) shaderir.Expr {
+	return shaderir.Expr{
+		Type:  shaderir.Call,
+		Exprs: append([]shaderir.Expr{callee}, args...),
 	}
 }
 
-func fieldSelectorExpr(a, b Expr) Expr {
-	return Expr{
-		Type:  FieldSelector,
-		Exprs: []Expr{a, b},
+func fieldSelectorExpr(a, b shaderir.Expr) shaderir.Expr {
+	return shaderir.Expr{
+		Type:  shaderir.FieldSelector,
+		Exprs: []shaderir.Expr{a, b},
 	}
 }
 
@@ -156,22 +156,22 @@ func TestOutput(t *testing.T) {
 
 	tests := []struct {
 		Name    string
-		Program Program
+		Program shaderir.Program
 		GlslVS  string
 		GlslFS  string
 		Metal   string
 	}{
 		{
 			Name:    "Empty",
-			Program: Program{},
+			Program: shaderir.Program{},
 			GlslVS:  ``,
 			GlslFS:  glsl.FragmentPrelude(glsl.GLSLVersionDefault),
 		},
 		{
 			Name: "Uniform",
-			Program: Program{
-				Uniforms: []Type{
-					{Main: Float},
+			Program: shaderir.Program{
+				Uniforms: []shaderir.Type{
+					{Main: shaderir.Float},
 				},
 			},
 			GlslVS: `uniform float U0;`,
@@ -180,12 +180,12 @@ uniform float U0;`,
 		},
 		{
 			Name: "UniformStruct",
-			Program: Program{
-				Uniforms: []Type{
+			Program: shaderir.Program{
+				Uniforms: []shaderir.Type{
 					{
-						Main: Struct,
-						Sub: []Type{
-							{Main: Float},
+						Main: shaderir.Struct,
+						Sub: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
 					},
 				},
@@ -204,15 +204,15 @@ uniform S0 U0;`,
 		},
 		{
 			Name: "Vars",
-			Program: Program{
-				Uniforms: []Type{
-					{Main: Float},
+			Program: shaderir.Program{
+				Uniforms: []shaderir.Type{
+					{Main: shaderir.Float},
 				},
-				Attributes: []Type{
-					{Main: Vec2},
+				Attributes: []shaderir.Type{
+					{Main: shaderir.Vec2},
 				},
-				Varyings: []Type{
-					{Main: Vec3},
+				Varyings: []shaderir.Type{
+					{Main: shaderir.Vec3},
 				},
 			},
 			GlslVS: `uniform float U0;
@@ -224,8 +224,8 @@ varying vec3 V0;`,
 		},
 		{
 			Name: "Func",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
 					},
@@ -243,17 +243,17 @@ void F0(void) {
 		},
 		{
 			Name: "FuncParams",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Float},
-							{Main: Vec2},
-							{Main: Vec4},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Float},
+							{Main: shaderir.Vec2},
+							{Main: shaderir.Vec4},
 						},
-						OutParams: []Type{
-							{Main: Mat4},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Mat4},
 						},
 					},
 				},
@@ -270,14 +270,14 @@ void F0(in float l0, in vec2 l1, in vec4 l2, out mat4 l3) {
 		},
 		{
 			Name: "FuncReturn",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Float},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
-						Return: Type{Main: Float},
+						Return: shaderir.Type{Main: shaderir.Float},
 						Block: block(
 							nil,
 							1,
@@ -302,19 +302,19 @@ float F0(in float l0) {
 		},
 		{
 			Name: "FuncLocals",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Float},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
-						OutParams: []Type{
-							{Main: Float},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
-						Block: block([]Type{
-							{Main: Mat4},
-							{Main: Mat4},
+						Block: block([]shaderir.Type{
+							{Main: shaderir.Mat4},
+							{Main: shaderir.Mat4},
 						}, 2),
 					},
 				},
@@ -335,27 +335,27 @@ void F0(in float l0, out float l1) {
 		},
 		{
 			Name: "FuncBlocks",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Float},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
-						OutParams: []Type{
-							{Main: Float},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
 						Block: block(
-							[]Type{
-								{Main: Mat4},
-								{Main: Mat4},
+							[]shaderir.Type{
+								{Main: shaderir.Mat4},
+								{Main: shaderir.Mat4},
 							},
 							2,
 							blockStmt(
 								block(
-									[]Type{
-										{Main: Mat4},
-										{Main: Mat4},
+									[]shaderir.Type{
+										{Main: shaderir.Mat4},
+										{Main: shaderir.Mat4},
 									},
 									4,
 								),
@@ -388,16 +388,16 @@ void F0(in float l0, out float l1) {
 		},
 		{
 			Name: "Add",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Float},
-							{Main: Float},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Float},
+							{Main: shaderir.Float},
 						},
-						OutParams: []Type{
-							{Main: Float},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
 						Block: block(
 							nil,
@@ -405,7 +405,7 @@ void F0(in float l0, out float l1) {
 							assignStmt(
 								localVariableExpr(2),
 								binaryExpr(
-									Add,
+									shaderir.Add,
 									localVariableExpr(0),
 									localVariableExpr(1),
 								),
@@ -428,17 +428,17 @@ void F0(in float l0, in float l1, out float l2) {
 		},
 		{
 			Name: "Selection",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Bool},
-							{Main: Float},
-							{Main: Float},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Bool},
+							{Main: shaderir.Float},
+							{Main: shaderir.Float},
 						},
-						OutParams: []Type{
-							{Main: Float},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
 						Block: block(
 							nil,
@@ -469,16 +469,16 @@ void F0(in bool l0, in float l1, in float l2, out float l3) {
 		},
 		{
 			Name: "Call",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Float},
-							{Main: Float},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Float},
+							{Main: shaderir.Float},
 						},
-						OutParams: []Type{
-							{Main: Vec2},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Vec2},
 						},
 						Block: block(
 							nil,
@@ -516,16 +516,16 @@ void F0(in float l0, in float l1, out vec2 l2) {
 		},
 		{
 			Name: "BuiltinFunc",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Float},
-							{Main: Float},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Float},
+							{Main: shaderir.Float},
 						},
-						OutParams: []Type{
-							{Main: Float},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
 						Block: block(
 							nil,
@@ -533,7 +533,7 @@ void F0(in float l0, in float l1, out vec2 l2) {
 							assignStmt(
 								localVariableExpr(2),
 								callExpr(
-									builtinFuncExpr(Min),
+									builtinFuncExpr(shaderir.Min),
 									localVariableExpr(0),
 									localVariableExpr(1),
 								),
@@ -556,15 +556,15 @@ void F0(in float l0, in float l1, out float l2) {
 		},
 		{
 			Name: "FieldSelector",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Vec4},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Vec4},
 						},
-						OutParams: []Type{
-							{Main: Vec2},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Vec2},
 						},
 						Block: block(
 							nil,
@@ -594,23 +594,23 @@ void F0(in vec4 l0, out vec2 l1) {
 		},
 		{
 			Name: "If",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Float},
-							{Main: Float},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Float},
+							{Main: shaderir.Float},
 						},
-						OutParams: []Type{
-							{Main: Float},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
 						Block: block(
 							nil,
 							3,
 							ifStmt(
 								binaryExpr(
-									EqualOp,
+									shaderir.EqualOp,
 									localVariableExpr(0),
 									floatExpr(0),
 								),
@@ -657,28 +657,28 @@ void F0(in float l0, in float l1, out float l2) {
 		},
 		{
 			Name: "For",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Float},
-							{Main: Float},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Float},
+							{Main: shaderir.Float},
 						},
-						OutParams: []Type{
-							{Main: Float},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
 						Block: block(
-							[]Type{
+							[]shaderir.Type{
 								{},
 							},
 							3,
 							forStmt(
-								Type{Main: Int},
+								shaderir.Type{Main: shaderir.Int},
 								3,
 								0,
 								100,
-								LessThanOp,
+								shaderir.LessThanOp,
 								1,
 								block(
 									nil,
@@ -711,32 +711,32 @@ void F0(in float l0, in float l1, out float l2) {
 		},
 		{
 			Name: "For2",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Float},
-							{Main: Float},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Float},
+							{Main: shaderir.Float},
 						},
-						OutParams: []Type{
-							{Main: Float},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
 						Block: block(
-							[]Type{
+							[]shaderir.Type{
 								{},
 							},
 							3,
 							forStmt(
-								Type{Main: Int},
+								shaderir.Type{Main: shaderir.Int},
 								3,
 								0,
 								100,
-								LessThanOp,
+								shaderir.LessThanOp,
 								1,
 								block(
-									[]Type{
-										{Main: Int},
+									[]shaderir.Type{
+										{Main: shaderir.Int},
 									},
 									4,
 									assignStmt(
@@ -783,33 +783,33 @@ void F0(float l0, float l1, thread float& l2) {
 		},
 		{
 			Name: "For3",
-			Program: Program{
-				Funcs: []Func{
+			Program: shaderir.Program{
+				Funcs: []shaderir.Func{
 					{
 						Index: 0,
-						InParams: []Type{
-							{Main: Float},
-							{Main: Float},
+						InParams: []shaderir.Type{
+							{Main: shaderir.Float},
+							{Main: shaderir.Float},
 						},
-						OutParams: []Type{
-							{Main: Float},
+						OutParams: []shaderir.Type{
+							{Main: shaderir.Float},
 						},
 						Block: block(
-							[]Type{
+							[]shaderir.Type{
 								{},
 								{},
 							},
 							3,
 							forStmt(
-								Type{Main: Int},
+								shaderir.Type{Main: shaderir.Int},
 								3,
 								0,
 								100,
-								LessThanOp,
+								shaderir.LessThanOp,
 								1,
 								block(
-									[]Type{
-										{Main: Int},
+									[]shaderir.Type{
+										{Main: shaderir.Int},
 									},
 									4,
 									assignStmt(
@@ -819,15 +819,15 @@ void F0(float l0, float l1, thread float& l2) {
 								),
 							),
 							forStmt(
-								Type{Main: Float},
+								shaderir.Type{Main: shaderir.Float},
 								4,
 								0,
 								100,
-								LessThanOp,
+								shaderir.LessThanOp,
 								1,
 								block(
-									[]Type{
-										{Main: Int},
+									[]shaderir.Type{
+										{Main: shaderir.Int},
 									},
 									5,
 									assignStmt(
@@ -886,20 +886,20 @@ void F0(float l0, float l1, thread float& l2) {
 		},
 		{
 			Name: "VertexFunc",
-			Program: Program{
-				Uniforms: []Type{
-					{Main: Float},
+			Program: shaderir.Program{
+				Uniforms: []shaderir.Type{
+					{Main: shaderir.Float},
 				},
-				Attributes: []Type{
-					{Main: Vec4},
-					{Main: Float},
-					{Main: Vec2},
+				Attributes: []shaderir.Type{
+					{Main: shaderir.Vec4},
+					{Main: shaderir.Float},
+					{Main: shaderir.Vec2},
 				},
-				Varyings: []Type{
-					{Main: Float},
-					{Main: Vec2},
+				Varyings: []shaderir.Type{
+					{Main: shaderir.Float},
+					{Main: shaderir.Vec2},
 				},
-				VertexFunc: VertexFunc{
+				VertexFunc: shaderir.VertexFunc{
 					Block: block(
 						nil,
 						4+1,
@@ -937,20 +937,20 @@ varying vec2 V1;`,
 		},
 		{
 			Name: "FragmentFunc",
-			Program: Program{
-				Uniforms: []Type{
-					{Main: Float},
+			Program: shaderir.Program{
+				Uniforms: []shaderir.Type{
+					{Main: shaderir.Float},
 				},
-				Attributes: []Type{
-					{Main: Vec4},
-					{Main: Float},
-					{Main: Vec2},
+				Attributes: []shaderir.Type{
+					{Main: shaderir.Vec4},
+					{Main: shaderir.Float},
+					{Main: shaderir.Vec2},
 				},
-				Varyings: []Type{
-					{Main: Float},
-					{Main: Vec2},
+				Varyings: []shaderir.Type{
+					{Main: shaderir.Float},
+					{Main: shaderir.Vec2},
 				},
-				VertexFunc: VertexFunc{
+				VertexFunc: shaderir.VertexFunc{
 					Block: block(
 						nil,
 						5+1,
@@ -968,11 +968,11 @@ varying vec2 V1;`,
 						),
 					),
 				},
-				FragmentFunc: FragmentFunc{
+				FragmentFunc: shaderir.FragmentFunc{
 					Block: block(
-						[]Type{
-							{Main: Float},
-							{Main: Vec2},
+						[]shaderir.Type{
+							{Main: shaderir.Float},
+							{Main: shaderir.Vec2},
 						},
 						3+1,
 						assignStmt(

--- a/shader_test.go
+++ b/shader_test.go
@@ -19,14 +19,14 @@ import (
 	"image/color"
 	"testing"
 
-	. "github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2"
 )
 
 func TestShaderFill(t *testing.T) {
 	const w, h = 16, 16
 
-	dst := NewImage(w, h)
-	s, err := NewShader([]byte(`package main
+	dst := ebiten.NewImage(w, h)
+	s, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	return vec4(1, 0, 0, 1)
@@ -55,8 +55,8 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 func TestShaderFillWithDrawImage(t *testing.T) {
 	const w, h = 16, 16
 
-	dst := NewImage(w, h)
-	s, err := NewShader([]byte(`package main
+	dst := ebiten.NewImage(w, h)
+	s, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	return vec4(1, 0, 0, 1)
@@ -66,8 +66,8 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Fatal(err)
 	}
 
-	src := NewImage(w/2, h/2)
-	op := &DrawRectShaderOptions{}
+	src := ebiten.NewImage(w/2, h/2)
+	op := &ebiten.DrawRectShaderOptions{}
 	op.Images[0] = src
 	dst.DrawRectShader(w/2, h/2, s, op)
 
@@ -88,8 +88,8 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 func TestShaderFillWithDrawTriangles(t *testing.T) {
 	const w, h = 16, 16
 
-	dst := NewImage(w, h)
-	s, err := NewShader([]byte(`package main
+	dst := ebiten.NewImage(w, h)
+	s, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	return vec4(1, 0, 0, 1)
@@ -99,11 +99,11 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Fatal(err)
 	}
 
-	src := NewImage(w/2, h/2)
-	op := &DrawTrianglesShaderOptions{}
+	src := ebiten.NewImage(w/2, h/2)
+	op := &ebiten.DrawTrianglesShaderOptions{}
 	op.Images[0] = src
 
-	vs := []Vertex{
+	vs := []ebiten.Vertex{
 		{
 			DstX:   0,
 			DstY:   0,
@@ -163,8 +163,8 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 func TestShaderFunction(t *testing.T) {
 	const w, h = 16, 16
 
-	dst := NewImage(w, h)
-	s, err := NewShader([]byte(`package main
+	dst := ebiten.NewImage(w, h)
+	s, err := ebiten.NewShader([]byte(`package main
 
 func clr(red float) (float, float, float, float) {
 	return red, 0, 0, 1
@@ -192,7 +192,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderShadowing(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	var position vec4
@@ -204,7 +204,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderDuplicatedVariables(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	var foo vec4
@@ -215,7 +215,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	var foo, foo vec4
@@ -225,7 +225,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	var foo vec4
@@ -236,7 +236,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Foo() (vec4, vec4) {
 	return vec4(0), vec4(0)
@@ -252,7 +252,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderDuplicatedFunctions(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Foo() {
 }
@@ -269,14 +269,14 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderNoMain(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 `)); err == nil {
 		t.Errorf("error must be non-nil but was nil")
 	}
 }
 
 func TestShaderNoNewVariables(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	_ := 1
@@ -286,7 +286,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	_, _ := 1, 1
@@ -296,7 +296,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Foo() (int, int) {
 	return 1, 1
@@ -310,7 +310,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	a, _ := 1, 1
@@ -321,7 +321,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Error(err)
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	_, a := 1, 1
@@ -334,7 +334,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderWrongReturn(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	return 0.0
@@ -343,7 +343,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Foo() (float, float) {
 	return 0
@@ -356,7 +356,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
@@ -364,7 +364,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Foo() float {
 }
@@ -378,7 +378,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderMultipleValueReturn(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Foo() (float, float) {
 	return 0.0
@@ -391,7 +391,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Foo() float {
 	return 0.0, 0.0
@@ -404,7 +404,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Foo() (float, float, float) {
 	return 0.0, 0.0
@@ -417,7 +417,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Foo() (float, float) {
 	return 0.0, 0.0
@@ -434,7 +434,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Foo() (float, float, float) {
 	return 0.0, 0.0, 0.0
@@ -453,7 +453,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderInit(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func init() {
 }
@@ -467,7 +467,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderUnspportedSyntax(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	x := func() {
@@ -479,7 +479,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	go func() {
@@ -490,7 +490,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	ch := make(chan int)
@@ -501,7 +501,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	x := 1i
@@ -512,7 +512,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	var x [4]float
@@ -524,7 +524,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	var x [4]float
@@ -540,8 +540,8 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 func TestShaderUninitializedUniformVariables(t *testing.T) {
 	const w, h = 16, 16
 
-	dst := NewImage(w, h)
-	s, err := NewShader([]byte(`package main
+	dst := ebiten.NewImage(w, h)
+	s, err := ebiten.NewShader([]byte(`package main
 
 var U vec4
 
@@ -567,7 +567,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderForbidAssigningSpecialVariables(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 var U vec4
 
@@ -579,7 +579,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 var U vec4
 
@@ -591,7 +591,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 var U [2]vec4
 
@@ -603,7 +603,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	texCoord = vec2(0)
@@ -613,7 +613,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	texCoord.x = 0
@@ -625,7 +625,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderBoolLiteral(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	true := vec4(0)
@@ -637,7 +637,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderUnusedVariable(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	x := 0
@@ -647,7 +647,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	x := 0
@@ -658,7 +658,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	x := vec4(0)
@@ -671,7 +671,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 
 	// Increment statement treats a variable 'used'.
 	// https://play.golang.org/p/2RuYMrSLjt3
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	x := 0
@@ -682,7 +682,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Error(err)
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	var a int
@@ -692,7 +692,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	var a, b int
@@ -704,7 +704,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderBlankLhs(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	x := _
@@ -715,7 +715,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	var x int = _
@@ -726,7 +726,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	x := 1
@@ -738,7 +738,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	x := 1 + _
@@ -749,7 +749,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	_++
@@ -759,7 +759,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	_ += 1
@@ -769,7 +769,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	_.x = 1
@@ -781,7 +781,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 }
 
 func TestShaderDuplicatedVarsAndConstants(t *testing.T) {
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	var a = 0
@@ -792,7 +792,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	const a = 0
@@ -803,7 +803,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	const a = 0
@@ -814,7 +814,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 const U0 = 0
 var U0 float
@@ -826,7 +826,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("error must be non-nil but was nil")
 	}
 
-	if _, err := NewShader([]byte(`package main
+	if _, err := ebiten.NewShader([]byte(`package main
 
 var U0 float
 const U0 = 0
@@ -842,8 +842,8 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 func TestShaderMatrix(t *testing.T) {
 	const w, h = 16, 16
 
-	dst := NewImage(w, h)
-	s, err := NewShader([]byte(`package main
+	dst := ebiten.NewImage(w, h)
+	s, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	var a, b mat4
@@ -862,8 +862,8 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Fatal(err)
 	}
 
-	src := NewImage(w, h)
-	op := &DrawRectShaderOptions{}
+	src := ebiten.NewImage(w, h)
+	op := &ebiten.DrawRectShaderOptions{}
 	op.Images[0] = src
 	dst.DrawRectShader(w, h, s, op)
 
@@ -881,7 +881,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 func TestShaderSubImage(t *testing.T) {
 	const w, h = 16, 16
 
-	s, err := NewShader([]byte(`package main
+	s, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	r := imageSrc0At(texCoord).r
@@ -893,7 +893,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Fatal(err)
 	}
 
-	src0 := NewImage(w, h)
+	src0 := ebiten.NewImage(w, h)
 	pix0 := make([]byte, 4*w*h)
 	for j := 0; j < h; j++ {
 		for i := 0; i < w; i++ {
@@ -906,9 +906,9 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		}
 	}
 	src0.ReplacePixels(pix0)
-	src0 = src0.SubImage(image.Rect(2, 3, 10, 11)).(*Image)
+	src0 = src0.SubImage(image.Rect(2, 3, 10, 11)).(*ebiten.Image)
 
-	src1 := NewImage(w, h)
+	src1 := ebiten.NewImage(w, h)
 	pix1 := make([]byte, 4*w*h)
 	for j := 0; j < h; j++ {
 		for i := 0; i < w; i++ {
@@ -921,9 +921,9 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		}
 	}
 	src1.ReplacePixels(pix1)
-	src1 = src1.SubImage(image.Rect(6, 8, 14, 16)).(*Image)
+	src1 = src1.SubImage(image.Rect(6, 8, 14, 16)).(*ebiten.Image)
 
-	testPixels := func(testname string, dst *Image) {
+	testPixels := func(testname string, dst *ebiten.Image) {
 		for j := 0; j < h; j++ {
 			for i := 0; i < w; i++ {
 				got := dst.At(i, j).(color.RGBA)
@@ -939,8 +939,8 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	}
 
 	t.Run("DrawRectShader", func(t *testing.T) {
-		dst := NewImage(w, h)
-		op := &DrawRectShaderOptions{}
+		dst := ebiten.NewImage(w, h)
+		op := &ebiten.DrawRectShaderOptions{}
 		op.Images[0] = src0
 		op.Images[1] = src1
 		dst.DrawRectShader(w/2, h/2, s, op)
@@ -948,8 +948,8 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	})
 
 	t.Run("DrawTrianglesShader", func(t *testing.T) {
-		dst := NewImage(w, h)
-		vs := []Vertex{
+		dst := ebiten.NewImage(w, h)
+		vs := []ebiten.Vertex{
 			{
 				DstX:   0,
 				DstY:   0,
@@ -993,7 +993,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		}
 		is := []uint16{0, 1, 2, 1, 2, 3}
 
-		op := &DrawTrianglesShaderOptions{}
+		op := &ebiten.DrawTrianglesShaderOptions{}
 		op.Images[0] = src0
 		op.Images[1] = src1
 		dst.DrawTrianglesShader(vs, is, s, op)
@@ -1005,7 +1005,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 func TestShaderDerivatives(t *testing.T) {
 	const w, h = 16, 16
 
-	s, err := NewShader([]byte(`package main
+	s, err := ebiten.NewShader([]byte(`package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	p := imageSrc0At(texCoord)
@@ -1016,8 +1016,8 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Fatal(err)
 	}
 
-	dst := NewImage(w, h)
-	src := NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
+	src := ebiten.NewImage(w, h)
 	pix := make([]byte, 4*w*h)
 	for j := 0; j < h; j++ {
 		for i := 0; i < w; i++ {
@@ -1032,7 +1032,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	}
 	src.ReplacePixels(pix)
 
-	op := &DrawRectShaderOptions{}
+	op := &ebiten.DrawRectShaderOptions{}
 	op.Images[0] = src
 	dst.DrawRectShader(w, h, s, op)
 
@@ -1058,7 +1058,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 func TestShaderDerivatives2(t *testing.T) {
 	const w, h = 16, 16
 
-	s, err := NewShader([]byte(`package main
+	s, err := ebiten.NewShader([]byte(`package main
 
 // This function uses dfdx and then should not be in GLSL's vertex shader (#1701).
 func Foo(p vec4) vec4 {
@@ -1074,8 +1074,8 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Fatal(err)
 	}
 
-	dst := NewImage(w, h)
-	src := NewImage(w, h)
+	dst := ebiten.NewImage(w, h)
+	src := ebiten.NewImage(w, h)
 	pix := make([]byte, 4*w*h)
 	for j := 0; j < h; j++ {
 		for i := 0; i < w; i++ {
@@ -1090,7 +1090,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	}
 	src.ReplacePixels(pix)
 
-	op := &DrawRectShaderOptions{}
+	op := &ebiten.DrawRectShaderOptions{}
 	op.Images[0] = src
 	dst.DrawRectShader(w, h, s, op)
 
@@ -1165,13 +1165,13 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Run(shader.Name, func(t *testing.T) {
 			const w, h = 1, 1
 
-			dst := NewImage(w, h)
-			s, err := NewShader([]byte(shader.Shader))
+			dst := ebiten.NewImage(w, h)
+			s, err := ebiten.NewShader([]byte(shader.Shader))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			op := &DrawRectShaderOptions{}
+			op := &ebiten.DrawRectShaderOptions{}
 			op.Uniforms = shader.Uniforms
 			dst.DrawRectShader(w, h, s, op)
 			if got, want := dst.At(0, 0), (color.RGBA{0xff, 0xff, 0xff, 0xff}); got != want {

--- a/text/text_test.go
+++ b/text/text_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/hajimehoshi/ebiten/v2"
 	t "github.com/hajimehoshi/ebiten/v2/internal/testing"
-	. "github.com/hajimehoshi/ebiten/v2/text"
+	"github.com/hajimehoshi/ebiten/v2/text"
 )
 
 func TestMain(m *testing.M) {
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 func TestTextColor(t *testing.T) {
 	clr := color.RGBA{0x80, 0x80, 0x80, 0x80}
 	img := ebiten.NewImage(30, 30)
-	Draw(img, "Hello", bitmapfont.Face, 12, 12, clr)
+	text.Draw(img, "Hello", bitmapfont.Face, 12, 12, clr)
 
 	w, h := img.Size()
 	allTransparent := true
@@ -123,7 +123,7 @@ func TestTextOverlap(t *testing.T) {
 
 	// With testFace, 'b' is rendered at the previous position as 0xff.
 	// 'a' is rendered at the current position as 0x80.
-	Draw(dst, "ab", f, 0, 0, color.White)
+	text.Draw(dst, "ab", f, 0, 0, color.White)
 	for j := 0; j < testFaceSize; j++ {
 		for i := 0; i < testFaceSize; i++ {
 			got := dst.At(i, j)
@@ -135,7 +135,7 @@ func TestTextOverlap(t *testing.T) {
 	}
 
 	// The glyph 'a' should be treated correctly.
-	Draw(dst, "a", f, testFaceSize, 0, color.White)
+	text.Draw(dst, "a", f, testFaceSize, 0, color.White)
 	for j := 0; j < testFaceSize; j++ {
 		for i := testFaceSize; i < testFaceSize*2; i++ {
 			got := dst.At(i, j)


### PR DESCRIPTION
Hi,

this PR removes the dot imports in test files as requested in issue #1824 

The only doubt is on the test for "2048 example" ([examples/2048/2048/tile_test.go#L18](https://github.com/hajimehoshi/ebiten/compare/main...r3vit:issue-1824-remove-dot-imports?expand=1#diff-3cd9d2a29ef6bc382e958f91e4c3b1a067740aad0d61d756706a2d173b4a99c8R18)) where I named it "example2048".

Let me know if this is what you're expecting or there is something incorrect :) 
Thank you!