### PR TITLE
examples/audio: reduce the noticeable delay when playing the sound effect

### DIFF
--- a/examples/audio/main.go
+++ b/examples/audio/main.go
@@ -51,12 +51,12 @@ const (
 var (
 	playerBarColor     = color.RGBA{0x80, 0x80, 0x80, 0xff}
 	playerCurrentColor = color.RGBA{0xff, 0xff, 0xff, 0xff}
-)
 
-var (
 	playButtonImage  *ebiten.Image
 	pauseButtonImage *ebiten.Image
 	alertButtonImage *ebiten.Image
+
+	sePlayer *audio.Player
 )
 
 func init() {
@@ -247,7 +247,12 @@ func (p *Player) playSEIfNeeded() {
 	if !p.shouldPlaySE() {
 		return
 	}
-	sePlayer := p.audioContext.NewPlayerFromBytes(p.seBytes)
+	if sePlayer == nil {
+		sePlayer = p.audioContext.NewPlayerFromBytes(p.seBytes)
+	} else {
+		sePlayer.Pause()
+		sePlayer.Rewind()
+	}
 	sePlayer.Play()
 }
 


### PR DESCRIPTION
There was a noticeable delay each time the sound effect was played (when pressing the `p` button).

With these changes, there is only a slight delay the first time the button is pressed, but not for the following key-presses.