### PR TITLE
image: reorder fields as recommended by the fieldalignment utility

### DIFF
--- a/image.go
+++ b/image.go
@@ -32,14 +32,11 @@ import (
 type Image struct {
 	// addr holds self to check copying.
 	// See strings.Builder for similar examples.
-	addr *Image
-
-	image *ui.Image
-
-	bounds   image.Rectangle
-	original *Image
-
+	addr             *Image
+	image            *ui.Image
+	original         *Image
 	setVerticesCache map[[2]int][4]byte
+	bounds           image.Rectangle
 }
 
 var emptyImage *Image


### PR DESCRIPTION
This reduces the struct size from 64 to 32 bytes.