### PR TITLE
inpututil: allow an arbitrary number of gamepad buttons.

### DIFF
--- a/inpututil/inpututil.go
+++ b/inpututil/inpututil.go
@@ -138,7 +138,7 @@ func (i *inputState) update() {
 		i.gamepadIDs[id] = struct{}{}
 
 		n := ebiten.GamepadButtonNum(id)
-		if _, ok := i.gamepadButtonDurations[id]; !ok || n != len(i.gamepadButtonDurations) {
+		if n != len(i.gamepadButtonDurations[id]) {
 			i.gamepadButtonDurations[id] = make([]int, n)
 		}
 		for b := ebiten.GamepadButton(0); b < ebiten.GamepadButton(n); b++ {

--- a/inpututil/inpututil.go
+++ b/inpututil/inpututil.go
@@ -137,12 +137,9 @@ func (i *inputState) update() {
 	for _, id := range i.gamepadIDsBuf {
 		i.gamepadIDs[id] = struct{}{}
 
-		if _, ok := i.gamepadButtonDurations[id]; !ok {
-			i.gamepadButtonDurations[id] = make([]int, ebiten.GamepadButtonMax+1)
-		}
 		n := ebiten.GamepadButtonNum(id)
-		if n > int(ebiten.GamepadButtonMax)+1 {
-			n = int(ebiten.GamepadButtonMax) + 1
+		if _, ok := i.gamepadButtonDurations[id]; !ok || n != len(i.gamepadButtonDurations) {
+			i.gamepadButtonDurations[id] = make([]int, n)
 		}
 		for b := ebiten.GamepadButton(0); b < ebiten.GamepadButton(n); b++ {
 			if ebiten.IsGamepadButtonPressed(id, b) {


### PR DESCRIPTION
Fixes crash in inpututil when a gamepad with more than "allowed" buttons is
connected.

For some reason, on one of my laptops, Ebiten tries to keyboard and touchpad devices as "gamepads". The keyboard in particular shows up with `GamepadButtonNum(id) > GamepadButtonMax+1`.

https://github.com/hajimehoshi/ebiten/commit/5bb22d2bcf45fe026b99820c90b8bcc9e02fc19a attempted to fix this, but failed as other inpututil functions (e.g. `IsGamepadButtonJustPressed`) would still crash when a too-high button is passed, which happens in `examples/gamepad/main.go` due to it looping from `0` to `GamepadButtonNum(id)-1`.

An alternate fix could be already hiding extraneous buttons in the gamepad driver itself so that `GamepadButtonNum` can never return values greater than `GamepadButtonMax+1`; I decided not go there as your previous patch indicated that supporting "extraneous" buttons might actually be intended.

Helps with issue #2027.