### PR TITLE
examples/mandelbrot: Reduce CPU cost by not updating the window

### DIFF
--- a/examples/mandelbrot/main.go
+++ b/examples/mandelbrot/main.go
@@ -103,6 +103,8 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 func main() {
 	ebiten.SetWindowSize(screenWidth, screenHeight)
 	ebiten.SetWindowTitle("Mandelbrot (Ebiten Demo)")
+	ebiten.SetFPSMode(ebiten.FPSModeVsyncOffMinimum)
+
 	if err := ebiten.RunGame(NewGame()); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
When the Mandelbrot calculation is over, there is no reason to continuously paint the window contents.