### PR TITLE
internal/cocoa & internal/graphicsdriver/mtl: remove usages of NSInvocations to directly call ID.Send

### DIFF
--- a/internal/cocoa/api_cocoa_darwin.go
+++ b/internal/cocoa/api_cocoa_darwin.go
@@ -108,16 +108,7 @@ type NSColor struct {
 }
 
 func NSColor_colorWithSRGBRedGreenBlueAlpha(red, green, blue, alpha CGFloat) (color NSColor) {
-	sig := NSMethodSignature_signatureWithObjCTypes("@@:ffff")
-	inv := NSInvocation_invocationWithMethodSignature(sig)
-	inv.SetSelector(sel_colorWithSRGBRedGreenBlueAlpha)
-	inv.SetArgumentAtIndex(unsafe.Pointer(&red), 2)
-	inv.SetArgumentAtIndex(unsafe.Pointer(&green), 3)
-	inv.SetArgumentAtIndex(unsafe.Pointer(&blue), 4)
-	inv.SetArgumentAtIndex(unsafe.Pointer(&alpha), 5)
-	inv.InvokeWithTarget(objc.ID(class_NSColor))
-	inv.GetReturnValue(unsafe.Pointer(&color))
-	return color
+	return NSColor{objc.ID(class_NSColor).Send(sel_colorWithSRGBRedGreenBlueAlpha, red, green, blue, alpha)}
 }
 
 type NSOperatingSystemVersion struct {

--- a/internal/graphicsdriver/metal/mtl/mtl_darwin.go
+++ b/internal/graphicsdriver/metal/mtl/mtl_darwin.go
@@ -910,14 +910,7 @@ func (rce RenderCommandEncoder) SetFragmentTexture(texture Texture, index int) {
 }
 
 func (rce RenderCommandEncoder) SetBlendColor(red, green, blue, alpha float32) {
-	inv := cocoa.NSInvocation_invocationWithMethodSignature(cocoa.NSMethodSignature_signatureWithObjCTypes("v@:ffff"))
-	inv.SetTarget(rce.commandEncoder)
-	inv.SetSelector(sel_setBlendColorRedGreenBlueAlpha)
-	inv.SetArgumentAtIndex(unsafe.Pointer(&red), 2)
-	inv.SetArgumentAtIndex(unsafe.Pointer(&green), 3)
-	inv.SetArgumentAtIndex(unsafe.Pointer(&blue), 4)
-	inv.SetArgumentAtIndex(unsafe.Pointer(&alpha), 5)
-	inv.Invoke()
+	rce.commandEncoder.Send(sel_setBlendColorRedGreenBlueAlpha, red, green, blue, alpha)
 }
 
 // SetDepthStencilState sets the depth and stencil test state.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
Updates #1162 

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
purego now supports using floats as arguments. We can remove these instances of NSInvocation that only existed to circumvent that feature.