### PR TITLE
glfw: disable set current directory to resources for macOS

### DIFF
--- a/internal/glfw/glfw_darwin.go
+++ b/internal/glfw/glfw_darwin.go
@@ -1,0 +1,26 @@
+// Copyright 2018 The Ebiten Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin && !js
+// +build darwin,!js
+
+package glfw
+
+import (
+	"github.com/go-gl/glfw/v3.3/glfw"
+)
+
+func init() {
+	glfw.InitHint(glfw.CocoaChdirResources, glfw.False)
+}


### PR DESCRIPTION
issues demo project for macOS
```
demo
demo/resources
```
demo/main.go
```
package main

import (
	"fmt"
	"os"

	_ "github.com/hajimehoshi/ebiten/v2"
)

func main() {
	fmt.Println(os.Getwd())
}
```

output for macOS
```
.../github.com/hajimehoshi/ebiten/cmd/demo/resources
```

this PR disable glfw.CocoaChdirResources  on macOS

