### PR TITLE
Fixes a typo.

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -81,7 +81,7 @@ func (g *GeoM) Element(i, j int) float64 {
 }
 
 // Concat multiplies a geometry matrix with the other geometry matrix.
-// This is same as muptiplying the matrix other and the matrix g in this order.
+// This is same as multiplying the matrix other and the matrix g in this order.
 func (g *GeoM) Concat(other GeoM) {
 	a := (other.a_1+1)*(g.a_1+1) + other.b*g.c
 	b := (other.a_1+1)*g.b + other.b*(g.d_1+1)


### PR DESCRIPTION
This change fixes a misspelling of the word "multiplying" in the docstring for `ebiten.GeoM.Concat`.