### PR TITLE
Provide ebiten.SetScreenFilterEnabled, a way to disable the default screen filter

### DIFF
--- a/gameforui.go
+++ b/gameforui.go
@@ -73,7 +73,7 @@ func (c *gameForUI) Update() error {
 	return c.game.Update()
 }
 
-func (c *gameForUI) Draw(screenScale float64, offsetX, offsetY float64, needsClearingScreen bool, framebufferYDirection graphicsdriver.YDirection, clearScreenEveryFrame bool) error {
+func (c *gameForUI) Draw(screenScale float64, offsetX, offsetY float64, needsClearingScreen bool, framebufferYDirection graphicsdriver.YDirection, clearScreenEveryFrame bool, forceFilter graphicsdriver.Filter) error {
 	c.offscreen.mipmap.SetVolatile(clearScreenEveryFrame)
 
 	// Even though updateCount == 0, the offscreen is cleared and Draw is called.
@@ -107,6 +107,8 @@ func (c *gameForUI) Draw(screenScale float64, offsetX, offsetY float64, needsCle
 	op.CompositeMode = CompositeModeCopy
 
 	switch {
+	case forceFilter >= 0:
+		op.Filter = Filter(forceFilter)
 	case math.Floor(s) == s:
 		op.Filter = FilterNearest
 	case s > 1:

--- a/gameforui.go
+++ b/gameforui.go
@@ -73,7 +73,7 @@ func (c *gameForUI) Update() error {
 	return c.game.Update()
 }
 
-func (c *gameForUI) Draw(screenScale float64, offsetX, offsetY float64, needsClearingScreen bool, framebufferYDirection graphicsdriver.YDirection, clearScreenEveryFrame bool, forceFilter graphicsdriver.Filter) error {
+func (c *gameForUI) Draw(screenScale float64, offsetX, offsetY float64, needsClearingScreen bool, framebufferYDirection graphicsdriver.YDirection, clearScreenEveryFrame, filterEnabled bool) error {
 	c.offscreen.mipmap.SetVolatile(clearScreenEveryFrame)
 
 	// Even though updateCount == 0, the offscreen is cleared and Draw is called.
@@ -107,8 +107,8 @@ func (c *gameForUI) Draw(screenScale float64, offsetX, offsetY float64, needsCle
 	op.CompositeMode = CompositeModeCopy
 
 	switch {
-	case forceFilter >= 0:
-		op.Filter = Filter(forceFilter)
+	case !filterEnabled:
+		op.Filter = FilterNearest
 	case math.Floor(s) == s:
 		op.Filter = FilterNearest
 	case s > 1:

--- a/internal/ui/context.go
+++ b/internal/ui/context.go
@@ -32,7 +32,7 @@ const DefaultTPS = 60
 type Game interface {
 	Layout(outsideWidth, outsideHeight float64, deviceScaleFactor float64) (int, int)
 	Update() error
-	Draw(screenScale float64, offsetX, offsetY float64, needsClearingScreen bool, framebufferYDirection graphicsdriver.YDirection, screenClearedEveryFrame bool) error
+	Draw(screenScale float64, offsetX, offsetY float64, needsClearingScreen bool, framebufferYDirection graphicsdriver.YDirection, screenClearedEveryFrame bool, forceFilter graphicsdriver.Filter) error
 }
 
 type contextImpl struct {
@@ -106,7 +106,7 @@ func (c *contextImpl) updateFrameImpl(updateCount int, outsideWidth, outsideHeig
 
 	// Draw the game.
 	screenScale, offsetX, offsetY := c.screenScaleAndOffsets(deviceScaleFactor)
-	if err := c.game.Draw(screenScale, offsetX, offsetY, graphics().NeedsClearingScreen(), graphics().FramebufferYDirection(), theGlobalState.isScreenClearedEveryFrame()); err != nil {
+	if err := c.game.Draw(screenScale, offsetX, offsetY, graphics().NeedsClearingScreen(), graphics().FramebufferYDirection(), theGlobalState.isScreenClearedEveryFrame(), theGlobalState.screenFilter()); err != nil {
 		return err
 	}
 
@@ -163,6 +163,7 @@ func (c *contextImpl) screenScaleAndOffsets(deviceScaleFactor float64) (float64,
 var theGlobalState = globalState{
 	maxTPS_:                    DefaultTPS,
 	isScreenClearedEveryFrame_: 1,
+	screenFilter_:              -1,
 }
 
 // globalState represents a global state in this package.
@@ -172,6 +173,7 @@ type globalState struct {
 	fpsMode_                   int32
 	maxTPS_                    int32
 	isScreenClearedEveryFrame_ int32
+	screenFilter_              int32
 }
 
 func (g *globalState) err() error {
@@ -220,6 +222,15 @@ func (g *globalState) setScreenClearedEveryFrame(cleared bool) {
 	atomic.StoreInt32(&g.isScreenClearedEveryFrame_, v)
 }
 
+func (g *globalState) screenFilter() graphicsdriver.Filter {
+	return graphicsdriver.Filter(atomic.LoadInt32(&g.screenFilter_))
+}
+
+func (g *globalState) setScreenFilter(filter graphicsdriver.Filter) {
+	v := int32(filter)
+	atomic.StoreInt32(&g.screenFilter_, v)
+}
+
 func SetError(err error) {
 	theGlobalState.setError(err)
 }
@@ -247,4 +258,8 @@ func IsScreenClearedEveryFrame() bool {
 
 func SetScreenClearedEveryFrame(cleared bool) {
 	theGlobalState.setScreenClearedEveryFrame(cleared)
+}
+
+func SetScreenFilter(filter graphicsdriver.Filter) {
+	theGlobalState.setScreenFilter(filter)
 }

--- a/internal/ui/context.go
+++ b/internal/ui/context.go
@@ -263,6 +263,10 @@ func SetScreenClearedEveryFrame(cleared bool) {
 	theGlobalState.setScreenClearedEveryFrame(cleared)
 }
 
+func IsScreenFilterEnabled() bool {
+	return theGlobalState.isScreenFilterEnabled()
+}
+
 func SetScreenFilterEnabled(enabled bool) {
 	theGlobalState.setScreenFilterEnabled(enabled)
 }

--- a/internal/ui/context.go
+++ b/internal/ui/context.go
@@ -32,7 +32,7 @@ const DefaultTPS = 60
 type Game interface {
 	Layout(outsideWidth, outsideHeight float64, deviceScaleFactor float64) (int, int)
 	Update() error
-	Draw(screenScale float64, offsetX, offsetY float64, needsClearingScreen bool, framebufferYDirection graphicsdriver.YDirection, screenClearedEveryFrame bool, forceFilter graphicsdriver.Filter) error
+	Draw(screenScale float64, offsetX, offsetY float64, needsClearingScreen bool, framebufferYDirection graphicsdriver.YDirection, screenClearedEveryFrame, filterEnabled bool) error
 }
 
 type contextImpl struct {
@@ -106,7 +106,7 @@ func (c *contextImpl) updateFrameImpl(updateCount int, outsideWidth, outsideHeig
 
 	// Draw the game.
 	screenScale, offsetX, offsetY := c.screenScaleAndOffsets(deviceScaleFactor)
-	if err := c.game.Draw(screenScale, offsetX, offsetY, graphics().NeedsClearingScreen(), graphics().FramebufferYDirection(), theGlobalState.isScreenClearedEveryFrame(), theGlobalState.screenFilter()); err != nil {
+	if err := c.game.Draw(screenScale, offsetX, offsetY, graphics().NeedsClearingScreen(), graphics().FramebufferYDirection(), theGlobalState.isScreenClearedEveryFrame(), theGlobalState.isScreenFilterEnabled()); err != nil {
 		return err
 	}
 
@@ -163,7 +163,7 @@ func (c *contextImpl) screenScaleAndOffsets(deviceScaleFactor float64) (float64,
 var theGlobalState = globalState{
 	maxTPS_:                    DefaultTPS,
 	isScreenClearedEveryFrame_: 1,
-	screenFilter_:              -1,
+	screenFilterEnabled_:       1,
 }
 
 // globalState represents a global state in this package.
@@ -173,7 +173,7 @@ type globalState struct {
 	fpsMode_                   int32
 	maxTPS_                    int32
 	isScreenClearedEveryFrame_ int32
-	screenFilter_              int32
+	screenFilterEnabled_       int32
 }
 
 func (g *globalState) err() error {
@@ -222,13 +222,16 @@ func (g *globalState) setScreenClearedEveryFrame(cleared bool) {
 	atomic.StoreInt32(&g.isScreenClearedEveryFrame_, v)
 }
 
-func (g *globalState) screenFilter() graphicsdriver.Filter {
-	return graphicsdriver.Filter(atomic.LoadInt32(&g.screenFilter_))
+func (g *globalState) isScreenFilterEnabled() bool {
+	return graphicsdriver.Filter(atomic.LoadInt32(&g.screenFilterEnabled_)) != 0
 }
 
-func (g *globalState) setScreenFilter(filter graphicsdriver.Filter) {
-	v := int32(filter)
-	atomic.StoreInt32(&g.screenFilter_, v)
+func (g *globalState) setScreenFilterEnabled(enabled bool) {
+	v := int32(0)
+	if enabled {
+		v = 1
+	}
+	atomic.StoreInt32(&g.screenFilterEnabled_, v)
 }
 
 func SetError(err error) {
@@ -260,6 +263,6 @@ func SetScreenClearedEveryFrame(cleared bool) {
 	theGlobalState.setScreenClearedEveryFrame(cleared)
 }
 
-func SetScreenFilter(filter graphicsdriver.Filter) {
-	theGlobalState.setScreenFilter(filter)
+func SetScreenFilterEnabled(enabled bool) {
+	theGlobalState.setScreenFilterEnabled(enabled)
 }

--- a/run.go
+++ b/run.go
@@ -18,7 +18,6 @@ import (
 	"sync/atomic"
 
 	"github.com/hajimehoshi/ebiten/v2/internal/clock"
-	"github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver"
 	"github.com/hajimehoshi/ebiten/v2/internal/ui"
 )
 
@@ -95,15 +94,13 @@ func IsScreenClearedEveryFrame() bool {
 	return ui.IsScreenClearedEveryFrame()
 }
 
-// SetScreenFilter requests a specific Filter to be used for upscaling/downscaling.
+// SetScreenFilterEnabled enables/disables the use of the "screen" filter Ebiten uses.
 //
-// Pass nil to revert to Ebiten's default filter selection.
-func SetScreenFilter(filter *Filter) {
-	if filter == nil {
-		ui.SetScreenFilter(-1)
-	} else {
-		ui.SetScreenFilter(graphicsdriver.Filter(*filter))
-	}
+// The "screen" filter is a box filter from game to display resolution.
+//
+// If disabled, nearest-neighbor filtering will be used for scaling instead.
+func SetScreenFilterEnabled(enabled bool) {
+	ui.SetScreenFilterEnabled(enabled)
 }
 
 type imageDumperGame struct {

--- a/run.go
+++ b/run.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 
 	"github.com/hajimehoshi/ebiten/v2/internal/clock"
+	"github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver"
 	"github.com/hajimehoshi/ebiten/v2/internal/ui"
 )
 
@@ -92,6 +93,17 @@ func SetScreenClearedEveryFrame(cleared bool) {
 // IsScreenClearedEveryFrame is concurrent-safe.
 func IsScreenClearedEveryFrame() bool {
 	return ui.IsScreenClearedEveryFrame()
+}
+
+// SetScreenFilter requests a specific Filter to be used for upscaling/downscaling.
+//
+// Pass nil to revert to Ebiten's default filter selection.
+func SetScreenFilter(filter *Filter) {
+	if filter == nil {
+		ui.SetScreenFilter(-1)
+	} else {
+		ui.SetScreenFilter(graphicsdriver.Filter(*filter))
+	}
 }
 
 type imageDumperGame struct {

--- a/run.go
+++ b/run.go
@@ -107,6 +107,13 @@ func SetScreenFilterEnabled(enabled bool) {
 	ui.SetScreenFilterEnabled(enabled)
 }
 
+// IsScreenFilterEnabled returns true if Ebiten's "screen" filter is enabled.
+//
+// IsScreenFilterEnabled is concurrent-safe.
+func IsScreenFilterEnabled() bool {
+	return ui.IsScreenFilterEnabled()
+}
+
 type imageDumperGame struct {
 	game Game
 	d    *imageDumper

--- a/run.go
+++ b/run.go
@@ -99,6 +99,10 @@ func IsScreenClearedEveryFrame() bool {
 // The "screen" filter is a box filter from game to display resolution.
 //
 // If disabled, nearest-neighbor filtering will be used for scaling instead.
+//
+// The default state is true.
+//
+// SetScreenFilterEnabled is concurrent-safe, but takes effect only at the next Draw call.
 func SetScreenFilterEnabled(enabled bool) {
 	ui.SetScreenFilterEnabled(enabled)
 }


### PR DESCRIPTION
Using FilterNearest rather than filterScreen or FilterLinear speeds up a
Dell E6500 from 23fps->36fps and 27fps->48fps.

Helps with https://github.com/hajimehoshi/ebiten/issues/1772.