### PR TITLE
Do not require installing file2byteslice to update go generate'd files.

### DIFF
--- a/audio/vorbis/generate.go
+++ b/audio/vorbis/generate.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate file2byteslice -package=vorbis_test -input=./test_mono.ogg -output=./testmonoogg_test.go -var=test_mono_ogg
-//go:generate file2byteslice -package=vorbis_test -input=./test_tooshort.ogg -output=./testtooshortogg_test.go -var=test_tooshort_ogg
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=vorbis_test -input=./test_mono.ogg -output=./testmonoogg_test.go -var=test_mono_ogg
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=vorbis_test -input=./test_tooshort.ogg -output=./testtooshortogg_test.go -var=test_tooshort_ogg
 //go:generate gofmt -s -w .
 
 package vorbis

--- a/cmd/ebitenmobile/generate.go
+++ b/cmd/ebitenmobile/generate.go
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate file2byteslice -package=main -input=gobind.go -output=gobind.src.go -var gobindsrc
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=main -input=gobind.go -output=gobind.src.go -var gobindsrc
 
 package main

--- a/ebitenutil/internal/assets/assets.go
+++ b/ebitenutil/internal/assets/assets.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //go:generate png2compressedrgba -input text.png -output /tmp/compressedTextRGBA
-//go:generate file2byteslice -input /tmp/compressedTextRGBA -output textrgba.go -package assets -var compressedTextRGBA
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -input /tmp/compressedTextRGBA -output textrgba.go -package assets -var compressedTextRGBA
 //go:generate gofmt -s -w .
 
 package assets

