### PR TITLE
Added option to set graphics engine programmatically

### DIFF
--- a/internal/ui/graphics.go
+++ b/internal/ui/graphics.go
@@ -28,32 +28,43 @@ type graphicsDriverGetter interface {
 	getMetal() graphicsdriver.Graphics
 }
 
-func chooseGraphicsDriver(getter graphicsDriverGetter) (graphicsdriver.Graphics, error) {
+func chooseGraphicsDriver(engine GraphicsEngine, getter graphicsDriverGetter) (graphicsdriver.Graphics, error) {
 	const envName = "EBITEN_GRAPHICS_LIBRARY"
 
 	switch env := os.Getenv(envName); env {
-	case "", "auto":
+	case "auto":
+		engine = GraphicsEngineAuto
+	case "opengl":
+		engine = GraphicsEngineOpenGL
+	case "directx":
+		engine = GraphicsEngineDirectX
+	case "metal":
+		engine = GraphicsEngineMetal
+	}
+
+	switch engine {
+	case GraphicsEngineAuto:
 		if g := getter.getAuto(); g != nil {
 			return g, nil
 		}
-		return nil, fmt.Errorf("ui: no graphics library is available")
-	case "opengl":
+		return nil, fmt.Errorf("ui: no graphics engine is available")
+	case GraphicsEngineOpenGL:
 		if g := getter.getOpenGL(); g != nil {
 			return g, nil
 		}
-		return nil, fmt.Errorf("ui: %s=%s is specified but OpenGL is not available", envName, env)
-	case "directx":
+		return nil, fmt.Errorf("ui: OpenGL engine is not available")
+	case GraphicsEngineDirectX:
 		if g := getter.getDirectX(); g != nil {
 			return g, nil
 		}
-		return nil, fmt.Errorf("ui: %s=%s is specified but DirectX is not available.", envName, env)
-	case "metal":
+		return nil, fmt.Errorf("ui: DirectX engine is not available")
+	case GraphicsEngineMetal:
 		if g := getter.getMetal(); g != nil {
 			return g, nil
 		}
-		return nil, fmt.Errorf("ui: %s=%s is specified but Metal is not available", envName, env)
+		return nil, fmt.Errorf("ui: Metal engine is not available")
 	default:
-		return nil, fmt.Errorf("ui: an unsupported graphics library is specified: %s", env)
+		return nil, fmt.Errorf("ui: an unsupported graphics engine is specified")
 	}
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -71,6 +71,15 @@ const (
 	WindowResizingModeEnabled
 )
 
+type GraphicsEngine int
+
+const (
+	GraphicsEngineAuto GraphicsEngine = iota
+	GraphicsEngineOpenGL
+	GraphicsEngineMetal
+	GraphicsEngineDirectX
+)
+
 type UserInterface struct {
 	userInterfaceImpl
 }

--- a/internal/ui/ui_cbackend.go
+++ b/internal/ui/ui_cbackend.go
@@ -61,7 +61,7 @@ type userInterfaceImpl struct {
 
 func (u *userInterfaceImpl) Run(game Game) error {
 	u.context = newContext(game)
-	g, err := chooseGraphicsDriver(&graphicsDriverGetterImpl{})
+	g, err := chooseGraphicsDriver(GraphicsEngineAuto, &graphicsDriverGetterImpl{})
 	if err != nil {
 		return err
 	}
@@ -137,6 +137,13 @@ func (*userInterfaceImpl) SetScreenTransparent(transparent bool) {
 }
 
 func (*userInterfaceImpl) SetInitFocused(focused bool) {
+}
+
+func (*userInterfaceImpl) AvailableEngines() []GraphicsEngine {
+	return nil
+}
+
+func (*userInterfaceImpl) SetEngine(engine GraphicsEngine) {
 }
 
 func (*userInterfaceImpl) Input() *Input {

--- a/internal/ui/ui_glfw_darwin.go
+++ b/internal/ui/ui_glfw_darwin.go
@@ -258,6 +258,10 @@ type graphicsDriverGetterImpl struct {
 	transparent bool
 }
 
+func (*graphicsDriverGetterImpl) availableEngines() []GraphicsEngine {
+	return []GraphicsEngine{GraphicsEngineAuto, GraphicsEngineOpenGL, GraphicsEngineMetal}
+}
+
 func (g *graphicsDriverGetterImpl) getAuto() graphicsdriver.Graphics {
 	if m := g.getMetal(); m != nil {
 		return m

--- a/internal/ui/ui_glfw_unix.go
+++ b/internal/ui/ui_glfw_unix.go
@@ -35,6 +35,10 @@ type graphicsDriverGetterImpl struct {
 	transparent bool
 }
 
+func (*graphicsDriverGetterImpl) availableEngines() []GraphicsEngine {
+	return []GraphicsEngine{GraphicsEngineAuto, GraphicsEngineOpenGL}
+}
+
 func (g *graphicsDriverGetterImpl) getAuto() graphicsdriver.Graphics {
 	return g.getOpenGL()
 }

--- a/internal/ui/ui_glfw_windows.go
+++ b/internal/ui/ui_glfw_windows.go
@@ -34,6 +34,15 @@ type graphicsDriverGetterImpl struct {
 	transparent bool
 }
 
+func (g *graphicsDriverGetterImpl) availableEngines() []GraphicsEngine {
+	ret := make([]GraphicsEngine, 0, 3)
+	ret = append(ret, GraphicsEngineAuto, GraphicsEngineOpenGL)
+	if g.transparent {
+		ret = append(ret, GraphicsEngineDirectX)
+	}
+	return ret
+}
+
 func (g *graphicsDriverGetterImpl) getAuto() graphicsdriver.Graphics {
 	if d := g.getDirectX(); d != nil {
 		return d

--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -77,6 +77,7 @@ type userInterfaceImpl struct {
 	renderingScheduled  bool
 	running             bool
 	initFocused         bool
+	engine              GraphicsEngine
 	cursorMode          CursorMode
 	cursorPrevMode      CursorMode
 	cursorShape         CursorShape
@@ -92,6 +93,7 @@ func init() {
 	theUI.userInterfaceImpl = userInterfaceImpl{
 		runnableOnUnfocused: true,
 		initFocused:         true,
+		engine:              GraphicsEngineAuto,
 	}
 	theUI.input.ui = &theUI.userInterfaceImpl
 }
@@ -612,7 +614,7 @@ func (u *userInterfaceImpl) Run(game Game) error {
 		}
 	}
 	u.running = true
-	g, err := chooseGraphicsDriver(&graphicsDriverGetterImpl{})
+	g, err := chooseGraphicsDriver(u.engine, &graphicsDriverGetterImpl{})
 	if err != nil {
 		return err
 	}
@@ -660,6 +662,17 @@ func (u *userInterfaceImpl) SetInitFocused(focused bool) {
 		panic("ui: SetInitFocused must be called before the main loop")
 	}
 	u.initFocused = focused
+}
+
+func (u *userInterfaceImpl) AvailableEngines() []GraphicsEngine {
+	return []GraphicsEngine{GraphicsEngineAuto, GraphicsEngineOpenGL}
+}
+
+func (u *userInterfaceImpl) SetEngine(engine GraphicsEngine) {
+	if u.running {
+		panic("ui: SetEngine must be called before the main loop")
+	}
+	u.engine = engine
 }
 
 func (u *userInterfaceImpl) Input() *Input {

--- a/internal/ui/ui_mobile.go
+++ b/internal/ui/ui_mobile.go
@@ -270,7 +270,7 @@ func (u *userInterfaceImpl) run(game Game, mainloop bool) (err error) {
 	}()
 
 	u.context = newContext(game)
-	g, err := chooseGraphicsDriver(&graphicsDriverGetterImpl{
+	g, err := chooseGraphicsDriver(GraphicsEngineAuto, &graphicsDriverGetterImpl{
 		gomobileBuild: mainloop,
 	})
 	if err != nil {
@@ -429,6 +429,14 @@ func (u *userInterfaceImpl) resetForTick() {
 }
 
 func (u *userInterfaceImpl) SetInitFocused(focused bool) {
+	// Do nothing
+}
+
+func (u *userInterfaceImpl) AvailableEngines() []GraphicsEngine {
+	return nil
+}
+
+func (u *userInterfaceImpl) SetEngine(engine GraphicsEngine) {
 	// Do nothing
 }
 

--- a/run.go
+++ b/run.go
@@ -476,7 +476,42 @@ func SetScreenTransparent(transparent bool) {
 //
 // SetInitFocused panics if this is called after the main loop.
 //
-// SetInitFocused is cuncurrent-safe.
+// SetInitFocused is concurrent-safe.
 func SetInitFocused(focused bool) {
 	ui.Get().SetInitFocused(focused)
+}
+
+// GraphicsEngine is a type of graphics engines.
+type GraphicsEngine = ui.GraphicsEngine
+
+const (
+	// GraphicsEngineAuto indicates that the game will determine the graphics engine to use.
+	// GraphicsEngineAuto is the default engine.
+	GraphicsEngineAuto GraphicsEngine = ui.GraphicsEngineAuto
+
+	// GraphicsEngineOpenGL indicates that the game should try to use OpenGL engine
+	GraphicsEngineOpenGL GraphicsEngine = ui.GraphicsEngineOpenGL
+
+	// GraphicsEngineMetal indicates that the game should try to use Apple Metal engine
+	GraphicsEngineMetal GraphicsEngine = ui.GraphicsEngineMetal
+
+	// GraphicsEngineDirectX indicates that the game should try to use Microsoft DirectX engine
+	GraphicsEngineDirectX GraphicsEngine = ui.GraphicsEngineDirectX
+)
+
+// AvailableEngines returns slice of available graphics engines on current platform.
+//
+// AvailableEngines is concurrent-safe.
+func AvailableEngines() []GraphicsEngine {
+	return ui.Get().AvailableEngines()
+}
+
+// SetEngine sets the graphics engine that will be used after run.
+// The default value is GraphicsEngineAuto.
+//
+// SetEngine panics if this is called after the main loop.
+//
+// SetEngine is concurrent-safe.
+func SetEngine(engine GraphicsEngine) {
+	ui.Get().SetEngine(engine)
 }


### PR DESCRIPTION
I would like to add an option to select the game engine in the Game's options (of course after game re-launch).
Currently I have to check-guess available engines on given platform on the Game side, and I have to play with env variables.
It would be nice to be able to receive a list of available graphics engines and be able to set desired engine before the game starts.