### PR TITLE
internal/gamepad: use RegisterLibFunc

### DIFF
--- a/internal/gamepad/api_cf_darwin.go
+++ b/internal/gamepad/api_cf_darwin.go
@@ -50,19 +50,7 @@ const (
 )
 
 var (
-	corefoundation                = purego.Dlopen("CoreFoundation.framework/CoreFoundation", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
-	procCFNumberCreate            = purego.Dlsym(corefoundation, "CFNumberCreate")
-	procCFNumberGetValue          = purego.Dlsym(corefoundation, "CFNumberGetValue")
-	procCFArrayCreate             = purego.Dlsym(corefoundation, "CFArrayCreate")
-	procCFArrayGetCount           = purego.Dlsym(corefoundation, "CFArrayGetCount")
-	procCFArrayGetValueAtIndex    = purego.Dlsym(corefoundation, "CFArrayGetValueAtIndex")
-	procCFDictionaryCreate        = purego.Dlsym(corefoundation, "CFDictionaryCreate")
-	procCFRelease                 = purego.Dlsym(corefoundation, "CFRelease")
-	procCFRunLoopGetMain          = purego.Dlsym(corefoundation, "CFRunLoopGetMain")
-	procCFRunLoopRunInMode        = purego.Dlsym(corefoundation, "CFRunLoopRunInMode")
-	procCFGetTypeID               = purego.Dlsym(corefoundation, "CFGetTypeID")
-	procCFStringGetCString        = purego.Dlsym(corefoundation, "CFStringGetCString")
-	procCFStringCreateWithCString = purego.Dlsym(corefoundation, "CFStringCreateWithCString")
+	corefoundation = purego.Dlopen("CoreFoundation.framework/CoreFoundation", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 
 	kCFTypeDictionaryKeyCallBacks   = purego.Dlsym(corefoundation, "kCFTypeDictionaryKeyCallBacks")
 	kCFTypeDictionaryValueCallBacks = purego.Dlsym(corefoundation, "kCFTypeDictionaryValueCallBacks")
@@ -70,69 +58,41 @@ var (
 	kCFRunLoopDefaultMode           = purego.Dlsym(corefoundation, "kCFRunLoopDefaultMode")
 )
 
-func _CFNumberCreate(allocator _CFAllocatorRef, theType _CFNumberType, valuePtr unsafe.Pointer) _CFNumberRef {
-	number, _, _ := purego.SyscallN(procCFNumberCreate, uintptr(allocator), uintptr(theType), uintptr(valuePtr))
-	return _CFNumberRef(number)
+func init() {
+	purego.RegisterLibFunc(&_CFNumberCreate, corefoundation, "CFNumberCreate")
+	purego.RegisterLibFunc(&_CFNumberGetValue, corefoundation, "CFNumberGetValue")
+	purego.RegisterLibFunc(&_CFArrayCreate, corefoundation, "CFArrayCreate")
+	purego.RegisterLibFunc(&_CFArrayGetValueAtIndex, corefoundation, "CFArrayGetValueAtIndex")
+	purego.RegisterLibFunc(&_CFArrayGetCount, corefoundation, "CFArrayGetCount")
+	purego.RegisterLibFunc(&_CFDictionaryCreate, corefoundation, "CFDictionaryCreate")
+	purego.RegisterLibFunc(&_CFRelease, corefoundation, "CFRelease")
+	purego.RegisterLibFunc(&_CFRunLoopGetMain, corefoundation, "CFRunLoopGetMain")
+	purego.RegisterLibFunc(&_CFRunLoopRunInMode, corefoundation, "CFRunLoopRunInMode")
+	purego.RegisterLibFunc(&_CFGetTypeID, corefoundation, "CFGetTypeID")
+	purego.RegisterLibFunc(&_CFStringGetCString, corefoundation, "CFStringGetCString")
+	purego.RegisterLibFunc(&_CFStringCreateWithCString, corefoundation, "CFStringCreateWithCString")
 }
 
-func _CFNumberGetValue(number _CFNumberRef, theType _CFNumberType, valuePtr unsafe.Pointer) bool {
-	ret, _, _ := purego.SyscallN(procCFNumberGetValue, uintptr(number), uintptr(theType), uintptr(valuePtr))
-	return ret != 0
-}
+var _CFNumberCreate func(allocator _CFAllocatorRef, theType _CFNumberType, valuePtr unsafe.Pointer) _CFNumberRef
 
-func _CFArrayCreate(allocator _CFAllocatorRef, values *unsafe.Pointer, numValues _CFIndex, callbacks *_CFArrayCallBacks) _CFArrayRef {
-	ret, _, _ := purego.SyscallN(procCFArrayCreate, uintptr(allocator), uintptr(unsafe.Pointer(values)), uintptr(numValues), uintptr(unsafe.Pointer(callbacks)))
-	return _CFArrayRef(ret)
-}
+var _CFNumberGetValue func(number _CFNumberRef, theType _CFNumberType, valuePtr unsafe.Pointer) bool
 
-func _CFArrayGetValueAtIndex(array _CFArrayRef, index _CFIndex) uintptr {
-	ret, _, _ := purego.SyscallN(procCFArrayGetValueAtIndex, uintptr(array), uintptr(index))
-	return ret
-}
+var _CFArrayCreate func(allocator _CFAllocatorRef, values *unsafe.Pointer, numValues _CFIndex, callbacks *_CFArrayCallBacks) _CFArrayRef
 
-func _CFArrayGetCount(array _CFArrayRef) _CFIndex {
-	ret, _, _ := purego.SyscallN(procCFArrayGetCount, uintptr(array))
-	return _CFIndex(ret)
-}
+var _CFArrayGetValueAtIndex func(array _CFArrayRef, index _CFIndex) uintptr
 
-func _CFDictionaryCreate(allocator _CFAllocatorRef, keys *unsafe.Pointer, values *unsafe.Pointer, numValues _CFIndex, keyCallBacks *_CFDictionaryKeyCallBacks, valueCallBacks *_CFDictionaryValueCallBacks) _CFDictionaryRef {
-	ret, _, _ := purego.SyscallN(procCFDictionaryCreate, uintptr(allocator), uintptr(unsafe.Pointer(keys)), uintptr(unsafe.Pointer(values)), uintptr(numValues), uintptr(unsafe.Pointer(keyCallBacks)), uintptr(unsafe.Pointer(valueCallBacks)))
-	return _CFDictionaryRef(ret)
-}
+var _CFArrayGetCount func(array _CFArrayRef) _CFIndex
 
-func _CFRelease(cf _CFTypeRef) {
-	purego.SyscallN(procCFRelease, uintptr(cf))
-}
+var _CFDictionaryCreate func(allocator _CFAllocatorRef, keys *unsafe.Pointer, values *unsafe.Pointer, numValues _CFIndex, keyCallBacks *_CFDictionaryKeyCallBacks, valueCallBacks *_CFDictionaryValueCallBacks) _CFDictionaryRef
 
-func _CFRunLoopGetMain() _CFRunLoopRef {
-	ret, _, _ := purego.SyscallN(procCFRunLoopGetMain)
-	return _CFRunLoopRef(ret)
-}
+var _CFRelease func(cf _CFTypeRef)
 
-func _CFRunLoopRunInMode(mode _CFRunLoopMode, seconds _CFTimeInterval, returnAfterSourceHandled bool) _CFRunLoopRunResult {
-	var b uintptr
-	if returnAfterSourceHandled {
-		b = 1
-	}
-	if seconds != 0 {
-		panic("corefoundation: seconds greater than 0 is not supported")
-	}
-	// TODO: support floats
-	ret, _, _ := purego.SyscallN(procCFRunLoopRunInMode, uintptr(mode), b)
-	return _CFRunLoopRunResult(ret)
-}
+var _CFRunLoopGetMain func() _CFRunLoopRef
 
-func _CFGetTypeID(cf _CFTypeRef) _CFTypeID {
-	ret, _, _ := purego.SyscallN(procCFGetTypeID, uintptr(cf))
-	return _CFTypeID(ret)
-}
+var _CFRunLoopRunInMode func(mode _CFRunLoopMode, seconds _CFTimeInterval, returnAfterSourceHandled bool) _CFRunLoopRunResult
 
-func _CFStringGetCString(theString _CFStringRef, buffer []byte, encoding _CFStringEncoding) bool {
-	ret, _, _ := purego.SyscallN(procCFStringGetCString, uintptr(theString), uintptr(unsafe.Pointer(&buffer[0])), uintptr(len(buffer)), uintptr(encoding))
-	return ret != 0
-}
+var _CFGetTypeID func(cf _CFTypeRef) _CFTypeID
 
-func _CFStringCreateWithCString(alloc _CFAllocatorRef, cstr []byte, encoding _CFStringEncoding) _CFStringRef {
-	ret, _, _ := purego.SyscallN(procCFStringCreateWithCString, uintptr(alloc), uintptr(unsafe.Pointer(&cstr[0])), uintptr(encoding))
-	return _CFStringRef(ret)
-}
+var _CFStringGetCString func(theString _CFStringRef, buffer []byte, encoding _CFStringEncoding) bool
+
+var _CFStringCreateWithCString func(alloc _CFAllocatorRef, cstr []byte, encoding _CFStringEncoding) _CFStringRef

--- a/internal/gamepad/api_hid_darwin.go
+++ b/internal/gamepad/api_hid_darwin.go
@@ -84,102 +84,55 @@ type _IOHIDElementType uint32
 
 type _IOHIDDeviceCallback func(context unsafe.Pointer, result _IOReturn, sender unsafe.Pointer, device _IOHIDDeviceRef)
 
-var (
-	iokit = purego.Dlopen("IOKit.framework/IOKit", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
+func init() {
+	iokit := purego.Dlopen("IOKit.framework/IOKit", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 
-	procIOHIDElementGetTypeID                      = purego.Dlsym(iokit, "IOHIDElementGetTypeID")
-	procIOHIDManagerCreate                         = purego.Dlsym(iokit, "IOHIDManagerCreate")
-	procIOHIDDeviceGetProperty                     = purego.Dlsym(iokit, "IOHIDDeviceGetProperty")
-	procIOHIDManagerOpen                           = purego.Dlsym(iokit, "IOHIDManagerOpen")
-	procIOHIDManagerSetDeviceMatchingMultiple      = purego.Dlsym(iokit, "IOHIDManagerSetDeviceMatchingMultiple")
-	procIOHIDManagerRegisterDeviceMatchingCallback = purego.Dlsym(iokit, "IOHIDManagerRegisterDeviceMatchingCallback")
-	procIOHIDManagerRegisterDeviceRemovalCallback  = purego.Dlsym(iokit, "IOHIDManagerRegisterDeviceRemovalCallback")
-	procIOHIDManagerScheduleWithRunLoop            = purego.Dlsym(iokit, "IOHIDManagerScheduleWithRunLoop")
-	procIOHIDElementGetType                        = purego.Dlsym(iokit, "IOHIDElementGetType")
-	procIOHIDElementGetUsage                       = purego.Dlsym(iokit, "IOHIDElementGetUsage")
-	procIOHIDElementGetUsagePage                   = purego.Dlsym(iokit, "IOHIDElementGetUsagePage")
-	procIOHIDElementGetLogicalMin                  = purego.Dlsym(iokit, "IOHIDElementGetLogicalMin")
-	procIOHIDElementGetLogicalMax                  = purego.Dlsym(iokit, "IOHIDElementGetLogicalMax")
-	procIOHIDDeviceGetValue                        = purego.Dlsym(iokit, "IOHIDDeviceGetValue")
-	procIOHIDValueGetIntegerValue                  = purego.Dlsym(iokit, "IOHIDValueGetIntegerValue")
-	procIOHIDDeviceCopyMatchingElements            = purego.Dlsym(iokit, "IOHIDDeviceCopyMatchingElements")
-)
-
-func _IOHIDElementGetTypeID() _CFTypeID {
-	ret, _, _ := purego.SyscallN(procIOHIDElementGetTypeID)
-	return _CFTypeID(ret)
+	purego.RegisterLibFunc(&_IOHIDElementGetTypeID, iokit, "IOHIDElementGetTypeID")
+	purego.RegisterLibFunc(&_IOHIDManagerCreate, iokit, "IOHIDManagerCreate")
+	purego.RegisterLibFunc(&_IOHIDDeviceGetProperty, iokit, "IOHIDDeviceGetProperty")
+	purego.RegisterLibFunc(&_IOHIDManagerOpen, iokit, "IOHIDManagerOpen")
+	purego.RegisterLibFunc(&_IOHIDManagerSetDeviceMatchingMultiple, iokit, "IOHIDManagerSetDeviceMatchingMultiple")
+	purego.RegisterLibFunc(&_IOHIDManagerRegisterDeviceMatchingCallback, iokit, "IOHIDManagerRegisterDeviceMatchingCallback")
+	purego.RegisterLibFunc(&_IOHIDManagerRegisterDeviceRemovalCallback, iokit, "IOHIDManagerRegisterDeviceRemovalCallback")
+	purego.RegisterLibFunc(&_IOHIDManagerScheduleWithRunLoop, iokit, "IOHIDManagerScheduleWithRunLoop")
+	purego.RegisterLibFunc(&_IOHIDElementGetType, iokit, "IOHIDElementGetType")
+	purego.RegisterLibFunc(&_IOHIDElementGetUsage, iokit, "IOHIDElementGetUsage")
+	purego.RegisterLibFunc(&_IOHIDElementGetUsagePage, iokit, "IOHIDElementGetUsagePage")
+	purego.RegisterLibFunc(&_IOHIDElementGetLogicalMin, iokit, "IOHIDElementGetLogicalMin")
+	purego.RegisterLibFunc(&_IOHIDElementGetLogicalMax, iokit, "IOHIDElementGetLogicalMax")
+	purego.RegisterLibFunc(&_IOHIDDeviceGetValue, iokit, "IOHIDDeviceGetValue")
+	purego.RegisterLibFunc(&_IOHIDValueGetIntegerValue, iokit, "IOHIDValueGetIntegerValue")
+	purego.RegisterLibFunc(&_IOHIDDeviceCopyMatchingElements, iokit, "IOHIDDeviceCopyMatchingElements")
 }
 
-func _IOHIDManagerCreate(allocator _CFAllocatorRef, options _IOOptionBits) _IOHIDManagerRef {
-	ret, _, _ := purego.SyscallN(procIOHIDManagerCreate, uintptr(allocator), uintptr(options))
-	return _IOHIDManagerRef(ret)
-}
+var _IOHIDElementGetTypeID func() _CFTypeID
 
-func _IOHIDDeviceGetProperty(device _IOHIDDeviceRef, key _CFStringRef) _CFTypeRef {
-	ret, _, _ := purego.SyscallN(procIOHIDDeviceGetProperty, uintptr(device), uintptr(key))
-	return _CFTypeRef(ret)
-}
+var _IOHIDManagerCreate func(allocator _CFAllocatorRef, options _IOOptionBits) _IOHIDManagerRef
 
-func _IOHIDManagerOpen(manager _IOHIDManagerRef, options _IOOptionBits) _IOReturn {
-	ret, _, _ := purego.SyscallN(procIOHIDManagerOpen, uintptr(manager), uintptr(options))
-	return _IOReturn(ret)
-}
+var _IOHIDDeviceGetProperty func(device _IOHIDDeviceRef, key _CFStringRef) _CFTypeRef
 
-func _IOHIDManagerSetDeviceMatchingMultiple(manager _IOHIDManagerRef, multiple _CFArrayRef) {
-	purego.SyscallN(procIOHIDManagerSetDeviceMatchingMultiple, uintptr(manager), uintptr(multiple))
-}
+var _IOHIDManagerOpen func(manager _IOHIDManagerRef, options _IOOptionBits) _IOReturn
 
-func _IOHIDManagerRegisterDeviceMatchingCallback(manager _IOHIDManagerRef, callback _IOHIDDeviceCallback, context unsafe.Pointer) {
-	purego.SyscallN(procIOHIDManagerRegisterDeviceMatchingCallback, uintptr(manager), purego.NewCallback(callback), uintptr(context))
-}
+var _IOHIDManagerSetDeviceMatchingMultiple func(manager _IOHIDManagerRef, multiple _CFArrayRef)
 
-func _IOHIDManagerRegisterDeviceRemovalCallback(manager _IOHIDManagerRef, callback _IOHIDDeviceCallback, context unsafe.Pointer) {
-	purego.SyscallN(procIOHIDManagerRegisterDeviceRemovalCallback, uintptr(manager), purego.NewCallback(callback), uintptr(context))
-}
+var _IOHIDManagerRegisterDeviceMatchingCallback func(manager _IOHIDManagerRef, callback _IOHIDDeviceCallback, context unsafe.Pointer)
 
-func _IOHIDManagerScheduleWithRunLoop(manager _IOHIDManagerRef, runLoop _CFRunLoopRef, runLoopMode _CFStringRef) {
-	purego.SyscallN(procIOHIDManagerScheduleWithRunLoop, uintptr(manager), uintptr(runLoop), uintptr(runLoopMode))
-}
+var _IOHIDManagerRegisterDeviceRemovalCallback func(manager _IOHIDManagerRef, callback _IOHIDDeviceCallback, context unsafe.Pointer)
 
-func _IOHIDElementGetType(element _IOHIDElementRef) _IOHIDElementType {
-	ret, _, _ := purego.SyscallN(procIOHIDElementGetType, uintptr(element))
-	return _IOHIDElementType(ret)
-}
+var _IOHIDManagerScheduleWithRunLoop func(manager _IOHIDManagerRef, runLoop _CFRunLoopRef, runLoopMode _CFStringRef)
 
-func _IOHIDElementGetUsage(element _IOHIDElementRef) uint32 {
-	ret, _, _ := purego.SyscallN(procIOHIDElementGetUsage, uintptr(element))
-	return uint32(ret)
-}
+var _IOHIDElementGetType func(element _IOHIDElementRef) _IOHIDElementType
 
-func _IOHIDElementGetUsagePage(element _IOHIDElementRef) uint32 {
-	ret, _, _ := purego.SyscallN(procIOHIDElementGetUsagePage, uintptr(element))
-	return uint32(ret)
-}
+var _IOHIDElementGetUsage func(element _IOHIDElementRef) uint32
 
-func _IOHIDElementGetLogicalMin(element _IOHIDElementRef) _CFIndex {
-	ret, _, _ := purego.SyscallN(procIOHIDElementGetLogicalMin, uintptr(element))
-	return _CFIndex(ret)
-}
+var _IOHIDElementGetUsagePage func(element _IOHIDElementRef) uint32
 
-func _IOHIDElementGetLogicalMax(element _IOHIDElementRef) _CFIndex {
-	ret, _, _ := purego.SyscallN(procIOHIDElementGetLogicalMax, uintptr(element))
-	return _CFIndex(ret)
-}
+var _IOHIDElementGetLogicalMin func(element _IOHIDElementRef) _CFIndex
 
-func _IOHIDDeviceGetValue(device _IOHIDDeviceRef, element _IOHIDElementRef, pValue *_IOHIDValueRef) _IOReturn {
-	if pValue == nil {
-		panic("IOHID: pValue cannot be nil")
-	}
-	ret, _, _ := purego.SyscallN(procIOHIDDeviceGetValue, uintptr(device), uintptr(element), uintptr(unsafe.Pointer(pValue)))
-	return _IOReturn(ret)
-}
+var _IOHIDElementGetLogicalMax func(element _IOHIDElementRef) _CFIndex
 
-func _IOHIDValueGetIntegerValue(value _IOHIDValueRef) _CFIndex {
-	ret, _, _ := purego.SyscallN(procIOHIDValueGetIntegerValue, uintptr(value))
-	return _CFIndex(ret)
-}
+var _IOHIDDeviceGetValue func(device _IOHIDDeviceRef, element _IOHIDElementRef, pValue *_IOHIDValueRef) _IOReturn
 
-func _IOHIDDeviceCopyMatchingElements(device _IOHIDDeviceRef, matching _CFDictionaryRef, options _IOOptionBits) _CFArrayRef {
-	ret, _, _ := purego.SyscallN(procIOHIDDeviceCopyMatchingElements, uintptr(device), uintptr(matching), uintptr(options))
-	return _CFArrayRef(ret)
-}
+var _IOHIDValueGetIntegerValue func(value _IOHIDValueRef) _CFIndex
+
+var _IOHIDDeviceCopyMatchingElements func(device _IOHIDDeviceRef, matching _CFDictionaryRef, options _IOOptionBits) _CFArrayRef


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
Updates #1162

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
RegisterLibFunction is typesafe and now supports float arguments. This fixes the todo of not supporting seconds greater than 0 inside of `_CFRunLoopRunInMode`
