### PR TITLE
Use FreeConsole instead of hiding

### DIFF
--- a/internal/uidriver/glfw/hideconsole_windows.go
+++ b/internal/uidriver/glfw/hideconsole_windows.go
@@ -33,7 +33,6 @@ var (
 	getConsoleWindowProc         = kernel32.NewProc("GetConsoleWindow")
 	freeConsoleWindowProc        = kernel32.NewProc("FreeConsole")
 	getWindowThreadProcessIdProc = user32.NewProc("GetWindowThreadProcessId")
-	showWindowAsyncProc          = user32.NewProc("ShowWindowAsync")
 )
 
 func getCurrentProcessId() (uint32, error) {
@@ -65,13 +64,6 @@ func freeConsole() error {
 	_, _, e := freeConsoleWindowProc.Call()
 	if e != nil && e.(windows.Errno) != 0 {
 		return fmt.Errorf("ui: FreeConsole failed: %d", e)
-	}
-	return nil
-}
-
-func showWindowAsync(hwnd uintptr, show int) error {
-	if _, _, e := showWindowAsyncProc.Call(hwnd, uintptr(show)); e != nil && e.(windows.Errno) != 0 {
-		return fmt.Errorf("ui: ShowWindowAsync failed: %d", e)
 	}
 	return nil
 }

--- a/internal/uidriver/glfw/hideconsole_windows.go
+++ b/internal/uidriver/glfw/hideconsole_windows.go
@@ -31,6 +31,7 @@ var (
 
 	getCurrentProcessIdProc      = kernel32.NewProc("GetCurrentProcessId")
 	getConsoleWindowProc         = kernel32.NewProc("GetConsoleWindow")
+	freeConsoleWindowProc        = kernel32.NewProc("FreeConsole")
 	getWindowThreadProcessIdProc = user32.NewProc("GetWindowThreadProcessId")
 	showWindowAsyncProc          = user32.NewProc("ShowWindowAsync")
 )
@@ -58,6 +59,14 @@ func getConsoleWindow() (uintptr, error) {
 		return 0, fmt.Errorf("ui: GetConsoleWindow failed: %d", e)
 	}
 	return r, nil
+}
+
+func freeConsole() error {
+	_, _, e := freeConsoleWindowProc.Call()
+	if e != nil && e.(windows.Errno) != 0 {
+		return fmt.Errorf("ui: FreeConsole failed: %d", e)
+	}
+	return nil
 }
 
 func showWindowAsync(hwnd uintptr, show int) error {
@@ -90,6 +99,7 @@ func hideConsoleWindowOnWindows() {
 	}
 	if pid == cpid {
 		// The current process created its own console. Hide this.
-		showWindowAsync(w, windows.SW_HIDE)
+		// Ignore error
+		freeConsole()
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/hajimehoshi/ebiten/issues/485

Using `FreeConsole` (https://docs.microsoft.com/en-us/windows/console/freeconsole) instead of hiding the console correctly works on my machine.

Calling it in every case, doesn't necessarily kill the console, but prevent logs from working, so it still needs to be done when we detect that current process created its own console.

From what is stated on `FreeConsole`'s page, the console will get destroyed automatically when no process refers to it anymore.
So it works in our case, since our process created its own console.

Also if this is adopted, `showWindowAsyncProc` reference could be dropped