### PR TITLE
all: use RTLD_LAZY in dlopen for darwin

### DIFF
--- a/internal/gamepad/api_cf_darwin.go
+++ b/internal/gamepad/api_cf_darwin.go
@@ -50,7 +50,7 @@ const (
 )
 
 var (
-	corefoundation                = purego.Dlopen("CoreFoundation.framework/CoreFoundation", purego.RTLD_GLOBAL)
+	corefoundation                = purego.Dlopen("CoreFoundation.framework/CoreFoundation", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 	procCFNumberCreate            = purego.Dlsym(corefoundation, "CFNumberCreate")
 	procCFNumberGetValue          = purego.Dlsym(corefoundation, "CFNumberGetValue")
 	procCFArrayCreate             = purego.Dlsym(corefoundation, "CFArrayCreate")

--- a/internal/gamepad/api_hid_darwin.go
+++ b/internal/gamepad/api_hid_darwin.go
@@ -85,7 +85,7 @@ type _IOHIDElementType uint32
 type _IOHIDDeviceCallback func(context unsafe.Pointer, result _IOReturn, sender unsafe.Pointer, device _IOHIDDeviceRef)
 
 var (
-	iokit = purego.Dlopen("IOKit.framework/IOKit", purego.RTLD_GLOBAL)
+	iokit = purego.Dlopen("IOKit.framework/IOKit", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 
 	procIOHIDElementGetTypeID                      = purego.Dlsym(iokit, "IOHIDElementGetTypeID")
 	procIOHIDManagerCreate                         = purego.Dlsym(iokit, "IOHIDManagerCreate")

--- a/internal/graphicsdriver/metal/ca/ca_darwin.go
+++ b/internal/graphicsdriver/metal/ca/ca_darwin.go
@@ -49,7 +49,7 @@ type MetalLayer struct {
 }
 
 var (
-	coreGraphics                = purego.Dlopen("/System/Library/Frameworks/CoreGraphics.framework/Versions/Current/CoreGraphics", purego.RTLD_GLOBAL)
+	coreGraphics                = purego.Dlopen("/System/Library/Frameworks/CoreGraphics.framework/Versions/Current/CoreGraphics", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 	_CGColorSpaceCreateWithName = purego.Dlsym(coreGraphics, "CGColorSpaceCreateWithName")
 	_CGColorSpaceRelease        = purego.Dlsym(coreGraphics, "CGColorSpaceRelease")
 	kCGColorSpaceDisplayP3      = purego.Dlsym(coreGraphics, "kCGColorSpaceDisplayP3")

--- a/internal/graphicsdriver/metal/mtl/example_darwin_test.go
+++ b/internal/graphicsdriver/metal/mtl/example_darwin_test.go
@@ -35,7 +35,7 @@ func init() {
 	//go:cgo_import_dynamic _ _ "Metal.framework/Metal"
 
 	// It is also necessary for CoreGraphics to be linked
-	purego.Dlopen("/System/Library/Frameworks/CoreGraphics.framework/Versions/Current/CoreGraphics", purego.RTLD_GLOBAL)
+	purego.Dlopen("/System/Library/Frameworks/CoreGraphics.framework/Versions/Current/CoreGraphics", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 }
 
 func Example_listDevices() {

--- a/internal/graphicsdriver/metal/mtl/mtl_darwin.go
+++ b/internal/graphicsdriver/metal/mtl/mtl_darwin.go
@@ -348,7 +348,7 @@ const (
 )
 
 var (
-	metal                         = purego.Dlopen("Metal.framework/Metal", purego.RTLD_GLOBAL)
+	metal                         = purego.Dlopen("Metal.framework/Metal", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 	_MTLCreateSystemDefaultDevice = purego.Dlsym(metal, "MTLCreateSystemDefaultDevice")
 )
 

--- a/internal/graphicsdriver/opengl/gl/procaddr_darwin.go
+++ b/internal/graphicsdriver/opengl/gl/procaddr_darwin.go
@@ -24,12 +24,12 @@ var (
 )
 
 func init() {
-	opengl = purego.Dlopen("/System/Library/Frameworks/OpenGLES.framework/Versions/Current/OpenGLES", purego.RTLD_GLOBAL)
+	opengl = purego.Dlopen("/System/Library/Frameworks/OpenGLES.framework/Versions/Current/OpenGLES", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 	if opengl != 0 {
 		isES = true
 		return
 	}
-	opengl = purego.Dlopen("/System/Library/Frameworks/OpenGL.framework/Versions/Current/OpenGL", purego.RTLD_GLOBAL)
+	opengl = purego.Dlopen("/System/Library/Frameworks/OpenGL.framework/Versions/Current/OpenGL", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 }
 
 func getProcAddress(name string) uintptr {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
Updates #1162

## What _type_ of issue is this addressing?
bug 

## What this PR does | solves
dlopen requires either RTLD_LAZY or RTLD_NOW but there was neither.
