### PR TITLE
Allow GLES2 builds outside of iOS/Android

### DIFF
--- a/internal/graphicsdriver/opengl/bytes.go
+++ b/internal/graphicsdriver/opengl/bytes.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build android || ios
-// +build android ios
+//go:build android || ios || gles2
+// +build android ios gles2
 
 package opengl
 

--- a/internal/graphicsdriver/opengl/context_desktop.go
+++ b/internal/graphicsdriver/opengl/context_desktop.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !android && !js && !ios
-// +build !android,!js,!ios
+//go:build !android && !js && !ios && !gles2
+// +build !android,!js,!ios,!gles2
 
 package opengl
 

--- a/internal/graphicsdriver/opengl/context_mobile.go
+++ b/internal/graphicsdriver/opengl/context_mobile.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build android || ios
-// +build android ios
+//go:build android || ios || gles2
+// +build android ios gles2
 
 package opengl
 

--- a/internal/graphicsdriver/opengl/gl/conversions_notwindows.go
+++ b/internal/graphicsdriver/opengl/gl/conversions_notwindows.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !gles2
+// +build !windows && !gles2
 
 package gl
 

--- a/internal/graphicsdriver/opengl/gles/default.go
+++ b/internal/graphicsdriver/opengl/gles/default.go
@@ -12,17 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build android || ios
-// +build android ios
+//go:build android || ios || gles2
+// +build android ios gles2
 
 package gles
 
 // #cgo android CFLAGS:  -Dos_android
 // #cgo android LDFLAGS: -lGLESv2
+// #cgo gles2   CFLAGS:  -Dgles2
+// #cgo gles2   LDFLAGS: -lGLESv2
 // #cgo ios     CFLAGS:  -Dos_ios
 // #cgo ios     LDFLAGS: -framework OpenGLES
 //
-// #if defined(os_android)
+// #if defined(os_android) || defined(gles2)
 //   #include <GLES2/gl2.h>
 // #endif
 //

--- a/internal/graphicsdriver/opengl/gles/gomobile.go
+++ b/internal/graphicsdriver/opengl/gles/gomobile.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build android || ios
-// +build android ios
+//go:build android || ios || gles2
+// +build android ios gles2
 
 package gles
 

--- a/internal/graphicsdriver/opengl/gles/interface.go
+++ b/internal/graphicsdriver/opengl/gles/interface.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build android || ios
-// +build android ios
+//go:build android || ios || gles2
+// +build android ios gles2
 
 package gles
 

--- a/internal/graphicsdriver/opengl/gles/str.go
+++ b/internal/graphicsdriver/opengl/gles/str.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build android || ios
-// +build android ios
+//go:build android || ios || gles2
+// +build android ios gles2
 
 package gles
 

--- a/internal/graphicsdriver/opengl/graphics_mobile.go
+++ b/internal/graphicsdriver/opengl/graphics_mobile.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build android || ios
-// +build android ios
+//go:build android || ios || gles2
+// +build android ios || gles2
 
 package opengl
 


### PR DESCRIPTION
This keeps the tags compatible with those use by https://github.com/go-gl/glfw