### PR TITLE
Add getters for GeoM fields.

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -80,6 +80,36 @@ func (g *GeoM) Element(i, j int) float64 {
 	}
 }
 
+// A returns the A value of the matrix.
+func (g *GeoM) A() float64 {
+	return g.a_1 + 1
+}
+
+// B returns the B value of the matrix.
+func (g *GeoM) B() float64 {
+	return g.b
+}
+
+// C returns the C value of the matrix.
+func (g *GeoM) C() float64 {
+	return g.c
+}
+
+// D returns the D value of the matrix.
+func (g *GeoM) D() float64 {
+	return g.d_1 + 1
+}
+
+// Tx returns the Tx value of the matrix.
+func (g *GeoM) Tx() float64 {
+	return g.tx
+}
+
+// Ty returns the Ty value of the matrix.
+func (g *GeoM) Ty() float64 {
+	return g.ty
+}
+
 // Concat multiplies a geometry matrix with the other geometry matrix.
 // This is same as muptiplying the matrix other and the matrix g in this order.
 func (g *GeoM) Concat(other GeoM) {

--- a/geom.go
+++ b/geom.go
@@ -80,32 +80,32 @@ func (g *GeoM) Element(i, j int) float64 {
 	}
 }
 
-// A returns the A value of the matrix.
+// A returns the element at the first row and the first column of the matrix.
 func (g *GeoM) A() float64 {
 	return g.a_1 + 1
 }
 
-// B returns the B value of the matrix.
+// B returns the element at the first row and the second column of the matrix.
 func (g *GeoM) B() float64 {
 	return g.b
 }
 
-// C returns the C value of the matrix.
+// C returns the element at the second row and the first column of the matrix.
 func (g *GeoM) C() float64 {
 	return g.c
 }
 
-// D returns the D value of the matrix.
+// D returns the element at the second row and the second column of the matrix.
 func (g *GeoM) D() float64 {
 	return g.d_1 + 1
 }
 
-// Tx returns the Tx value of the matrix.
+// Tx returns the element at the first row and the third column of the matrix.
 func (g *GeoM) Tx() float64 {
 	return g.tx
 }
 
-// Ty returns the Ty value of the matrix.
+// Ty returns the element at the second row and the third column of the matrix.
 func (g *GeoM) Ty() float64 {
 	return g.ty
 }

--- a/geom_test.go
+++ b/geom_test.go
@@ -297,6 +297,14 @@ func newGeoM(a, b, c, d, tx, ty float64) ebiten.GeoM {
 	return outp
 }
 
+func TestGeomGetter(t *testing.T) {
+	geoM := newGeoM(1, 2, 3, 4, 5, 6)
+	geoM2 := newGeoM(geoM.A(), geoM.B(), geoM.C(), geoM.D(), geoM.Tx(), geoM.Ty())
+	if geoM != geoM2 {
+		t.Errorf("got: %s want: %s", geoMToString(geoM), geoMToString(geoM2))
+	}
+}
+
 func TestGeomSkew(t *testing.T) {
 	testSkew := func(skewX, skewY float64, input, expected ebiten.GeoM) {
 		input.Skew(skewX, skewY)


### PR DESCRIPTION
`Element` exists but requires knowing which indices to look-up and can
fatal in the case of dev error. Adding getters let's the dev directly
access the field they care about and makes the callsite more readable.

e.g. `geoM.Tx()` over `geoM.Element(0, 2)`.