--- a/examples/resources/generate.go
+++ b/examples/resources/generate.go
@@ -12,39 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate file2byteslice -package=audio -input=./audio/jab.wav -output=./audio/jab.go -var=Jab_wav
-//go:generate file2byteslice -package=audio -input=./audio/jump.ogg -output=./audio/jump.go -var=Jump_ogg
-//go:generate file2byteslice -package=audio -input=./audio/ragtime.mp3 -output=./audio/ragtime.mp3.go -var=Ragtime_mp3
-//go:generate file2byteslice -package=audio -input=./audio/ragtime.ogg -output=./audio/ragtime.ogg.go -var=Ragtime_ogg
-//go:generate file2byteslice -package=fonts -input=./fonts/mplus-1p-regular.ttf -output=./fonts/mplus1pregular.go -var=MPlus1pRegular_ttf
-//go:generate file2byteslice -package=fonts -input=./fonts/pressstart2p.ttf -output=./fonts/pressstart2p.go -var=PressStart2P_ttf
-//go:generate file2byteslice -package=images -input=./images/ebiten.png -output=./images/ebiten.go -var=Ebiten_png
-//go:generate file2byteslice -package=images -input=./images/fiveyears.jpg -output=./images/fiveyears.go -var=FiveYears_jpg
-//go:generate file2byteslice -package=images -input=./images/gophers.jpg -output=./images/gophers.go -var=Gophers_jpg
-//go:generate file2byteslice -package=images -input=./images/runner.png -output=./images/runner.go -var=Runner_png
-//go:generate file2byteslice -package=images -input=./images/smoke.png -output=./images/smoke.go -var=Smoke_png
-//go:generate file2byteslice -package=images -input=./images/spritesheet.png -output=./images/spritesheet.go -var=Spritesheet_png
-//go:generate file2byteslice -package=images -input=./images/tile.png -output=./images/tile.go -var=Tile_png
-//go:generate file2byteslice -package=images -input=./images/tiles.png -output=./images/tiles.go -var=Tiles_png
-//go:generate file2byteslice -package=images -input=./images/ui.png -output=./images/ui.go -var=UI_png
-//go:generate file2byteslice -package=audio -input=./images/audio/alert.png -output=./images/audio/alert.go -var=Alert_png
-//go:generate file2byteslice -package=audio -input=./images/audio/pause.png -output=./images/audio/pause.go -var=Pause_png
-//go:generate file2byteslice -package=audio -input=./images/audio/play.png -output=./images/audio/play.go -var=Play_png
-//go:generate file2byteslice -package=blocks -input=./images/blocks/background.png -output=./images/blocks/background.go -var=Background_png
-//go:generate file2byteslice -package=blocks -input=./images/blocks/blocks.png -output=./images/blocks/blocks.go -var=Blocks_png
-//go:generate file2byteslice -package=flappy -input=./images/flappy/gopher.png -output=./images/flappy/gopher.go -var=Gopher_png
-//go:generate file2byteslice -package=flappy -input=./images/flappy/tiles.png -output=./images/flappy/tiles.go -var=Tiles_png
-//go:generate file2byteslice -package=mascot -input=./images/mascot/out01.png -output=./images/mascot/out01.go -var=Out01_png
-//go:generate file2byteslice -package=mascot -input=./images/mascot/out02.png -output=./images/mascot/out02.go -var=Out02_png
-//go:generate file2byteslice -package=mascot -input=./images/mascot/out03.png -output=./images/mascot/out03.go -var=Out03_png
-//go:generate file2byteslice -package=shader -input=./images/shader/gopher.png -output=./images/shader/gopher.go -var=Gopher_png
-//go:generate file2byteslice -package=shader -input=./images/shader/gopherbg.png -output=./images/shader/gopherbg.go -var=GopherBg_png
-//go:generate file2byteslice -package=shader -input=./images/shader/normal.png -output=./images/shader/normal.go -var=Normal_png
-//go:generate file2byteslice -package=shader -input=./images/shader/noise.png -output=./images/shader/noise.go -var=Noise_png
-//go:generate file2byteslice -package=platformer -input=./images/platformer/background.png -output=./images/platformer/background.go -var=Background_png
-//go:generate file2byteslice -package=platformer -input=./images/platformer/left.png -output=./images/platformer/left.go -var=Left_png
-//go:generate file2byteslice -package=platformer -input=./images/platformer/mainchar.png -output=./images/platformer/mainchar.go -var=MainChar_png
-//go:generate file2byteslice -package=platformer -input=./images/platformer/right.png -output=./images/platformer/right.go -var=Right_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=audio -input=./audio/jab.wav -output=./audio/jab.go -var=Jab_wav
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=audio -input=./audio/jump.ogg -output=./audio/jump.go -var=Jump_ogg
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=audio -input=./audio/ragtime.mp3 -output=./audio/ragtime.mp3.go -var=Ragtime_mp3
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=audio -input=./audio/ragtime.ogg -output=./audio/ragtime.ogg.go -var=Ragtime_ogg
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=fonts -input=./fonts/mplus-1p-regular.ttf -output=./fonts/mplus1pregular.go -var=MPlus1pRegular_ttf
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=fonts -input=./fonts/pressstart2p.ttf -output=./fonts/pressstart2p.go -var=PressStart2P_ttf
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=images -input=./images/ebiten.png -output=./images/ebiten.go -var=Ebiten_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=images -input=./images/fiveyears.jpg -output=./images/fiveyears.go -var=FiveYears_jpg
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=images -input=./images/gophers.jpg -output=./images/gophers.go -var=Gophers_jpg
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=images -input=./images/runner.png -output=./images/runner.go -var=Runner_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=images -input=./images/smoke.png -output=./images/smoke.go -var=Smoke_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=images -input=./images/spritesheet.png -output=./images/spritesheet.go -var=Spritesheet_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=images -input=./images/tile.png -output=./images/tile.go -var=Tile_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=images -input=./images/tiles.png -output=./images/tiles.go -var=Tiles_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=images -input=./images/ui.png -output=./images/ui.go -var=UI_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=audio -input=./images/audio/alert.png -output=./images/audio/alert.go -var=Alert_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=audio -input=./images/audio/pause.png -output=./images/audio/pause.go -var=Pause_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=audio -input=./images/audio/play.png -output=./images/audio/play.go -var=Play_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=blocks -input=./images/blocks/background.png -output=./images/blocks/background.go -var=Background_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=blocks -input=./images/blocks/blocks.png -output=./images/blocks/blocks.go -var=Blocks_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=flappy -input=./images/flappy/gopher.png -output=./images/flappy/gopher.go -var=Gopher_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=flappy -input=./images/flappy/tiles.png -output=./images/flappy/tiles.go -var=Tiles_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=mascot -input=./images/mascot/out01.png -output=./images/mascot/out01.go -var=Out01_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=mascot -input=./images/mascot/out02.png -output=./images/mascot/out02.go -var=Out02_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=mascot -input=./images/mascot/out03.png -output=./images/mascot/out03.go -var=Out03_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=shader -input=./images/shader/gopher.png -output=./images/shader/gopher.go -var=Gopher_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=shader -input=./images/shader/gopherbg.png -output=./images/shader/gopherbg.go -var=GopherBg_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=shader -input=./images/shader/normal.png -output=./images/shader/normal.go -var=Normal_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=shader -input=./images/shader/noise.png -output=./images/shader/noise.go -var=Noise_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=platformer -input=./images/platformer/background.png -output=./images/platformer/background.go -var=Background_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=platformer -input=./images/platformer/left.png -output=./images/platformer/left.go -var=Left_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=platformer -input=./images/platformer/mainchar.png -output=./images/platformer/mainchar.go -var=MainChar_png
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=platformer -input=./images/platformer/right.png -output=./images/platformer/right.go -var=Right_png
 //go:generate gofmt -s -w .
 
 package resources

