### PR TITLE
text,vector: fix typos and redundant casts

### DIFF
--- a/text/text.go
+++ b/text/text.go
@@ -52,7 +52,7 @@ func adjustOffsetGranularity(x fixed.Int26_6) fixed.Int26_6 {
 	return x / (1 << 4) * (1 << 4)
 }
 
-func drawGlyph(dst *ebiten.Image, face font.Face, r rune, img *ebiten.Image, topleft fixed.Point26_6, op *ebiten.DrawImageOptions) {
+func drawGlyph(dst *ebiten.Image, img *ebiten.Image, topleft fixed.Point26_6, op *ebiten.DrawImageOptions) {
 	if img == nil {
 		return
 	}
@@ -259,7 +259,7 @@ func DrawWithOptions(dst *ebiten.Image, text string, face font.Face, options *eb
 			Y: b.Min.Y & ((1 << 6) - 1),
 		}
 		img := getGlyphImage(face, r, offset)
-		drawGlyph(dst, face, r, img, fixed.Point26_6{
+		drawGlyph(dst, img, fixed.Point26_6{
 			X: dx + b.Min.X - offset.X,
 			Y: dy + b.Min.Y - offset.Y,
 		}, options)

--- a/vector/path.go
+++ b/vector/path.go
@@ -275,7 +275,7 @@ func (p *Path) ArcTo(x1, y1, x2, y2, radius float32) {
 	theta := math.Acos(float64(d0.x*d1.x + d0.y*d1.y))
 	// TODO: When theta is bigger than π/2, the arc should be split into two.
 
-	// dist is the distance between the control point and the arc's begenning and ending points.
+	// dist is the distance between the control point and the arc's beginning and ending points.
 	dist := radius / float32(math.Tan(theta/2))
 
 	// TODO: What if dist is too big?

--- a/vector/util.go
+++ b/vector/util.go
@@ -94,7 +94,7 @@ func StrokeRect(dst *ebiten.Image, x, y, width, height float32, strokeWidth floa
 // DrawFilledCircle filles a circle with the specified center position (cx, cy), the radius (r), width and color.
 func DrawFilledCircle(dst *ebiten.Image, cx, cy, r float32, clr color.Color) {
 	var path Path
-	path.Arc(float32(cx), float32(cy), float32(r), 0, 2*math.Pi, Clockwise)
+	path.Arc(cx, cy, r, 0, 2*math.Pi, Clockwise)
 	vs, is := path.AppendVerticesAndIndicesForFilling(nil, nil)
 
 	drawVerticesForUtil(dst, vs, is, clr)
@@ -105,7 +105,7 @@ func DrawFilledCircle(dst *ebiten.Image, cx, cy, r float32, clr color.Color) {
 // clr has be to be a solid (non-transparent) color.
 func StrokeCircle(dst *ebiten.Image, cx, cy, r float32, strokeWidth float32, clr color.Color) {
 	var path Path
-	path.Arc(float32(cx), float32(cy), float32(r), 0, 2*math.Pi, Clockwise)
+	path.Arc(cx, cy, r, 0, 2*math.Pi, Clockwise)
 	path.Close()
 
 	strokeOp := &StrokeOptions{}


### PR DESCRIPTION
Signed-off-by: Pierre Curto <pierre.curto@gmail.com>

<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
No issue required (as per the contributor guidelines) as this is basic typo fixes.

## What _type_ of issue is this addressing?
NA

## What this PR does | solves
Simple typos, unused function variables and unnecessary conversions.
