### PR TITLE
linux: Fix a typo that caused oddly cut off gamepad names.

### DIFF
--- a/internal/gamepad/gamepad_linux.go
+++ b/internal/gamepad/gamepad_linux.go
@@ -149,7 +149,7 @@ func (*nativeGamepadsImpl) openGamepad(gamepads *gamepads, path string) (err err
 	cname := make([]byte, 256)
 	name := "Unknown"
 	// TODO: Is it OK to ignore the error here?
-	if err := ioctl(fd, uint(_EVIOCGNAME(uint(len(name)))), unsafe.Pointer(&cname[0])); err == nil {
+	if err := ioctl(fd, uint(_EVIOCGNAME(uint(len(cname)))), unsafe.Pointer(&cname[0])); err == nil {
 		name = unix.ByteSliceToString(cname)
 	}
 


### PR DESCRIPTION
This change allows gamepad names up to 256 characters, which is usually
enough. Before, names were cut off after 7 characters, matching the string
"Unknown" that is used if querying the name fails.