--- a/examples/shader/generate.go
+++ b/examples/shader/generate.go
@@ -17,11 +17,11 @@
 
 package main
 
-//go:generate file2byteslice -package=main -input=default.go -output=default_go.go -var=default_go -buildtags=example
-//go:generate file2byteslice -package=main -input=texel.go -output=texel_go.go -var=texel_go -buildtags=example
-//go:generate file2byteslice -package=main -input=lighting.go -output=lighting_go.go -var=lighting_go -buildtags=example
-//go:generate file2byteslice -package=main -input=radialblur.go -output=radialblur_go.go -var=radialblur_go -buildtags=example
-//go:generate file2byteslice -package=main -input=chromaticaberration.go -output=chromaticaberration_go.go -var=chromaticaberration_go -buildtags=example
-//go:generate file2byteslice -package=main -input=dissolve.go -output=dissolve_go.go -var=dissolve_go -buildtags=example
-//go:generate file2byteslice -package=main -input=water.go -output=water_go.go -var=water_go -buildtags=example
-//go:generate file2byteslice -package=main -input=crt.go -output=crt_go.go -var=crt_go -buildtags=example
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=main -input=default.go -output=default_go.go -var=default_go -buildtags=example
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=main -input=texel.go -output=texel_go.go -var=texel_go -buildtags=example
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=main -input=lighting.go -output=lighting_go.go -var=lighting_go -buildtags=example
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=main -input=radialblur.go -output=radialblur_go.go -var=radialblur_go -buildtags=example
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=main -input=chromaticaberration.go -output=chromaticaberration_go.go -var=chromaticaberration_go -buildtags=example
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=main -input=dissolve.go -output=dissolve_go.go -var=dissolve_go -buildtags=example
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=main -input=water.go -output=water_go.go -var=water_go -buildtags=example
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package=main -input=crt.go -output=crt_go.go -var=crt_go -buildtags=example

--- a/internal/gamepaddb/gamepaddb.go
+++ b/internal/gamepaddb/gamepaddb.go
@@ -18,7 +18,7 @@
 //
 //     curl --location --remote-name https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/master/gamecontrollerdb.txt
 
-//go:generate file2byteslice -package gamepaddb -input=./gamecontrollerdb.txt -output=./gamecontrollerdb.txt.go -var=gamecontrollerdbTxt
+//go:generate go run github.com/hajimehoshi/file2byteslice/cmd/file2byteslice -package gamepaddb -input=./gamecontrollerdb.txt -output=./gamecontrollerdb.txt.go -var=gamecontrollerdbTxt
 
 package gamepaddb
 


### PR DESCRIPTION
The tool is already referenced in `go.mod`, so it is trivial to just `go run` it - that way, `go generate` can use it without the user explicitly installing it first.

Tested: modifying `gobind.go` and running `go generate` now applies correctly to `gobind.src.go`.

Note that this means that `GOOS=windows go generate` no longer will work on Linux - if this is a problem, we could prepend the `go` command with `env GOOS= GOARCH=` every time. This same limitation also already exists for some of your `go run` commands in there, though, so I thought it's fine to keep it that way.