### PR TITLE
linux/gamepad: Do not fail on EPERM return values.

### DIFF
--- a/internal/gamepad/gamepad_linux.go
+++ b/internal/gamepad/gamepad_linux.go
@@ -108,6 +108,10 @@ func (*nativeGamepadsImpl) openGamepad(gamepads *gamepads, path string) (err err
 		if err == unix.EACCES {
 			return nil
 		}
+		// This happens with the Snap sandbox.
+		if err == unix.EPERM {
+			return nil
+		}
 		// This happens just after a disconnection.
 		if err == unix.ENOENT {
 			return nil


### PR DESCRIPTION
This appears to happen inside the Snap sandbox when accessing a non-gamepad /dev/input device.