### PR TITLE
internal/graphicsdriver/opengl: replace Get with NewGraphics

### DIFF
--- a/internal/graphicsdriver/opengl/graphics.go
+++ b/internal/graphicsdriver/opengl/graphics.go
@@ -23,13 +23,15 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/internal/shaderir"
 )
 
-var theGraphics Graphics
-
-func Get() *Graphics {
+// NewGraphics creates an implementation of graphicsdriver.Graphcis for OpenGL.
+// The returned graphics value is nil iff the error is not nil.
+func NewGraphics() (graphicsdriver.Graphics, error) {
 	if microsoftgdk.IsXbox() {
-		return nil
+		return nil, fmt.Errorf("opengl: OpenGL is not supported on Xbox")
 	}
-	return &theGraphics
+	g := &Graphics{}
+	g.init()
+	return g, nil
 }
 
 type activatedTexture struct {

--- a/internal/graphicsdriver/opengl/graphics_notmobile.go
+++ b/internal/graphicsdriver/opengl/graphics_notmobile.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Ebiten Authors
+// Copyright 2022 The Ebitengine Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build android || ios
-// +build android ios
+//go:build !android && !ios
+// +build !android,!ios
 
 package opengl
 
-import (
-	"golang.org/x/mobile/gl"
-
-	"github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver/opengl/gles"
-)
-
 func (g *Graphics) init() {
-	g.context.ctx = gles.DefaultContext{}
-}
-
-func (g *Graphics) SetGomobileGLContext(context gl.Context) {
-	g.context.ctx = gles.NewGomobileContext(context)
+	// Do nothing.
 }

--- a/internal/ui/graphics.go
+++ b/internal/ui/graphics.go
@@ -22,8 +22,8 @@ import (
 )
 
 type graphicsDriverGetter interface {
-	getAuto() graphicsdriver.Graphics
-	getOpenGL() graphicsdriver.Graphics
+	newAuto() (graphicsdriver.Graphics, error)
+	newOpenGL() (graphicsdriver.Graphics, error)
 	getDirectX() graphicsdriver.Graphics
 	getMetal() graphicsdriver.Graphics
 }
@@ -33,15 +33,23 @@ func chooseGraphicsDriver(getter graphicsDriverGetter) (graphicsdriver.Graphics,
 
 	switch env := os.Getenv(envName); env {
 	case "", "auto":
-		if g := getter.getAuto(); g != nil {
-			return g, nil
+		g, err := getter.newAuto()
+		if err != nil {
+			return nil, err
 		}
-		return nil, fmt.Errorf("ui: no graphics library is available")
+		if g == nil {
+			return nil, fmt.Errorf("ui: no graphics library is available")
+		}
+		return g, nil
 	case "opengl":
-		if g := getter.getOpenGL(); g != nil {
-			return g, nil
+		g, err := getter.newOpenGL()
+		if err != nil {
+			return nil, err
 		}
-		return nil, fmt.Errorf("ui: %s=%s is specified but OpenGL is not available", envName, env)
+		if g == nil {
+			return nil, fmt.Errorf("ui: %s=%s is specified but OpenGL is not available", envName, env)
+		}
+		return g, nil
 	case "directx":
 		if g := getter.getDirectX(); g != nil {
 			return g, nil

--- a/internal/ui/ui_android.go
+++ b/internal/ui/ui_android.go
@@ -23,15 +23,12 @@ type graphicsDriverGetterImpl struct {
 	gomobileBuild bool
 }
 
-func (g *graphicsDriverGetterImpl) getAuto() graphicsdriver.Graphics {
-	return g.getOpenGL()
+func (g *graphicsDriverGetterImpl) newAuto() (graphicsdriver.Graphics, error) {
+	return g.newOpenGL()
 }
 
-func (*graphicsDriverGetterImpl) getOpenGL() graphicsdriver.Graphics {
-	if g := opengl.Get(); g != nil {
-		return g
-	}
-	return nil
+func (*graphicsDriverGetterImpl) newOpenGL() (graphicsdriver.Graphics, error) {
+	return opengl.NewGraphics()
 }
 
 func (*graphicsDriverGetterImpl) getDirectX() graphicsdriver.Graphics {

--- a/internal/ui/ui_cbackend.go
+++ b/internal/ui/ui_cbackend.go
@@ -27,15 +27,12 @@ import (
 
 type graphicsDriverGetterImpl struct{}
 
-func (g *graphicsDriverGetterImpl) getAuto() graphicsdriver.Graphics {
-	return g.getOpenGL()
+func (g *graphicsDriverGetterImpl) newAuto() (graphicsdriver.Graphics, error) {
+	return g.newOpenGL()
 }
 
-func (*graphicsDriverGetterImpl) getOpenGL() graphicsdriver.Graphics {
-	if g := opengl.Get(); g != nil {
-		return g
-	}
-	return nil
+func (*graphicsDriverGetterImpl) newOpenGL() (graphicsdriver.Graphics, error) {
+	return opengl.NewGraphics()
 }
 
 func (*graphicsDriverGetterImpl) getDirectX() graphicsdriver.Graphics {

--- a/internal/ui/ui_glfw_darwin.go
+++ b/internal/ui/ui_glfw_darwin.go
@@ -258,18 +258,15 @@ type graphicsDriverGetterImpl struct {
 	transparent bool
 }
 
-func (g *graphicsDriverGetterImpl) getAuto() graphicsdriver.Graphics {
+func (g *graphicsDriverGetterImpl) newAuto() (graphicsdriver.Graphics, error) {
 	if m := g.getMetal(); m != nil {
-		return m
+		return m, nil
 	}
-	return g.getOpenGL()
+	return g.newOpenGL()
 }
 
-func (*graphicsDriverGetterImpl) getOpenGL() graphicsdriver.Graphics {
-	if g := opengl.Get(); g != nil {
-		return g
-	}
-	return nil
+func (*graphicsDriverGetterImpl) newOpenGL() (graphicsdriver.Graphics, error) {
+	return opengl.NewGraphics()
 }
 
 func (*graphicsDriverGetterImpl) getDirectX() graphicsdriver.Graphics {

--- a/internal/ui/ui_glfw_unix.go
+++ b/internal/ui/ui_glfw_unix.go
@@ -35,15 +35,12 @@ type graphicsDriverGetterImpl struct {
 	transparent bool
 }
 
-func (g *graphicsDriverGetterImpl) getAuto() graphicsdriver.Graphics {
-	return g.getOpenGL()
+func (g *graphicsDriverGetterImpl) newAuto() (graphicsdriver.Graphics, error) {
+	return g.newOpenGL()
 }
 
-func (*graphicsDriverGetterImpl) getOpenGL() graphicsdriver.Graphics {
-	if g := opengl.Get(); g != nil {
-		return g
-	}
-	return nil
+func (*graphicsDriverGetterImpl) newOpenGL() (graphicsdriver.Graphics, error) {
+	return opengl.NewGraphics()
 }
 
 func (*graphicsDriverGetterImpl) getDirectX() graphicsdriver.Graphics {

--- a/internal/ui/ui_glfw_windows.go
+++ b/internal/ui/ui_glfw_windows.go
@@ -35,18 +35,15 @@ type graphicsDriverGetterImpl struct {
 	transparent bool
 }
 
-func (g *graphicsDriverGetterImpl) getAuto() graphicsdriver.Graphics {
+func (g *graphicsDriverGetterImpl) newAuto() (graphicsdriver.Graphics, error) {
 	if d := g.getDirectX(); d != nil {
-		return d
+		return d, nil
 	}
-	return g.getOpenGL()
+	return g.newOpenGL()
 }
 
-func (*graphicsDriverGetterImpl) getOpenGL() graphicsdriver.Graphics {
-	if g := opengl.Get(); g != nil {
-		return g
-	}
-	return nil
+func (*graphicsDriverGetterImpl) newOpenGL() (graphicsdriver.Graphics, error) {
+	return opengl.NewGraphics()
 }
 
 func (g *graphicsDriverGetterImpl) getDirectX() graphicsdriver.Graphics {

--- a/internal/ui/ui_ios.go
+++ b/internal/ui/ui_ios.go
@@ -27,18 +27,15 @@ type graphicsDriverGetterImpl struct {
 	gomobileBuild bool
 }
 
-func (g *graphicsDriverGetterImpl) getAuto() graphicsdriver.Graphics {
+func (g *graphicsDriverGetterImpl) newAuto() (graphicsdriver.Graphics, error) {
 	if m := g.getMetal(); m != nil {
-		return m
+		return m, nil
 	}
-	return g.getOpenGL()
+	return g.newOpenGL()
 }
 
-func (*graphicsDriverGetterImpl) getOpenGL() graphicsdriver.Graphics {
-	if g := opengl.Get(); g != nil {
-		return g
-	}
-	return nil
+func (*graphicsDriverGetterImpl) newOpenGL() (graphicsdriver.Graphics, error) {
+	return opengl.NewGraphics()
 }
 
 func (*graphicsDriverGetterImpl) getDirectX() graphicsdriver.Graphics {

--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -27,15 +27,12 @@ import (
 
 type graphicsDriverGetterImpl struct{}
 
-func (g *graphicsDriverGetterImpl) getAuto() graphicsdriver.Graphics {
-	return g.getOpenGL()
+func (g *graphicsDriverGetterImpl) newAuto() (graphicsdriver.Graphics, error) {
+	return g.newOpenGL()
 }
 
-func (*graphicsDriverGetterImpl) getOpenGL() graphicsdriver.Graphics {
-	if g := opengl.Get(); g != nil {
-		return g
-	}
-	return nil
+func (*graphicsDriverGetterImpl) newOpenGL() (graphicsdriver.Graphics, error) {
+	return opengl.NewGraphics()
 }
 
 func (*graphicsDriverGetterImpl) getDirectX() graphicsdriver.Graphics {


### PR DESCRIPTION
This is a prepartion to return an error when a graphics driver, especially
DirectX, fails to initialize.

Updates #2142