### PR TITLE
Fix uint16 underflow handling in gamepads.

### DIFF
--- a/internal/gamepad/gamepad_linux.go
+++ b/internal/gamepad/gamepad_linux.go
@@ -328,7 +328,7 @@ func (g *nativeGamepad) update(gamepad *gamepads) error {
 
 		switch e.typ {
 		case unix.EV_KEY:
-			if int(e.code)-_BTN_MISC < len(g.keyMap) {
+			if int(e.code-_BTN_MISC) < len(g.keyMap) {
 				idx := g.keyMap[e.code-_BTN_MISC]
 				g.buttons[idx] = e.value != 0
 			}


### PR DESCRIPTION
Fixes crash where Ebiten considers a keyboard a gamepad with way too many buttons.

For some reason, on one of my laptops, Ebiten tries to keyboard and touchpad devices as "gamepads" - but then when parsing its button data, it crashes. Apparently here, `EV_KEY` codes are returned with a code smaller than `_BTN_MISC` whenever pressing a key on the laptop.

https://github.com/hajimehoshi/ebiten/commit/b98568901086d92cf8a2565340a909cc04496822 attempted to fix this, but the subtraction was done as signed int data type, meaning it didn't actually detect underflow. My fix is doing the subtraction as uint16 just like in the following line where the same expression is used to access keyMap - an alternate fix would probably be adding an `e.code >= _BTN_MISC` check instead.

Helps with issue #2027.