### PR TITLE
Playground for editing and testing ebiten's examples

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,0 +1,28 @@
+name: Steam
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Prepare ebiten for testing it from the Static Go Playground
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      
+      - name: Download dependencies (vendor)
+        run: go mod vendor
+        
+      - name: Publish an artifact ready to use
+        uses: actions/upload-artifact@v3
+        with:
+          name: static-go-playground-sources
+          path: .

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Download dependencies (vendor)
         run: go mod vendor
         
-      - name: Prepare zip file
-        run: mkdir public && zip -r public/static-go-playground-sources-latest.zip . -x '*.git*'
+      - name: Prepare zip file with all the required sources
+        run: mkdir public && zip -r public/sources-latest.zip . -x '*.git*'
         
-      - name: Publish the ready to use sources
+      - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,4 +1,4 @@
-name: Steam
+name: Playground
 
 on: [push, pull_request]
 
@@ -21,8 +21,11 @@ jobs:
       - name: Download dependencies (vendor)
         run: go mod vendor
         
-      - name: Publish an artifact ready to use
-        uses: actions/upload-artifact@v3
+      - name: Prepare zip file
+        run: mkdir public && zip -r public/static-go-playground-sources-latest.zip . -x .git public
+        
+      - name: Publish the ready to use sources
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          name: static-go-playground-sources
-          path: .
+          publish_dir: ./public
+          # keep_files: true

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -22,10 +22,11 @@ jobs:
         run: go mod vendor
         
       - name: Prepare zip file
-        run: mkdir public && zip -r public/static-go-playground-sources-latest.zip . -x .git public
+        run: mkdir public && zip -r public/static-go-playground-sources-latest.zip . -x '*.git*'
         
       - name: Publish the ready to use sources
         uses: peaceiris/actions-gh-pages@v3
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
           # keep_files: true


### PR DESCRIPTION
First of all, thanks for building such an amazing tool.

I'll start with a little bit of background: I created the [Static Go Playground](https://github.com/Yeicor/static-go-playground) project, which is the Go Compiler running completely inside the web browser. It allows Go developers to easily publish their demos in such a way that they can be modified and tested by users without any Go installation, and from any device.

I used your project for my demo as it is a great fit and has nice visual examples (hope it's ok). This pull request just adds a quick workflow (of around 25 secs) that automates the only required operation for using the Static Go Playground: vendoring dependencies and hosting a zip file of all the sources.

After applying this, you can just share a link that will open the Static Go Playground and automatically download the sources, compile any of the examples and run it. The link that would do this (for my fork) is: https://yeicor.github.io/static-go-playground/?fs_dl_/src=https://yeicor.github.io/ebiten/sources-latest.zip&build=/src/examples/chipmunk. It always points to the latest sources, so it could also be useful for quickly testing pull requests. It takes a minute to do the download and initial compilation, but compiled files are cached and the next builds will be much faster.

In conclusion, just wanted to show you this related project and offer the possibility to integrate it, but if you think this falls outside the scope of this repository, feel free to close this request.