### PR TITLE
opengl: Fix state tracking of glBindTexture / glActiveTexture interaction

### DIFF
--- a/internal/graphicsdriver/opengl/program.go
+++ b/internal/graphicsdriver/opengl/program.go
@@ -219,6 +219,7 @@ func (g *Graphics) useProgram(program program, uniforms []uniformVariable, textu
 		}
 		g.state.lastActiveTexture = 0
 		g.context.ctx.ActiveTexture(gl.TEXTURE0)
+		g.context.lastTexture = 0 // Make sure next bindTexture call actually does something.
 	}
 
 	for _, u := range uniforms {
@@ -267,6 +268,7 @@ loop:
 		if g.state.lastActiveTexture != idx {
 			g.context.ctx.ActiveTexture(uint32(gl.TEXTURE0 + idx))
 			g.state.lastActiveTexture = idx
+			g.context.lastTexture = 0 // Make sure next bindTexture call actually does something.
 		}
 
 		// Apparently, a texture must be bound every time. The cache is not used here.


### PR DESCRIPTION
# What issue is this addressing?
Closes #2525
Closes https://github.com/divVerent/aaaaxy/issues/68

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

After switching texture units using glActiveTexture, a different texture may be bound. For now, let's just force the active texture state variable to zero so the next glBindTexture call isn't skipped.