### PR TITLE
internal/gamepaddb: fix mapping support for e.g. `dpleft:-a0`.

### DIFF
--- a/internal/gamepaddb/gamepaddb.go
+++ b/internal/gamepaddb/gamepaddb.go
@@ -228,14 +228,30 @@ func parseMappingElement(str string) (*mapping, error) {
 
 		if str[0] == '+' {
 			numstr = str[2:]
+			// Only use the positive half, i.e. 0..1.
 			min = 0
 		} else if str[0] == '-' {
 			numstr = str[2:]
-			max = 0
+			// Only use the negative half, i.e. -1..0,
+			// but invert the sense so 0 does not "press" buttons.
+			//
+			// In other words, this is the same as '+' but with the input axis
+			// value reversed.
+			//
+			// See SDL's source:
+			// https://github.com/libsdl-org/SDL/blob/f398d8a42422c049d77c744658f1cd2bb011ed4a/src/joystick/SDL_gamecontroller.c#L960
+			min, max = 0, min
 		}
 
+		// Map min..max to -1..+1.
+		//
+		// See SDL's source:
+		// https://github.com/libsdl-org/SDL/blob/f398d8a42422c049d77c744658f1cd2bb011ed4a/src/joystick/SDL_gamecontroller.c#L276
+		// then simplify assuming output range -1..+1.
+		//
+		// Yields:
 		scale := 2 / (max - min)
-		offset := -(max + min)
+		offset := -(max + min) / (max - min)
 		if tilda {
 			scale = -scale
 			offset = -offset


### PR DESCRIPTION
SDL interprets this as "map -1 to 1, map 0 to -1", so we should do the same.

This fix contains two parts:

- Fix the intended output range.
- Also fix the formula to map a range to a range.

The fix does not change behavior if a "-a" mapping isn't used, as in any other case max-min == 1 or max+min == 0.

Fixes #2334 