### PR TITLE
Correction in go doc example

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -21,7 +21,7 @@
 //
 //     // Update proceeds the game state.
 //     // Update is called every tick (1/60 [s] by default).
-//     func (g *Game) Update() error {
+//     func (g *Game) Update(screen *ebiten.Image) error {
 //         // Write your game's logical update.
 //         return nil
 //     }


### PR DESCRIPTION
Correction in go doc example to ensure example satisfies the `Game` interface.

Current example results in:
```
cannot use game (type *Game) as type ebiten.Game in argument to ebiten.RunGame:
	*Game does not implement ebiten.Game (wrong type for Update method)
		have Update() error
		want Update(*ebiten.Image) error (exit status 2)
```