### PR TITLE
ci: Add spell checking ref #2227

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,6 +15,11 @@ jobs:
           cond: ${{ github.event_name == 'pull_request' }}
           if_true: "github-pr-review"
           if_false: "github-check"
+      - name: Generate list of generated files
+        uses: gh640/command-result-action@v1  # see https://gotohayato.com/content/558/
+        id: generate
+        with:
+          command: grep -l -F "DO NOT EDIT" -R .
       - name: misspell
         uses: reviewdog/action-misspell@v1
         with:
@@ -23,4 +28,4 @@ jobs:
             *.go
           exclude: |
             ./.git/*
-            ./examples/resources/*
+            ${{ steps.generate.outputs.stdout }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -16,7 +16,7 @@ jobs:
           if_true: "github-pr-review"
           if_false: "github-check"
       - name: Generate list of generated files
-        uses: gh640/command-result-action@v1  # see https://gotohayato.com/content/558/
+        uses: gh640/command-result-action@v1
         id: generate
         with:
           command: grep -l -F "DO NOT EDIT" -R .

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -18,7 +18,6 @@ jobs:
       - name: misspell
         uses: reviewdog/action-misspell@v1
         with:
-          github_token: ${{ secrets.github_token }}
           reporter: ${{ steps.reporter.outputs.value }}
           pattern: |
             *.go

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -22,3 +22,6 @@ jobs:
           reporter: ${{ steps.reporter.outputs.value }}
           pattern: |
             *.go
+          exclude: |
+            ./.git/*
+            ./examples/resources/*

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,24 @@
+name: reviewdog
+
+on: [push, pull_request]
+
+jobs:
+  misspell:
+    name: runner / misspell
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code.
+        uses: actions/checkout@v3
+      - uses: haya14busa/action-cond@v1
+        id: reporter
+        with:
+          cond: ${{ github.event_name == 'pull_request' }}
+          if_true: "github-pr-review"
+          if_false: "github-check"
+      - name: misspell
+        uses: reviewdog/action-misspell@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: ${{ steps.reporter.outputs.value }}
+          pattern: |
+            *.go


### PR DESCRIPTION

Inspired #2227.

Add code spell cheking for `go` files.

Fork repo test result example (before #2227 merged)
https://github.com/tsuyoshicho/ebiten/runs/7651519891?check_suite_focus=true