### PR TITLE
Fix window float enable/disable (#1960)

### DIFF
--- a/examples/windowsize/main.go
+++ b/examples/windowsize/main.go
@@ -305,6 +305,7 @@ func (g *game) Draw(screen *ebiten.Image) {
 	screen.DrawImage(gophersImage, op)
 
 	wx, wy := ebiten.WindowPosition()
+	ww, wh := ebiten.WindowSize()
 	minw, minh, maxw, maxh := ebiten.WindowSizeLimits()
 	cx, cy := ebiten.CursorPosition()
 	tpsStr := "Sync with FPS"
@@ -344,12 +345,13 @@ func (g *game) Draw(screen *ebiten.Image) {
 [W] Switch whether to skip clearing the screen
 %s
 IsFocused?: %s
-Windows Position: (%d, %d)
+Window Position: (%d, %d)
+Window Size: (%d, %d)
 Window size limitation: (%d, %d) - (%d, %d)
 Cursor: (%d, %d)
 TPS: Current: %0.2f / Max: %s
 FPS: %0.2f
-Device Scale Factor: %0.2f`, msgM, msgR, fg, wx, wy, minw, minh, maxw, maxh, cx, cy, ebiten.CurrentTPS(), tpsStr, ebiten.CurrentFPS(), ebiten.DeviceScaleFactor())
+Device Scale Factor: %0.2f`, msgM, msgR, fg, wx, wy, ww, wh, minw, minh, maxw, maxh, cx, cy, ebiten.CurrentTPS(), tpsStr, ebiten.CurrentFPS(), ebiten.DeviceScaleFactor())
 	ebitenutil.DebugPrint(screen, msg)
 }
 

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -823,8 +823,9 @@ event:
 		}
 	}
 	if u.defaultFramebufferSizeCallback == 0 {
-		// When window gets resized (either by manual window resize or a window
-		// manager), glfw sends a framebuffer size callback which we need to handle
+		// When the window gets resized (either by manual window resize or a window
+		// manager), glfw sends a framebuffer size callback which we need to handle (#1960).
+		// This event is the only way to handle the size change at least on i3 window manager.
 		u.defaultFramebufferSizeCallback = glfw.ToFramebufferSizeCallback(func(_ *glfw.Window, w, h int) {
 			u.setWindowSizeInDIP(w, h, u.isFullscreen())
 		})

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -823,6 +823,8 @@ event:
 		}
 	}
 	if u.defaultFramebufferSizeCallback == 0 {
+		// When window gets resized (either by manual window resize or a window
+		// manager), glfw sends a framebuffer size callback which we need to handle
 		u.defaultFramebufferSizeCallback = glfw.ToFramebufferSizeCallback(func(_ *glfw.Window, w, h int) {
 			u.setWindowSizeInDIP(w, h, u.isFullscreen())
 		})

--- a/internal/uidriver/glfw/ui.go
+++ b/internal/uidriver/glfw/ui.go
@@ -104,10 +104,11 @@ type UserInterface struct {
 	input   Input
 	iwindow window
 
-	sizeCallback              glfw.SizeCallback
-	closeCallback             glfw.CloseCallback
-	framebufferSizeCallback   glfw.FramebufferSizeCallback
-	framebufferSizeCallbackCh chan struct{}
+	sizeCallback                   glfw.SizeCallback
+	closeCallback                  glfw.CloseCallback
+	framebufferSizeCallback        glfw.FramebufferSizeCallback
+	defaultFramebufferSizeCallback glfw.FramebufferSizeCallback
+	framebufferSizeCallbackCh      chan struct{}
 
 	t thread.Thread
 	m sync.RWMutex
@@ -821,7 +822,13 @@ event:
 			time.Sleep(time.Millisecond)
 		}
 	}
-	window.SetFramebufferSizeCallback(glfw.ToFramebufferSizeCallback(nil))
+	if u.defaultFramebufferSizeCallback == 0 {
+		u.defaultFramebufferSizeCallback = glfw.ToFramebufferSizeCallback(func(_ *glfw.Window, w, h int) {
+			u.setWindowSizeInDIP(w, h, u.isFullscreen())
+		})
+	}
+	window.SetFramebufferSizeCallback(u.defaultFramebufferSizeCallback)
+
 	close(u.framebufferSizeCallbackCh)
 	u.framebufferSizeCallbackCh = nil
 }


### PR DESCRIPTION
When resizing with i3 (and possibly other WMs), the only way to now new framebuffer/window size is to get event from glfw.
This also calls `setWindowSizeInDIP` to update window size afterwards (instead of calling `context.Layout` directly)

Framebuffer size callbacks are used for handling window resize in glfw examples [like here](https://github.com/glfw/glfw/blob/master/examples/gears.c#L248)

I'm not 100% sure that this is the best solution, so any suggestions welcome.
@sedyh this might also fix #1620 - can you please check (there are still glitches, but maybe it's somewhat better)?