### PR TITLE
direct users to the readme in the docs repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,12 @@ You don't have to update existing files' license comments.
 
 `example` is to prevent from installing executions by `go get github.com/hajimehoshi/ebiten/v2/...`.
 
-## Documentation
+## Implementation details
 
 See the [documents](https://ebiten.org/documents/implementation.html) about internal implementation.
+
+## Fixing the documentation
+
+Ebiten's documentations are managed at [ebiten/ebiten.org](https://github.com/ebiten/ebiten.org).  
+
+Before submitting a documentation PR, read through the [README](https://github.com/ebiten/ebiten.org/blob/main/README.md) in that repo.


### PR DESCRIPTION
Adds a small link to the docs readme to ensure users find the proper procedure for making a docs PR.

Signed-off-by: Jacob Salmela <me@jacobsalmela.com>