### PR TITLE
internal/goglfw: separate windows specific struct from common structs

### DIFF
--- a/internal/goglfw/internal_windows.go
+++ b/internal/goglfw/internal_windows.go
@@ -7,8 +7,6 @@ package goglfw
 
 import (
 	"unsafe"
-
-	"golang.org/x/sys/windows"
 )
 
 const (
@@ -93,11 +91,7 @@ type context struct {
 	getProcAddress     func(string) uintptr
 	destroy            func(*Window) error
 
-	wgl struct {
-		dc       _HDC
-		handle   _HGLRC
-		interval int
-	}
+	state platformContextState
 }
 
 type (
@@ -174,29 +168,7 @@ type Window struct {
 		drop        DropCallback
 	}
 
-	win32 struct {
-		handle    windows.HWND
-		bigIcon   _HICON
-		smallIcon _HICON
-
-		cursorTracked  bool
-		frameAction    bool
-		iconified      bool
-		maximized      bool
-		transparent    bool // Whether to enable framebuffer transparency on DWM
-		scaleToMonitor bool
-
-		// Cached size used to filter out duplicate events
-		width  int
-		height int
-
-		// The last received cursor position, regardless of source
-		lastCursorPosX int
-		lastCursorPosY int
-
-		// The last recevied high surrogate when decoding pairs of UTF-16 messages
-		highSurrogate uint16
-	}
+	state platformWindowState
 }
 
 type Monitor struct {
@@ -206,28 +178,15 @@ type Monitor struct {
 
 	modes []*VidMode
 
-	win32 struct {
-		handle _HMONITOR
-
-		// This size matches the static size of DISPLAY_DEVICE.DeviceName
-		adapterName string
-		displayName string
-		modesPruned bool
-		modeChanged bool
-	}
+	state platformMonitorState
 }
 
 type Cursor struct {
-	win32 struct {
-		handle _HCURSOR
-	}
+	state platformCursorState
 }
 
 type tls struct {
-	win32 struct {
-		allocated bool
-		index     uint32
-	}
+	state platformTLSState
 }
 
 type library struct {
@@ -253,42 +212,8 @@ type library struct {
 		monitor MonitorCallback
 	}
 
-	win32 struct {
-		instance                 _HINSTANCE
-		helperWindowHandle       windows.HWND
-		deviceNotificationHandle _HDEVNOTIFY
-		acquiredMonitorCount     int
-		clipboardString          string
-		keycodes                 [512]Key
-		scancodes                [KeyLast + 1]int
-		keynames                 [KeyLast + 1]string
-
-		// Where to place the cursor when re-enabled
-		restoreCursorPosX float64
-		restoreCursorPosY float64
-
-		// The window whose disabled cursor mode is active
-		disabledCursorWindow *Window
-		rawInput             []byte
-		mouseTrailSize       uint32
-	}
-
-	wgl struct {
-		inited bool
-
-		EXT_swap_control               bool
-		EXT_colorspace                 bool
-		ARB_multisample                bool
-		ARB_framebuffer_sRGB           bool
-		EXT_framebuffer_sRGB           bool
-		ARB_pixel_format               bool
-		ARB_create_context             bool
-		ARB_create_context_profile     bool
-		EXT_create_context_es2_profile bool
-		ARB_create_context_robustness  bool
-		ARB_create_context_no_error    bool
-		ARB_context_flush_control      bool
-	}
+	windowState  platformLibraryWindowState
+	contextState platformLibraryContextState
 }
 
 func boolToInt(x bool) int {

--- a/internal/goglfw/internal_windows.go
+++ b/internal/goglfw/internal_windows.go
@@ -91,7 +91,7 @@ type context struct {
 	getProcAddress     func(string) uintptr
 	destroy            func(*Window) error
 
-	state platformContextState
+	platform platformContextState
 }
 
 type (
@@ -168,7 +168,7 @@ type Window struct {
 		drop        DropCallback
 	}
 
-	state platformWindowState
+	platform platformWindowState
 }
 
 type Monitor struct {
@@ -178,15 +178,15 @@ type Monitor struct {
 
 	modes []*VidMode
 
-	state platformMonitorState
+	platform platformMonitorState
 }
 
 type Cursor struct {
-	state platformCursorState
+	platform platformCursorState
 }
 
 type tls struct {
-	state platformTLSState
+	platform platformTLSState
 }
 
 type library struct {
@@ -212,8 +212,8 @@ type library struct {
 		monitor MonitorCallback
 	}
 
-	windowState  platformLibraryWindowState
-	contextState platformLibraryContextState
+	platformWindow  platformLibraryWindowState
+	platformContext platformLibraryContextState
 }
 
 func boolToInt(x bool) int {

--- a/internal/goglfw/wglcontext_windows.go
+++ b/internal/goglfw/wglcontext_windows.go
@@ -29,9 +29,9 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 	var nativeCount int32
 	var attribs []int32
 
-	if _glfw.wgl.ARB_pixel_format {
+	if _glfw.contextState.ARB_pixel_format {
 		var attrib int32 = _WGL_NUMBER_PIXEL_FORMATS_ARB
-		if err := wglGetPixelFormatAttribivARB(w.context.wgl.dc, 1, 0, 1, &attrib, &nativeCount); err != nil {
+		if err := wglGetPixelFormatAttribivARB(w.context.state.dc, 1, 0, 1, &attrib, &nativeCount); err != nil {
 			return 0, err
 		}
 
@@ -59,21 +59,21 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 			_WGL_STEREO_ARB,
 			_WGL_DOUBLE_BUFFER_ARB)
 
-		if _glfw.wgl.ARB_multisample {
+		if _glfw.contextState.ARB_multisample {
 			attribs = append(attribs, _WGL_SAMPLES_ARB)
 		}
 
 		if ctxconfig.client == OpenGLAPI {
-			if _glfw.wgl.ARB_framebuffer_sRGB || _glfw.wgl.EXT_framebuffer_sRGB {
+			if _glfw.contextState.ARB_framebuffer_sRGB || _glfw.contextState.EXT_framebuffer_sRGB {
 				attribs = append(attribs, _WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB)
 			}
 		} else {
-			if _glfw.wgl.EXT_colorspace {
+			if _glfw.contextState.EXT_colorspace {
 				attribs = append(attribs, _WGL_COLORSPACE_EXT)
 			}
 		}
 	} else {
-		c, err := _DescribePixelFormat(w.context.wgl.dc, 1, uint32(unsafe.Sizeof(_PIXELFORMATDESCRIPTOR{})), nil)
+		c, err := _DescribePixelFormat(w.context.state.dc, 1, uint32(unsafe.Sizeof(_PIXELFORMATDESCRIPTOR{})), nil)
 		if err != nil {
 			return 0, err
 		}
@@ -85,10 +85,10 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 		var u fbconfig
 		pixelFormat := uintptr(i) + 1
 
-		if _glfw.wgl.ARB_pixel_format {
+		if _glfw.contextState.ARB_pixel_format {
 			// Get pixel format attributes through "modern" extension
 			values := make([]int32, len(attribs))
-			if err := wglGetPixelFormatAttribivARB(w.context.wgl.dc, int32(pixelFormat), 0, uint32(len(attribs)), &attribs[0], &values[0]); err != nil {
+			if err := wglGetPixelFormatAttribivARB(w.context.state.dc, int32(pixelFormat), 0, uint32(len(attribs)), &attribs[0], &values[0]); err != nil {
 				return 0, err
 			}
 
@@ -131,18 +131,18 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 				u.stereo = true
 			}
 
-			if _glfw.wgl.ARB_multisample {
+			if _glfw.contextState.ARB_multisample {
 				u.samples = int(findAttribValue(_WGL_SAMPLES_ARB))
 			}
 
 			if ctxconfig.client == OpenGLAPI {
-				if _glfw.wgl.ARB_framebuffer_sRGB || _glfw.wgl.EXT_framebuffer_sRGB {
+				if _glfw.contextState.ARB_framebuffer_sRGB || _glfw.contextState.EXT_framebuffer_sRGB {
 					if findAttribValue(_WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB) != 0 {
 						u.sRGB = true
 					}
 				}
 			} else {
-				if _glfw.wgl.EXT_colorspace {
+				if _glfw.contextState.EXT_colorspace {
 					if findAttribValue(_WGL_COLORSPACE_EXT) == _WGL_COLORSPACE_SRGB_EXT {
 						u.sRGB = true
 					}
@@ -152,7 +152,7 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 			// Get pixel format attributes through legacy PFDs
 
 			var pfd _PIXELFORMATDESCRIPTOR
-			if _, err := _DescribePixelFormat(w.context.wgl.dc, int32(pixelFormat), uint32(unsafe.Sizeof(pfd)), &pfd); err != nil {
+			if _, err := _DescribePixelFormat(w.context.state.dc, int32(pixelFormat), uint32(unsafe.Sizeof(pfd)), &pfd); err != nil {
 				return 0, err
 			}
 
@@ -210,7 +210,7 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 
 func makeContextCurrentWGL(window *Window) error {
 	if window != nil {
-		if err := wglMakeCurrent(window.context.wgl.dc, window.context.wgl.handle); err != nil {
+		if err := wglMakeCurrent(window.context.state.dc, window.context.state.handle); err != nil {
 			_ = _glfw.contextSlot.set(0)
 			return err
 		}
@@ -244,14 +244,14 @@ func swapBuffersWGL(window *Window) error {
 
 		// HACK: Use DwmFlush when desktop composition is enabled
 		if enabled {
-			for i := 0; i < window.context.wgl.interval; i++ {
+			for i := 0; i < window.context.state.interval; i++ {
 				// Ignore an error from DWM functions as they might not be implemented e.g. on Proton (#2113).
 				_ = _DwmFlush()
 			}
 		}
 	}
 
-	if err := _SwapBuffers(window.context.wgl.dc); err != nil {
+	if err := _SwapBuffers(window.context.state.dc); err != nil {
 		return err
 	}
 	return nil
@@ -264,7 +264,7 @@ func swapIntervalWGL(interval int) error {
 	}
 	window := (*Window)(unsafe.Pointer(ptr))
 
-	window.context.wgl.interval = interval
+	window.context.state.interval = interval
 
 	if window.monitor == nil && _IsWindowsVistaOrGreater() {
 		// DWM Composition is always enabled on Win8+
@@ -285,7 +285,7 @@ func swapIntervalWGL(interval int) error {
 		}
 	}
 
-	if _glfw.wgl.EXT_swap_control {
+	if _glfw.contextState.EXT_swap_control {
 		if err := wglSwapIntervalEXT(int32(interval)); err != nil {
 			return err
 		}
@@ -323,14 +323,14 @@ func getProcAddressWGL(procname string) uintptr {
 }
 
 func destroyContextWGL(window *Window) error {
-	if window.context.wgl.handle != 0 {
+	if window.context.state.handle != 0 {
 		// Ignore ERROR_BUSY. This happens when the thread is different from the context thread (#2518).
 		// This is a known issue of GLFW (glfw/glfw#2239).
 		// TODO: Delete the context on an appropriate thread.
-		if err := wglDeleteContext(window.context.wgl.handle); err != nil && !errors.Is(err, windows.ERROR_BUSY) {
+		if err := wglDeleteContext(window.context.state.handle); err != nil && !errors.Is(err, windows.ERROR_BUSY) {
 			return err
 		}
-		window.context.wgl.handle = 0
+		window.context.state.handle = 0
 	}
 	return nil
 }
@@ -340,7 +340,7 @@ func initWGL() error {
 		return fmt.Errorf("goglfw: WGL is not available in Xbox")
 	}
 
-	if _glfw.wgl.inited {
+	if _glfw.contextState.inited {
 		return nil
 	}
 
@@ -355,7 +355,7 @@ func initWGL() error {
 	// NOTE: This code will accept the Microsoft GDI ICD; accelerated context
 	//       creation failure occurs during manual pixel format enumeration
 
-	dc, err := _GetDC(_glfw.win32.helperWindowHandle)
+	dc, err := _GetDC(_glfw.windowState.helperWindowHandle)
 	if err != nil {
 		return err
 	}
@@ -397,18 +397,18 @@ func initWGL() error {
 
 	// NOTE: WGL_ARB_extensions_string and WGL_EXT_extensions_string are not
 	//       checked below as we are already using them
-	_glfw.wgl.ARB_multisample = extensionSupportedWGL("WGL_ARB_multisample")
-	_glfw.wgl.ARB_framebuffer_sRGB = extensionSupportedWGL("WGL_ARB_framebuffer_sRGB")
-	_glfw.wgl.EXT_framebuffer_sRGB = extensionSupportedWGL("WGL_EXT_framebuffer_sRGB")
-	_glfw.wgl.ARB_create_context = extensionSupportedWGL("WGL_ARB_create_context")
-	_glfw.wgl.ARB_create_context_profile = extensionSupportedWGL("WGL_ARB_create_context_profile")
-	_glfw.wgl.EXT_create_context_es2_profile = extensionSupportedWGL("WGL_EXT_create_context_es2_profile")
-	_glfw.wgl.ARB_create_context_robustness = extensionSupportedWGL("WGL_ARB_create_context_robustness")
-	_glfw.wgl.ARB_create_context_no_error = extensionSupportedWGL("WGL_ARB_create_context_no_error")
-	_glfw.wgl.EXT_swap_control = extensionSupportedWGL("WGL_EXT_swap_control")
-	_glfw.wgl.EXT_colorspace = extensionSupportedWGL("WGL_EXT_colorspace")
-	_glfw.wgl.ARB_pixel_format = extensionSupportedWGL("WGL_ARB_pixel_format")
-	_glfw.wgl.ARB_context_flush_control = extensionSupportedWGL("WGL_ARB_context_flush_control")
+	_glfw.contextState.ARB_multisample = extensionSupportedWGL("WGL_ARB_multisample")
+	_glfw.contextState.ARB_framebuffer_sRGB = extensionSupportedWGL("WGL_ARB_framebuffer_sRGB")
+	_glfw.contextState.EXT_framebuffer_sRGB = extensionSupportedWGL("WGL_EXT_framebuffer_sRGB")
+	_glfw.contextState.ARB_create_context = extensionSupportedWGL("WGL_ARB_create_context")
+	_glfw.contextState.ARB_create_context_profile = extensionSupportedWGL("WGL_ARB_create_context_profile")
+	_glfw.contextState.EXT_create_context_es2_profile = extensionSupportedWGL("WGL_EXT_create_context_es2_profile")
+	_glfw.contextState.ARB_create_context_robustness = extensionSupportedWGL("WGL_ARB_create_context_robustness")
+	_glfw.contextState.ARB_create_context_no_error = extensionSupportedWGL("WGL_ARB_create_context_no_error")
+	_glfw.contextState.EXT_swap_control = extensionSupportedWGL("WGL_EXT_swap_control")
+	_glfw.contextState.EXT_colorspace = extensionSupportedWGL("WGL_EXT_colorspace")
+	_glfw.contextState.ARB_pixel_format = extensionSupportedWGL("WGL_ARB_pixel_format")
+	_glfw.contextState.ARB_context_flush_control = extensionSupportedWGL("WGL_ARB_context_flush_control")
 
 	if err := wglMakeCurrent(pdc, prc); err != nil {
 		return err
@@ -416,7 +416,7 @@ func initWGL() error {
 	if err := wglDeleteContext(rc); err != nil {
 		return err
 	}
-	_glfw.wgl.inited = true
+	_glfw.contextState.inited = true
 	return nil
 }
 
@@ -426,14 +426,14 @@ func terminateWGL() {
 func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) error {
 	var share _HGLRC
 	if ctxconfig.share != nil {
-		share = ctxconfig.share.context.wgl.handle
+		share = ctxconfig.share.context.state.handle
 	}
 
-	dc, err := _GetDC(w.win32.handle)
+	dc, err := _GetDC(w.state.handle)
 	if err != nil {
 		return err
 	}
-	w.context.wgl.dc = dc
+	w.context.state.dc = dc
 
 	pixelFormat, err := w.choosePixelFormat(ctxconfig, fbconfig)
 	if err != nil {
@@ -441,29 +441,29 @@ func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) erro
 	}
 
 	var pfd _PIXELFORMATDESCRIPTOR
-	if _, err := _DescribePixelFormat(w.context.wgl.dc, int32(pixelFormat), uint32(unsafe.Sizeof(pfd)), &pfd); err != nil {
+	if _, err := _DescribePixelFormat(w.context.state.dc, int32(pixelFormat), uint32(unsafe.Sizeof(pfd)), &pfd); err != nil {
 		return err
 	}
 
-	if err := _SetPixelFormat(w.context.wgl.dc, int32(pixelFormat), &pfd); err != nil {
+	if err := _SetPixelFormat(w.context.state.dc, int32(pixelFormat), &pfd); err != nil {
 		return err
 	}
 
 	if ctxconfig.client == OpenGLAPI {
-		if ctxconfig.forward && !_glfw.wgl.ARB_create_context {
+		if ctxconfig.forward && !_glfw.contextState.ARB_create_context {
 			return fmt.Errorf("goglfw: a forward compatible OpenGL context requested but WGL_ARB_create_context is unavailable: %w", VersionUnavailable)
 		}
 
-		if ctxconfig.profile != 0 && !_glfw.wgl.ARB_create_context_profile {
+		if ctxconfig.profile != 0 && !_glfw.contextState.ARB_create_context_profile {
 			return fmt.Errorf("goglfw: OpenGL profile requested but WGL_ARB_create_context_profile is unavailable: %w", VersionUnavailable)
 		}
 	} else {
-		if !_glfw.wgl.ARB_create_context || !_glfw.wgl.ARB_create_context_profile || !_glfw.wgl.EXT_create_context_es2_profile {
+		if !_glfw.contextState.ARB_create_context || !_glfw.contextState.ARB_create_context_profile || !_glfw.contextState.EXT_create_context_es2_profile {
 			return fmt.Errorf("goglfw: OpenGL ES requested but WGL_ARB_create_context_es2_profile is unavailable: %w", ApiUnavailable)
 		}
 	}
 
-	if _glfw.wgl.ARB_create_context {
+	if _glfw.contextState.ARB_create_context {
 		var flags int32
 		var mask int32
 		if ctxconfig.client == OpenGLAPI {
@@ -486,7 +486,7 @@ func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) erro
 
 		var attribs []int32
 		if ctxconfig.robustness != 0 {
-			if _glfw.wgl.ARB_create_context_robustness {
+			if _glfw.contextState.ARB_create_context_robustness {
 				if ctxconfig.robustness == NoResetNotification {
 					attribs = append(attribs, _WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB, _WGL_NO_RESET_NOTIFICATION_ARB)
 				} else if ctxconfig.robustness == LoseContextOnReset {
@@ -497,7 +497,7 @@ func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) erro
 		}
 
 		if ctxconfig.release != 0 {
-			if _glfw.wgl.ARB_context_flush_control {
+			if _glfw.contextState.ARB_context_flush_control {
 				if ctxconfig.release == ReleaseBehaviorNone {
 					attribs = append(attribs, _WGL_CONTEXT_RELEASE_BEHAVIOR_ARB, _WGL_CONTEXT_RELEASE_BEHAVIOR_NONE_ARB)
 				} else if ctxconfig.release == ReleaseBehaviorFlush {
@@ -507,7 +507,7 @@ func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) erro
 		}
 
 		if ctxconfig.noerror {
-			if _glfw.wgl.ARB_create_context_no_error {
+			if _glfw.contextState.ARB_create_context_no_error {
 				attribs = append(attribs, _WGL_CONTEXT_OPENGL_NO_ERROR_ARB, 1)
 			}
 		}
@@ -531,19 +531,19 @@ func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) erro
 		attribs = append(attribs, 0, 0)
 
 		var err error
-		w.context.wgl.handle, err = wglCreateContextAttribsARB(w.context.wgl.dc, share, &attribs[0])
+		w.context.state.handle, err = wglCreateContextAttribsARB(w.context.state.dc, share, &attribs[0])
 		if err != nil {
 			return err
 		}
 	} else {
 		var err error
-		w.context.wgl.handle, err = wglCreateContext(w.context.wgl.dc)
+		w.context.state.handle, err = wglCreateContext(w.context.state.dc)
 		if err != nil {
 			return err
 		}
 
 		if share != 0 {
-			if err := wglShareLists(share, w.context.wgl.handle); err != nil {
+			if err := wglShareLists(share, w.context.state.handle); err != nil {
 				return err
 			}
 		}
@@ -568,5 +568,5 @@ func getWGLContext(handle *Window) _HGLRC {
 		// TODO: Should this return an error?
 		return 0
 	}
-	return window.context.wgl.handle
+	return window.context.state.handle
 }

--- a/internal/goglfw/wglcontext_windows.go
+++ b/internal/goglfw/wglcontext_windows.go
@@ -29,9 +29,9 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 	var nativeCount int32
 	var attribs []int32
 
-	if _glfw.contextState.ARB_pixel_format {
+	if _glfw.platformContext.ARB_pixel_format {
 		var attrib int32 = _WGL_NUMBER_PIXEL_FORMATS_ARB
-		if err := wglGetPixelFormatAttribivARB(w.context.state.dc, 1, 0, 1, &attrib, &nativeCount); err != nil {
+		if err := wglGetPixelFormatAttribivARB(w.context.platform.dc, 1, 0, 1, &attrib, &nativeCount); err != nil {
 			return 0, err
 		}
 
@@ -59,21 +59,21 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 			_WGL_STEREO_ARB,
 			_WGL_DOUBLE_BUFFER_ARB)
 
-		if _glfw.contextState.ARB_multisample {
+		if _glfw.platformContext.ARB_multisample {
 			attribs = append(attribs, _WGL_SAMPLES_ARB)
 		}
 
 		if ctxconfig.client == OpenGLAPI {
-			if _glfw.contextState.ARB_framebuffer_sRGB || _glfw.contextState.EXT_framebuffer_sRGB {
+			if _glfw.platformContext.ARB_framebuffer_sRGB || _glfw.platformContext.EXT_framebuffer_sRGB {
 				attribs = append(attribs, _WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB)
 			}
 		} else {
-			if _glfw.contextState.EXT_colorspace {
+			if _glfw.platformContext.EXT_colorspace {
 				attribs = append(attribs, _WGL_COLORSPACE_EXT)
 			}
 		}
 	} else {
-		c, err := _DescribePixelFormat(w.context.state.dc, 1, uint32(unsafe.Sizeof(_PIXELFORMATDESCRIPTOR{})), nil)
+		c, err := _DescribePixelFormat(w.context.platform.dc, 1, uint32(unsafe.Sizeof(_PIXELFORMATDESCRIPTOR{})), nil)
 		if err != nil {
 			return 0, err
 		}
@@ -85,10 +85,10 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 		var u fbconfig
 		pixelFormat := uintptr(i) + 1
 
-		if _glfw.contextState.ARB_pixel_format {
+		if _glfw.platformContext.ARB_pixel_format {
 			// Get pixel format attributes through "modern" extension
 			values := make([]int32, len(attribs))
-			if err := wglGetPixelFormatAttribivARB(w.context.state.dc, int32(pixelFormat), 0, uint32(len(attribs)), &attribs[0], &values[0]); err != nil {
+			if err := wglGetPixelFormatAttribivARB(w.context.platform.dc, int32(pixelFormat), 0, uint32(len(attribs)), &attribs[0], &values[0]); err != nil {
 				return 0, err
 			}
 
@@ -131,18 +131,18 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 				u.stereo = true
 			}
 
-			if _glfw.contextState.ARB_multisample {
+			if _glfw.platformContext.ARB_multisample {
 				u.samples = int(findAttribValue(_WGL_SAMPLES_ARB))
 			}
 
 			if ctxconfig.client == OpenGLAPI {
-				if _glfw.contextState.ARB_framebuffer_sRGB || _glfw.contextState.EXT_framebuffer_sRGB {
+				if _glfw.platformContext.ARB_framebuffer_sRGB || _glfw.platformContext.EXT_framebuffer_sRGB {
 					if findAttribValue(_WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB) != 0 {
 						u.sRGB = true
 					}
 				}
 			} else {
-				if _glfw.contextState.EXT_colorspace {
+				if _glfw.platformContext.EXT_colorspace {
 					if findAttribValue(_WGL_COLORSPACE_EXT) == _WGL_COLORSPACE_SRGB_EXT {
 						u.sRGB = true
 					}
@@ -152,7 +152,7 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 			// Get pixel format attributes through legacy PFDs
 
 			var pfd _PIXELFORMATDESCRIPTOR
-			if _, err := _DescribePixelFormat(w.context.state.dc, int32(pixelFormat), uint32(unsafe.Sizeof(pfd)), &pfd); err != nil {
+			if _, err := _DescribePixelFormat(w.context.platform.dc, int32(pixelFormat), uint32(unsafe.Sizeof(pfd)), &pfd); err != nil {
 				return 0, err
 			}
 
@@ -210,7 +210,7 @@ func (w *Window) choosePixelFormat(ctxconfig *ctxconfig, fbconfig_ *fbconfig) (i
 
 func makeContextCurrentWGL(window *Window) error {
 	if window != nil {
-		if err := wglMakeCurrent(window.context.state.dc, window.context.state.handle); err != nil {
+		if err := wglMakeCurrent(window.context.platform.dc, window.context.platform.handle); err != nil {
 			_ = _glfw.contextSlot.set(0)
 			return err
 		}
@@ -244,14 +244,14 @@ func swapBuffersWGL(window *Window) error {
 
 		// HACK: Use DwmFlush when desktop composition is enabled
 		if enabled {
-			for i := 0; i < window.context.state.interval; i++ {
+			for i := 0; i < window.context.platform.interval; i++ {
 				// Ignore an error from DWM functions as they might not be implemented e.g. on Proton (#2113).
 				_ = _DwmFlush()
 			}
 		}
 	}
 
-	if err := _SwapBuffers(window.context.state.dc); err != nil {
+	if err := _SwapBuffers(window.context.platform.dc); err != nil {
 		return err
 	}
 	return nil
@@ -264,7 +264,7 @@ func swapIntervalWGL(interval int) error {
 	}
 	window := (*Window)(unsafe.Pointer(ptr))
 
-	window.context.state.interval = interval
+	window.context.platform.interval = interval
 
 	if window.monitor == nil && _IsWindowsVistaOrGreater() {
 		// DWM Composition is always enabled on Win8+
@@ -285,7 +285,7 @@ func swapIntervalWGL(interval int) error {
 		}
 	}
 
-	if _glfw.contextState.EXT_swap_control {
+	if _glfw.platformContext.EXT_swap_control {
 		if err := wglSwapIntervalEXT(int32(interval)); err != nil {
 			return err
 		}
@@ -323,14 +323,14 @@ func getProcAddressWGL(procname string) uintptr {
 }
 
 func destroyContextWGL(window *Window) error {
-	if window.context.state.handle != 0 {
+	if window.context.platform.handle != 0 {
 		// Ignore ERROR_BUSY. This happens when the thread is different from the context thread (#2518).
 		// This is a known issue of GLFW (glfw/glfw#2239).
 		// TODO: Delete the context on an appropriate thread.
-		if err := wglDeleteContext(window.context.state.handle); err != nil && !errors.Is(err, windows.ERROR_BUSY) {
+		if err := wglDeleteContext(window.context.platform.handle); err != nil && !errors.Is(err, windows.ERROR_BUSY) {
 			return err
 		}
-		window.context.state.handle = 0
+		window.context.platform.handle = 0
 	}
 	return nil
 }
@@ -340,7 +340,7 @@ func initWGL() error {
 		return fmt.Errorf("goglfw: WGL is not available in Xbox")
 	}
 
-	if _glfw.contextState.inited {
+	if _glfw.platformContext.inited {
 		return nil
 	}
 
@@ -355,7 +355,7 @@ func initWGL() error {
 	// NOTE: This code will accept the Microsoft GDI ICD; accelerated context
 	//       creation failure occurs during manual pixel format enumeration
 
-	dc, err := _GetDC(_glfw.windowState.helperWindowHandle)
+	dc, err := _GetDC(_glfw.platformWindow.helperWindowHandle)
 	if err != nil {
 		return err
 	}
@@ -397,18 +397,18 @@ func initWGL() error {
 
 	// NOTE: WGL_ARB_extensions_string and WGL_EXT_extensions_string are not
 	//       checked below as we are already using them
-	_glfw.contextState.ARB_multisample = extensionSupportedWGL("WGL_ARB_multisample")
-	_glfw.contextState.ARB_framebuffer_sRGB = extensionSupportedWGL("WGL_ARB_framebuffer_sRGB")
-	_glfw.contextState.EXT_framebuffer_sRGB = extensionSupportedWGL("WGL_EXT_framebuffer_sRGB")
-	_glfw.contextState.ARB_create_context = extensionSupportedWGL("WGL_ARB_create_context")
-	_glfw.contextState.ARB_create_context_profile = extensionSupportedWGL("WGL_ARB_create_context_profile")
-	_glfw.contextState.EXT_create_context_es2_profile = extensionSupportedWGL("WGL_EXT_create_context_es2_profile")
-	_glfw.contextState.ARB_create_context_robustness = extensionSupportedWGL("WGL_ARB_create_context_robustness")
-	_glfw.contextState.ARB_create_context_no_error = extensionSupportedWGL("WGL_ARB_create_context_no_error")
-	_glfw.contextState.EXT_swap_control = extensionSupportedWGL("WGL_EXT_swap_control")
-	_glfw.contextState.EXT_colorspace = extensionSupportedWGL("WGL_EXT_colorspace")
-	_glfw.contextState.ARB_pixel_format = extensionSupportedWGL("WGL_ARB_pixel_format")
-	_glfw.contextState.ARB_context_flush_control = extensionSupportedWGL("WGL_ARB_context_flush_control")
+	_glfw.platformContext.ARB_multisample = extensionSupportedWGL("WGL_ARB_multisample")
+	_glfw.platformContext.ARB_framebuffer_sRGB = extensionSupportedWGL("WGL_ARB_framebuffer_sRGB")
+	_glfw.platformContext.EXT_framebuffer_sRGB = extensionSupportedWGL("WGL_EXT_framebuffer_sRGB")
+	_glfw.platformContext.ARB_create_context = extensionSupportedWGL("WGL_ARB_create_context")
+	_glfw.platformContext.ARB_create_context_profile = extensionSupportedWGL("WGL_ARB_create_context_profile")
+	_glfw.platformContext.EXT_create_context_es2_profile = extensionSupportedWGL("WGL_EXT_create_context_es2_profile")
+	_glfw.platformContext.ARB_create_context_robustness = extensionSupportedWGL("WGL_ARB_create_context_robustness")
+	_glfw.platformContext.ARB_create_context_no_error = extensionSupportedWGL("WGL_ARB_create_context_no_error")
+	_glfw.platformContext.EXT_swap_control = extensionSupportedWGL("WGL_EXT_swap_control")
+	_glfw.platformContext.EXT_colorspace = extensionSupportedWGL("WGL_EXT_colorspace")
+	_glfw.platformContext.ARB_pixel_format = extensionSupportedWGL("WGL_ARB_pixel_format")
+	_glfw.platformContext.ARB_context_flush_control = extensionSupportedWGL("WGL_ARB_context_flush_control")
 
 	if err := wglMakeCurrent(pdc, prc); err != nil {
 		return err
@@ -416,7 +416,7 @@ func initWGL() error {
 	if err := wglDeleteContext(rc); err != nil {
 		return err
 	}
-	_glfw.contextState.inited = true
+	_glfw.platformContext.inited = true
 	return nil
 }
 
@@ -426,14 +426,14 @@ func terminateWGL() {
 func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) error {
 	var share _HGLRC
 	if ctxconfig.share != nil {
-		share = ctxconfig.share.context.state.handle
+		share = ctxconfig.share.context.platform.handle
 	}
 
-	dc, err := _GetDC(w.state.handle)
+	dc, err := _GetDC(w.platform.handle)
 	if err != nil {
 		return err
 	}
-	w.context.state.dc = dc
+	w.context.platform.dc = dc
 
 	pixelFormat, err := w.choosePixelFormat(ctxconfig, fbconfig)
 	if err != nil {
@@ -441,29 +441,29 @@ func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) erro
 	}
 
 	var pfd _PIXELFORMATDESCRIPTOR
-	if _, err := _DescribePixelFormat(w.context.state.dc, int32(pixelFormat), uint32(unsafe.Sizeof(pfd)), &pfd); err != nil {
+	if _, err := _DescribePixelFormat(w.context.platform.dc, int32(pixelFormat), uint32(unsafe.Sizeof(pfd)), &pfd); err != nil {
 		return err
 	}
 
-	if err := _SetPixelFormat(w.context.state.dc, int32(pixelFormat), &pfd); err != nil {
+	if err := _SetPixelFormat(w.context.platform.dc, int32(pixelFormat), &pfd); err != nil {
 		return err
 	}
 
 	if ctxconfig.client == OpenGLAPI {
-		if ctxconfig.forward && !_glfw.contextState.ARB_create_context {
+		if ctxconfig.forward && !_glfw.platformContext.ARB_create_context {
 			return fmt.Errorf("goglfw: a forward compatible OpenGL context requested but WGL_ARB_create_context is unavailable: %w", VersionUnavailable)
 		}
 
-		if ctxconfig.profile != 0 && !_glfw.contextState.ARB_create_context_profile {
+		if ctxconfig.profile != 0 && !_glfw.platformContext.ARB_create_context_profile {
 			return fmt.Errorf("goglfw: OpenGL profile requested but WGL_ARB_create_context_profile is unavailable: %w", VersionUnavailable)
 		}
 	} else {
-		if !_glfw.contextState.ARB_create_context || !_glfw.contextState.ARB_create_context_profile || !_glfw.contextState.EXT_create_context_es2_profile {
+		if !_glfw.platformContext.ARB_create_context || !_glfw.platformContext.ARB_create_context_profile || !_glfw.platformContext.EXT_create_context_es2_profile {
 			return fmt.Errorf("goglfw: OpenGL ES requested but WGL_ARB_create_context_es2_profile is unavailable: %w", ApiUnavailable)
 		}
 	}
 
-	if _glfw.contextState.ARB_create_context {
+	if _glfw.platformContext.ARB_create_context {
 		var flags int32
 		var mask int32
 		if ctxconfig.client == OpenGLAPI {
@@ -486,7 +486,7 @@ func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) erro
 
 		var attribs []int32
 		if ctxconfig.robustness != 0 {
-			if _glfw.contextState.ARB_create_context_robustness {
+			if _glfw.platformContext.ARB_create_context_robustness {
 				if ctxconfig.robustness == NoResetNotification {
 					attribs = append(attribs, _WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB, _WGL_NO_RESET_NOTIFICATION_ARB)
 				} else if ctxconfig.robustness == LoseContextOnReset {
@@ -497,7 +497,7 @@ func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) erro
 		}
 
 		if ctxconfig.release != 0 {
-			if _glfw.contextState.ARB_context_flush_control {
+			if _glfw.platformContext.ARB_context_flush_control {
 				if ctxconfig.release == ReleaseBehaviorNone {
 					attribs = append(attribs, _WGL_CONTEXT_RELEASE_BEHAVIOR_ARB, _WGL_CONTEXT_RELEASE_BEHAVIOR_NONE_ARB)
 				} else if ctxconfig.release == ReleaseBehaviorFlush {
@@ -507,7 +507,7 @@ func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) erro
 		}
 
 		if ctxconfig.noerror {
-			if _glfw.contextState.ARB_create_context_no_error {
+			if _glfw.platformContext.ARB_create_context_no_error {
 				attribs = append(attribs, _WGL_CONTEXT_OPENGL_NO_ERROR_ARB, 1)
 			}
 		}
@@ -531,19 +531,19 @@ func (w *Window) createContextWGL(ctxconfig *ctxconfig, fbconfig *fbconfig) erro
 		attribs = append(attribs, 0, 0)
 
 		var err error
-		w.context.state.handle, err = wglCreateContextAttribsARB(w.context.state.dc, share, &attribs[0])
+		w.context.platform.handle, err = wglCreateContextAttribsARB(w.context.platform.dc, share, &attribs[0])
 		if err != nil {
 			return err
 		}
 	} else {
 		var err error
-		w.context.state.handle, err = wglCreateContext(w.context.state.dc)
+		w.context.platform.handle, err = wglCreateContext(w.context.platform.dc)
 		if err != nil {
 			return err
 		}
 
 		if share != 0 {
-			if err := wglShareLists(share, w.context.state.handle); err != nil {
+			if err := wglShareLists(share, w.context.platform.handle); err != nil {
 				return err
 			}
 		}
@@ -568,5 +568,5 @@ func getWGLContext(handle *Window) _HGLRC {
 		// TODO: Should this return an error?
 		return 0
 	}
-	return window.context.state.handle
+	return window.context.platform.handle
 }

--- a/internal/goglfw/win32init_windows.go
+++ b/internal/goglfw/win32init_windows.go
@@ -15,138 +15,138 @@ import (
 )
 
 func createKeyTables() {
-	for i := range _glfw.windowState.keycodes {
-		_glfw.windowState.keycodes[i] = -1
+	for i := range _glfw.platformWindow.keycodes {
+		_glfw.platformWindow.keycodes[i] = -1
 	}
-	for i := range _glfw.windowState.scancodes {
-		_glfw.windowState.keycodes[i] = -1
+	for i := range _glfw.platformWindow.scancodes {
+		_glfw.platformWindow.keycodes[i] = -1
 	}
 
-	_glfw.windowState.keycodes[0x00B] = Key0
-	_glfw.windowState.keycodes[0x002] = Key1
-	_glfw.windowState.keycodes[0x003] = Key2
-	_glfw.windowState.keycodes[0x004] = Key3
-	_glfw.windowState.keycodes[0x005] = Key4
-	_glfw.windowState.keycodes[0x006] = Key5
-	_glfw.windowState.keycodes[0x007] = Key6
-	_glfw.windowState.keycodes[0x008] = Key7
-	_glfw.windowState.keycodes[0x009] = Key8
-	_glfw.windowState.keycodes[0x00A] = Key9
-	_glfw.windowState.keycodes[0x01E] = KeyA
-	_glfw.windowState.keycodes[0x030] = KeyB
-	_glfw.windowState.keycodes[0x02E] = KeyC
-	_glfw.windowState.keycodes[0x020] = KeyD
-	_glfw.windowState.keycodes[0x012] = KeyE
-	_glfw.windowState.keycodes[0x021] = KeyF
-	_glfw.windowState.keycodes[0x022] = KeyG
-	_glfw.windowState.keycodes[0x023] = KeyH
-	_glfw.windowState.keycodes[0x017] = KeyI
-	_glfw.windowState.keycodes[0x024] = KeyJ
-	_glfw.windowState.keycodes[0x025] = KeyK
-	_glfw.windowState.keycodes[0x026] = KeyL
-	_glfw.windowState.keycodes[0x032] = KeyM
-	_glfw.windowState.keycodes[0x031] = KeyN
-	_glfw.windowState.keycodes[0x018] = KeyO
-	_glfw.windowState.keycodes[0x019] = KeyP
-	_glfw.windowState.keycodes[0x010] = KeyQ
-	_glfw.windowState.keycodes[0x013] = KeyR
-	_glfw.windowState.keycodes[0x01F] = KeyS
-	_glfw.windowState.keycodes[0x014] = KeyT
-	_glfw.windowState.keycodes[0x016] = KeyU
-	_glfw.windowState.keycodes[0x02F] = KeyV
-	_glfw.windowState.keycodes[0x011] = KeyW
-	_glfw.windowState.keycodes[0x02D] = KeyX
-	_glfw.windowState.keycodes[0x015] = KeyY
-	_glfw.windowState.keycodes[0x02C] = KeyZ
+	_glfw.platformWindow.keycodes[0x00B] = Key0
+	_glfw.platformWindow.keycodes[0x002] = Key1
+	_glfw.platformWindow.keycodes[0x003] = Key2
+	_glfw.platformWindow.keycodes[0x004] = Key3
+	_glfw.platformWindow.keycodes[0x005] = Key4
+	_glfw.platformWindow.keycodes[0x006] = Key5
+	_glfw.platformWindow.keycodes[0x007] = Key6
+	_glfw.platformWindow.keycodes[0x008] = Key7
+	_glfw.platformWindow.keycodes[0x009] = Key8
+	_glfw.platformWindow.keycodes[0x00A] = Key9
+	_glfw.platformWindow.keycodes[0x01E] = KeyA
+	_glfw.platformWindow.keycodes[0x030] = KeyB
+	_glfw.platformWindow.keycodes[0x02E] = KeyC
+	_glfw.platformWindow.keycodes[0x020] = KeyD
+	_glfw.platformWindow.keycodes[0x012] = KeyE
+	_glfw.platformWindow.keycodes[0x021] = KeyF
+	_glfw.platformWindow.keycodes[0x022] = KeyG
+	_glfw.platformWindow.keycodes[0x023] = KeyH
+	_glfw.platformWindow.keycodes[0x017] = KeyI
+	_glfw.platformWindow.keycodes[0x024] = KeyJ
+	_glfw.platformWindow.keycodes[0x025] = KeyK
+	_glfw.platformWindow.keycodes[0x026] = KeyL
+	_glfw.platformWindow.keycodes[0x032] = KeyM
+	_glfw.platformWindow.keycodes[0x031] = KeyN
+	_glfw.platformWindow.keycodes[0x018] = KeyO
+	_glfw.platformWindow.keycodes[0x019] = KeyP
+	_glfw.platformWindow.keycodes[0x010] = KeyQ
+	_glfw.platformWindow.keycodes[0x013] = KeyR
+	_glfw.platformWindow.keycodes[0x01F] = KeyS
+	_glfw.platformWindow.keycodes[0x014] = KeyT
+	_glfw.platformWindow.keycodes[0x016] = KeyU
+	_glfw.platformWindow.keycodes[0x02F] = KeyV
+	_glfw.platformWindow.keycodes[0x011] = KeyW
+	_glfw.platformWindow.keycodes[0x02D] = KeyX
+	_glfw.platformWindow.keycodes[0x015] = KeyY
+	_glfw.platformWindow.keycodes[0x02C] = KeyZ
 
-	_glfw.windowState.keycodes[0x028] = KeyApostrophe
-	_glfw.windowState.keycodes[0x02B] = KeyBackslash
-	_glfw.windowState.keycodes[0x033] = KeyComma
-	_glfw.windowState.keycodes[0x00D] = KeyEqual
-	_glfw.windowState.keycodes[0x029] = KeyGraveAccent
-	_glfw.windowState.keycodes[0x01A] = KeyLeftBracket
-	_glfw.windowState.keycodes[0x00C] = KeyMinus
-	_glfw.windowState.keycodes[0x034] = KeyPeriod
-	_glfw.windowState.keycodes[0x01B] = KeyRightBracket
-	_glfw.windowState.keycodes[0x027] = KeySemicolon
-	_glfw.windowState.keycodes[0x035] = KeySlash
-	_glfw.windowState.keycodes[0x056] = KeyWorld2
+	_glfw.platformWindow.keycodes[0x028] = KeyApostrophe
+	_glfw.platformWindow.keycodes[0x02B] = KeyBackslash
+	_glfw.platformWindow.keycodes[0x033] = KeyComma
+	_glfw.platformWindow.keycodes[0x00D] = KeyEqual
+	_glfw.platformWindow.keycodes[0x029] = KeyGraveAccent
+	_glfw.platformWindow.keycodes[0x01A] = KeyLeftBracket
+	_glfw.platformWindow.keycodes[0x00C] = KeyMinus
+	_glfw.platformWindow.keycodes[0x034] = KeyPeriod
+	_glfw.platformWindow.keycodes[0x01B] = KeyRightBracket
+	_glfw.platformWindow.keycodes[0x027] = KeySemicolon
+	_glfw.platformWindow.keycodes[0x035] = KeySlash
+	_glfw.platformWindow.keycodes[0x056] = KeyWorld2
 
-	_glfw.windowState.keycodes[0x00E] = KeyBackspace
-	_glfw.windowState.keycodes[0x153] = KeyDelete
-	_glfw.windowState.keycodes[0x14F] = KeyEnd
-	_glfw.windowState.keycodes[0x01C] = KeyEnter
-	_glfw.windowState.keycodes[0x001] = KeyEscape
-	_glfw.windowState.keycodes[0x147] = KeyHome
-	_glfw.windowState.keycodes[0x152] = KeyInsert
-	_glfw.windowState.keycodes[0x15D] = KeyMenu
-	_glfw.windowState.keycodes[0x151] = KeyPageDown
-	_glfw.windowState.keycodes[0x149] = KeyPageUp
-	_glfw.windowState.keycodes[0x045] = KeyPause
-	_glfw.windowState.keycodes[0x039] = KeySpace
-	_glfw.windowState.keycodes[0x00F] = KeyTab
-	_glfw.windowState.keycodes[0x03A] = KeyCapsLock
-	_glfw.windowState.keycodes[0x145] = KeyNumLock
-	_glfw.windowState.keycodes[0x046] = KeyScrollLock
-	_glfw.windowState.keycodes[0x03B] = KeyF1
-	_glfw.windowState.keycodes[0x03C] = KeyF2
-	_glfw.windowState.keycodes[0x03D] = KeyF3
-	_glfw.windowState.keycodes[0x03E] = KeyF4
-	_glfw.windowState.keycodes[0x03F] = KeyF5
-	_glfw.windowState.keycodes[0x040] = KeyF6
-	_glfw.windowState.keycodes[0x041] = KeyF7
-	_glfw.windowState.keycodes[0x042] = KeyF8
-	_glfw.windowState.keycodes[0x043] = KeyF9
-	_glfw.windowState.keycodes[0x044] = KeyF10
-	_glfw.windowState.keycodes[0x057] = KeyF11
-	_glfw.windowState.keycodes[0x058] = KeyF12
-	_glfw.windowState.keycodes[0x064] = KeyF13
-	_glfw.windowState.keycodes[0x065] = KeyF14
-	_glfw.windowState.keycodes[0x066] = KeyF15
-	_glfw.windowState.keycodes[0x067] = KeyF16
-	_glfw.windowState.keycodes[0x068] = KeyF17
-	_glfw.windowState.keycodes[0x069] = KeyF18
-	_glfw.windowState.keycodes[0x06A] = KeyF19
-	_glfw.windowState.keycodes[0x06B] = KeyF20
-	_glfw.windowState.keycodes[0x06C] = KeyF21
-	_glfw.windowState.keycodes[0x06D] = KeyF22
-	_glfw.windowState.keycodes[0x06E] = KeyF23
-	_glfw.windowState.keycodes[0x076] = KeyF24
-	_glfw.windowState.keycodes[0x038] = KeyLeftAlt
-	_glfw.windowState.keycodes[0x01D] = KeyLeftControl
-	_glfw.windowState.keycodes[0x02A] = KeyLeftShift
-	_glfw.windowState.keycodes[0x15B] = KeyLeftSuper
-	_glfw.windowState.keycodes[0x137] = KeyPrintScreen
-	_glfw.windowState.keycodes[0x138] = KeyRightAlt
-	_glfw.windowState.keycodes[0x11D] = KeyRightControl
-	_glfw.windowState.keycodes[0x036] = KeyRightShift
-	_glfw.windowState.keycodes[0x15C] = KeyRightSuper
-	_glfw.windowState.keycodes[0x150] = KeyDown
-	_glfw.windowState.keycodes[0x14B] = KeyLeft
-	_glfw.windowState.keycodes[0x14D] = KeyRight
-	_glfw.windowState.keycodes[0x148] = KeyUp
+	_glfw.platformWindow.keycodes[0x00E] = KeyBackspace
+	_glfw.platformWindow.keycodes[0x153] = KeyDelete
+	_glfw.platformWindow.keycodes[0x14F] = KeyEnd
+	_glfw.platformWindow.keycodes[0x01C] = KeyEnter
+	_glfw.platformWindow.keycodes[0x001] = KeyEscape
+	_glfw.platformWindow.keycodes[0x147] = KeyHome
+	_glfw.platformWindow.keycodes[0x152] = KeyInsert
+	_glfw.platformWindow.keycodes[0x15D] = KeyMenu
+	_glfw.platformWindow.keycodes[0x151] = KeyPageDown
+	_glfw.platformWindow.keycodes[0x149] = KeyPageUp
+	_glfw.platformWindow.keycodes[0x045] = KeyPause
+	_glfw.platformWindow.keycodes[0x039] = KeySpace
+	_glfw.platformWindow.keycodes[0x00F] = KeyTab
+	_glfw.platformWindow.keycodes[0x03A] = KeyCapsLock
+	_glfw.platformWindow.keycodes[0x145] = KeyNumLock
+	_glfw.platformWindow.keycodes[0x046] = KeyScrollLock
+	_glfw.platformWindow.keycodes[0x03B] = KeyF1
+	_glfw.platformWindow.keycodes[0x03C] = KeyF2
+	_glfw.platformWindow.keycodes[0x03D] = KeyF3
+	_glfw.platformWindow.keycodes[0x03E] = KeyF4
+	_glfw.platformWindow.keycodes[0x03F] = KeyF5
+	_glfw.platformWindow.keycodes[0x040] = KeyF6
+	_glfw.platformWindow.keycodes[0x041] = KeyF7
+	_glfw.platformWindow.keycodes[0x042] = KeyF8
+	_glfw.platformWindow.keycodes[0x043] = KeyF9
+	_glfw.platformWindow.keycodes[0x044] = KeyF10
+	_glfw.platformWindow.keycodes[0x057] = KeyF11
+	_glfw.platformWindow.keycodes[0x058] = KeyF12
+	_glfw.platformWindow.keycodes[0x064] = KeyF13
+	_glfw.platformWindow.keycodes[0x065] = KeyF14
+	_glfw.platformWindow.keycodes[0x066] = KeyF15
+	_glfw.platformWindow.keycodes[0x067] = KeyF16
+	_glfw.platformWindow.keycodes[0x068] = KeyF17
+	_glfw.platformWindow.keycodes[0x069] = KeyF18
+	_glfw.platformWindow.keycodes[0x06A] = KeyF19
+	_glfw.platformWindow.keycodes[0x06B] = KeyF20
+	_glfw.platformWindow.keycodes[0x06C] = KeyF21
+	_glfw.platformWindow.keycodes[0x06D] = KeyF22
+	_glfw.platformWindow.keycodes[0x06E] = KeyF23
+	_glfw.platformWindow.keycodes[0x076] = KeyF24
+	_glfw.platformWindow.keycodes[0x038] = KeyLeftAlt
+	_glfw.platformWindow.keycodes[0x01D] = KeyLeftControl
+	_glfw.platformWindow.keycodes[0x02A] = KeyLeftShift
+	_glfw.platformWindow.keycodes[0x15B] = KeyLeftSuper
+	_glfw.platformWindow.keycodes[0x137] = KeyPrintScreen
+	_glfw.platformWindow.keycodes[0x138] = KeyRightAlt
+	_glfw.platformWindow.keycodes[0x11D] = KeyRightControl
+	_glfw.platformWindow.keycodes[0x036] = KeyRightShift
+	_glfw.platformWindow.keycodes[0x15C] = KeyRightSuper
+	_glfw.platformWindow.keycodes[0x150] = KeyDown
+	_glfw.platformWindow.keycodes[0x14B] = KeyLeft
+	_glfw.platformWindow.keycodes[0x14D] = KeyRight
+	_glfw.platformWindow.keycodes[0x148] = KeyUp
 
-	_glfw.windowState.keycodes[0x052] = KeyKP0
-	_glfw.windowState.keycodes[0x04F] = KeyKP1
-	_glfw.windowState.keycodes[0x050] = KeyKP2
-	_glfw.windowState.keycodes[0x051] = KeyKP3
-	_glfw.windowState.keycodes[0x04B] = KeyKP4
-	_glfw.windowState.keycodes[0x04C] = KeyKP5
-	_glfw.windowState.keycodes[0x04D] = KeyKP6
-	_glfw.windowState.keycodes[0x047] = KeyKP7
-	_glfw.windowState.keycodes[0x048] = KeyKP8
-	_glfw.windowState.keycodes[0x049] = KeyKP9
-	_glfw.windowState.keycodes[0x04E] = KeyKPAdd
-	_glfw.windowState.keycodes[0x053] = KeyKPDecimal
-	_glfw.windowState.keycodes[0x135] = KeyKPDivide
-	_glfw.windowState.keycodes[0x11C] = KeyKPEnter
-	_glfw.windowState.keycodes[0x059] = KeyKPEqual
-	_glfw.windowState.keycodes[0x037] = KeyKPMultiply
-	_glfw.windowState.keycodes[0x04A] = KeyKPSubtract
+	_glfw.platformWindow.keycodes[0x052] = KeyKP0
+	_glfw.platformWindow.keycodes[0x04F] = KeyKP1
+	_glfw.platformWindow.keycodes[0x050] = KeyKP2
+	_glfw.platformWindow.keycodes[0x051] = KeyKP3
+	_glfw.platformWindow.keycodes[0x04B] = KeyKP4
+	_glfw.platformWindow.keycodes[0x04C] = KeyKP5
+	_glfw.platformWindow.keycodes[0x04D] = KeyKP6
+	_glfw.platformWindow.keycodes[0x047] = KeyKP7
+	_glfw.platformWindow.keycodes[0x048] = KeyKP8
+	_glfw.platformWindow.keycodes[0x049] = KeyKP9
+	_glfw.platformWindow.keycodes[0x04E] = KeyKPAdd
+	_glfw.platformWindow.keycodes[0x053] = KeyKPDecimal
+	_glfw.platformWindow.keycodes[0x135] = KeyKPDivide
+	_glfw.platformWindow.keycodes[0x11C] = KeyKPEnter
+	_glfw.platformWindow.keycodes[0x059] = KeyKPEqual
+	_glfw.platformWindow.keycodes[0x037] = KeyKPMultiply
+	_glfw.platformWindow.keycodes[0x04A] = KeyKPSubtract
 
 	for scancode := 0; scancode < 512; scancode++ {
-		if _glfw.windowState.keycodes[scancode] > 0 {
-			_glfw.windowState.scancodes[_glfw.windowState.keycodes[scancode]] = scancode
+		if _glfw.platformWindow.keycodes[scancode] > 0 {
+			_glfw.platformWindow.scancodes[_glfw.platformWindow.keycodes[scancode]] = scancode
 		}
 	}
 }
@@ -157,14 +157,14 @@ func updateKeyNamesWin32() {
 		return
 	}
 
-	for i := range _glfw.windowState.keynames {
-		_glfw.windowState.keynames[i] = ""
+	for i := range _glfw.platformWindow.keynames {
+		_glfw.platformWindow.keynames[i] = ""
 	}
 
 	var state [256]byte
 
 	for key := KeySpace; key <= KeyLast; key++ {
-		scancode := _glfw.windowState.scancodes[key]
+		scancode := _glfw.platformWindow.scancodes[key]
 		if scancode == -1 {
 			continue
 		}
@@ -193,21 +193,21 @@ func updateKeyNamesWin32() {
 			continue
 		}
 
-		_glfw.windowState.keynames[key] = windows.UTF16ToString(chars[:length])
+		_glfw.platformWindow.keynames[key] = windows.UTF16ToString(chars[:length])
 	}
 }
 
 func createHelperWindow() error {
-	h, err := _CreateWindowExW(_WS_EX_OVERLAPPEDWINDOW, _GLFW_WNDCLASSNAME, "GLFW message window", _WS_CLIPSIBLINGS|_WS_CLIPCHILDREN, 0, 0, 1, 1, 0, 0, _glfw.windowState.instance, nil)
+	h, err := _CreateWindowExW(_WS_EX_OVERLAPPEDWINDOW, _GLFW_WNDCLASSNAME, "GLFW message window", _WS_CLIPSIBLINGS|_WS_CLIPCHILDREN, 0, 0, 1, 1, 0, 0, _glfw.platformWindow.instance, nil)
 	if err != nil {
 		return err
 	}
 
-	_glfw.windowState.helperWindowHandle = h
+	_glfw.platformWindow.helperWindowHandle = h
 
 	// HACK: The command to the first ShowWindow call is ignored if the parent
 	//       process passed along a STARTUPINFO, so clear that with a no-op call
-	_ShowWindow(_glfw.windowState.helperWindowHandle, _SW_HIDE)
+	_ShowWindow(_glfw.platformWindow.helperWindowHandle, _SW_HIDE)
 
 	// Register for HID device notifications
 	if !microsoftgdk.IsXbox() {
@@ -222,15 +222,15 @@ func createHelperWindow() error {
 		dbi.dbcc_size = uint32(unsafe.Sizeof(dbi))
 		dbi.dbcc_devicetype = _DBT_DEVTYP_DEVICEINTERFACE
 		dbi.dbcc_classguid = _GUID_DEVINTERFACE_HID
-		notify, err := _RegisterDeviceNotificationW(windows.Handle(_glfw.windowState.helperWindowHandle), unsafe.Pointer(&dbi), _DEVICE_NOTIFY_WINDOW_HANDLE)
+		notify, err := _RegisterDeviceNotificationW(windows.Handle(_glfw.platformWindow.helperWindowHandle), unsafe.Pointer(&dbi), _DEVICE_NOTIFY_WINDOW_HANDLE)
 		if err != nil {
 			return err
 		}
-		_glfw.windowState.deviceNotificationHandle = notify
+		_glfw.platformWindow.deviceNotificationHandle = notify
 	}
 
 	var msg _MSG
-	for _PeekMessageW(&msg, _glfw.windowState.helperWindowHandle, 0, 0, _PM_REMOVE) {
+	for _PeekMessageW(&msg, _glfw.platformWindow.helperWindowHandle, 0, 0, _PM_REMOVE) {
 		_TranslateMessage(&msg)
 		_DispatchMessageW(&msg)
 	}
@@ -281,7 +281,7 @@ func platformInit() error {
 	if err != nil {
 		return err
 	}
-	_glfw.windowState.instance = _HINSTANCE(m)
+	_glfw.platformWindow.instance = _HINSTANCE(m)
 
 	createKeyTables()
 	updateKeyNamesWin32()
@@ -335,15 +335,15 @@ func platformInit() error {
 }
 
 func platformTerminate() error {
-	if _glfw.windowState.deviceNotificationHandle != 0 {
-		if err := _UnregisterDeviceNotification(_glfw.windowState.deviceNotificationHandle); err != nil {
+	if _glfw.platformWindow.deviceNotificationHandle != 0 {
+		if err := _UnregisterDeviceNotification(_glfw.platformWindow.deviceNotificationHandle); err != nil {
 			return err
 		}
 	}
 
-	if _glfw.windowState.helperWindowHandle != 0 {
+	if _glfw.platformWindow.helperWindowHandle != 0 {
 		if !microsoftgdk.IsXbox() {
-			if err := _DestroyWindow(_glfw.windowState.helperWindowHandle); err != nil {
+			if err := _DestroyWindow(_glfw.platformWindow.helperWindowHandle); err != nil {
 				return err
 			}
 		}

--- a/internal/goglfw/win32init_windows.go
+++ b/internal/goglfw/win32init_windows.go
@@ -15,138 +15,138 @@ import (
 )
 
 func createKeyTables() {
-	for i := range _glfw.win32.keycodes {
-		_glfw.win32.keycodes[i] = -1
+	for i := range _glfw.windowState.keycodes {
+		_glfw.windowState.keycodes[i] = -1
 	}
-	for i := range _glfw.win32.scancodes {
-		_glfw.win32.keycodes[i] = -1
+	for i := range _glfw.windowState.scancodes {
+		_glfw.windowState.keycodes[i] = -1
 	}
 
-	_glfw.win32.keycodes[0x00B] = Key0
-	_glfw.win32.keycodes[0x002] = Key1
-	_glfw.win32.keycodes[0x003] = Key2
-	_glfw.win32.keycodes[0x004] = Key3
-	_glfw.win32.keycodes[0x005] = Key4
-	_glfw.win32.keycodes[0x006] = Key5
-	_glfw.win32.keycodes[0x007] = Key6
-	_glfw.win32.keycodes[0x008] = Key7
-	_glfw.win32.keycodes[0x009] = Key8
-	_glfw.win32.keycodes[0x00A] = Key9
-	_glfw.win32.keycodes[0x01E] = KeyA
-	_glfw.win32.keycodes[0x030] = KeyB
-	_glfw.win32.keycodes[0x02E] = KeyC
-	_glfw.win32.keycodes[0x020] = KeyD
-	_glfw.win32.keycodes[0x012] = KeyE
-	_glfw.win32.keycodes[0x021] = KeyF
-	_glfw.win32.keycodes[0x022] = KeyG
-	_glfw.win32.keycodes[0x023] = KeyH
-	_glfw.win32.keycodes[0x017] = KeyI
-	_glfw.win32.keycodes[0x024] = KeyJ
-	_glfw.win32.keycodes[0x025] = KeyK
-	_glfw.win32.keycodes[0x026] = KeyL
-	_glfw.win32.keycodes[0x032] = KeyM
-	_glfw.win32.keycodes[0x031] = KeyN
-	_glfw.win32.keycodes[0x018] = KeyO
-	_glfw.win32.keycodes[0x019] = KeyP
-	_glfw.win32.keycodes[0x010] = KeyQ
-	_glfw.win32.keycodes[0x013] = KeyR
-	_glfw.win32.keycodes[0x01F] = KeyS
-	_glfw.win32.keycodes[0x014] = KeyT
-	_glfw.win32.keycodes[0x016] = KeyU
-	_glfw.win32.keycodes[0x02F] = KeyV
-	_glfw.win32.keycodes[0x011] = KeyW
-	_glfw.win32.keycodes[0x02D] = KeyX
-	_glfw.win32.keycodes[0x015] = KeyY
-	_glfw.win32.keycodes[0x02C] = KeyZ
+	_glfw.windowState.keycodes[0x00B] = Key0
+	_glfw.windowState.keycodes[0x002] = Key1
+	_glfw.windowState.keycodes[0x003] = Key2
+	_glfw.windowState.keycodes[0x004] = Key3
+	_glfw.windowState.keycodes[0x005] = Key4
+	_glfw.windowState.keycodes[0x006] = Key5
+	_glfw.windowState.keycodes[0x007] = Key6
+	_glfw.windowState.keycodes[0x008] = Key7
+	_glfw.windowState.keycodes[0x009] = Key8
+	_glfw.windowState.keycodes[0x00A] = Key9
+	_glfw.windowState.keycodes[0x01E] = KeyA
+	_glfw.windowState.keycodes[0x030] = KeyB
+	_glfw.windowState.keycodes[0x02E] = KeyC
+	_glfw.windowState.keycodes[0x020] = KeyD
+	_glfw.windowState.keycodes[0x012] = KeyE
+	_glfw.windowState.keycodes[0x021] = KeyF
+	_glfw.windowState.keycodes[0x022] = KeyG
+	_glfw.windowState.keycodes[0x023] = KeyH
+	_glfw.windowState.keycodes[0x017] = KeyI
+	_glfw.windowState.keycodes[0x024] = KeyJ
+	_glfw.windowState.keycodes[0x025] = KeyK
+	_glfw.windowState.keycodes[0x026] = KeyL
+	_glfw.windowState.keycodes[0x032] = KeyM
+	_glfw.windowState.keycodes[0x031] = KeyN
+	_glfw.windowState.keycodes[0x018] = KeyO
+	_glfw.windowState.keycodes[0x019] = KeyP
+	_glfw.windowState.keycodes[0x010] = KeyQ
+	_glfw.windowState.keycodes[0x013] = KeyR
+	_glfw.windowState.keycodes[0x01F] = KeyS
+	_glfw.windowState.keycodes[0x014] = KeyT
+	_glfw.windowState.keycodes[0x016] = KeyU
+	_glfw.windowState.keycodes[0x02F] = KeyV
+	_glfw.windowState.keycodes[0x011] = KeyW
+	_glfw.windowState.keycodes[0x02D] = KeyX
+	_glfw.windowState.keycodes[0x015] = KeyY
+	_glfw.windowState.keycodes[0x02C] = KeyZ
 
-	_glfw.win32.keycodes[0x028] = KeyApostrophe
-	_glfw.win32.keycodes[0x02B] = KeyBackslash
-	_glfw.win32.keycodes[0x033] = KeyComma
-	_glfw.win32.keycodes[0x00D] = KeyEqual
-	_glfw.win32.keycodes[0x029] = KeyGraveAccent
-	_glfw.win32.keycodes[0x01A] = KeyLeftBracket
-	_glfw.win32.keycodes[0x00C] = KeyMinus
-	_glfw.win32.keycodes[0x034] = KeyPeriod
-	_glfw.win32.keycodes[0x01B] = KeyRightBracket
-	_glfw.win32.keycodes[0x027] = KeySemicolon
-	_glfw.win32.keycodes[0x035] = KeySlash
-	_glfw.win32.keycodes[0x056] = KeyWorld2
+	_glfw.windowState.keycodes[0x028] = KeyApostrophe
+	_glfw.windowState.keycodes[0x02B] = KeyBackslash
+	_glfw.windowState.keycodes[0x033] = KeyComma
+	_glfw.windowState.keycodes[0x00D] = KeyEqual
+	_glfw.windowState.keycodes[0x029] = KeyGraveAccent
+	_glfw.windowState.keycodes[0x01A] = KeyLeftBracket
+	_glfw.windowState.keycodes[0x00C] = KeyMinus
+	_glfw.windowState.keycodes[0x034] = KeyPeriod
+	_glfw.windowState.keycodes[0x01B] = KeyRightBracket
+	_glfw.windowState.keycodes[0x027] = KeySemicolon
+	_glfw.windowState.keycodes[0x035] = KeySlash
+	_glfw.windowState.keycodes[0x056] = KeyWorld2
 
-	_glfw.win32.keycodes[0x00E] = KeyBackspace
-	_glfw.win32.keycodes[0x153] = KeyDelete
-	_glfw.win32.keycodes[0x14F] = KeyEnd
-	_glfw.win32.keycodes[0x01C] = KeyEnter
-	_glfw.win32.keycodes[0x001] = KeyEscape
-	_glfw.win32.keycodes[0x147] = KeyHome
-	_glfw.win32.keycodes[0x152] = KeyInsert
-	_glfw.win32.keycodes[0x15D] = KeyMenu
-	_glfw.win32.keycodes[0x151] = KeyPageDown
-	_glfw.win32.keycodes[0x149] = KeyPageUp
-	_glfw.win32.keycodes[0x045] = KeyPause
-	_glfw.win32.keycodes[0x039] = KeySpace
-	_glfw.win32.keycodes[0x00F] = KeyTab
-	_glfw.win32.keycodes[0x03A] = KeyCapsLock
-	_glfw.win32.keycodes[0x145] = KeyNumLock
-	_glfw.win32.keycodes[0x046] = KeyScrollLock
-	_glfw.win32.keycodes[0x03B] = KeyF1
-	_glfw.win32.keycodes[0x03C] = KeyF2
-	_glfw.win32.keycodes[0x03D] = KeyF3
-	_glfw.win32.keycodes[0x03E] = KeyF4
-	_glfw.win32.keycodes[0x03F] = KeyF5
-	_glfw.win32.keycodes[0x040] = KeyF6
-	_glfw.win32.keycodes[0x041] = KeyF7
-	_glfw.win32.keycodes[0x042] = KeyF8
-	_glfw.win32.keycodes[0x043] = KeyF9
-	_glfw.win32.keycodes[0x044] = KeyF10
-	_glfw.win32.keycodes[0x057] = KeyF11
-	_glfw.win32.keycodes[0x058] = KeyF12
-	_glfw.win32.keycodes[0x064] = KeyF13
-	_glfw.win32.keycodes[0x065] = KeyF14
-	_glfw.win32.keycodes[0x066] = KeyF15
-	_glfw.win32.keycodes[0x067] = KeyF16
-	_glfw.win32.keycodes[0x068] = KeyF17
-	_glfw.win32.keycodes[0x069] = KeyF18
-	_glfw.win32.keycodes[0x06A] = KeyF19
-	_glfw.win32.keycodes[0x06B] = KeyF20
-	_glfw.win32.keycodes[0x06C] = KeyF21
-	_glfw.win32.keycodes[0x06D] = KeyF22
-	_glfw.win32.keycodes[0x06E] = KeyF23
-	_glfw.win32.keycodes[0x076] = KeyF24
-	_glfw.win32.keycodes[0x038] = KeyLeftAlt
-	_glfw.win32.keycodes[0x01D] = KeyLeftControl
-	_glfw.win32.keycodes[0x02A] = KeyLeftShift
-	_glfw.win32.keycodes[0x15B] = KeyLeftSuper
-	_glfw.win32.keycodes[0x137] = KeyPrintScreen
-	_glfw.win32.keycodes[0x138] = KeyRightAlt
-	_glfw.win32.keycodes[0x11D] = KeyRightControl
-	_glfw.win32.keycodes[0x036] = KeyRightShift
-	_glfw.win32.keycodes[0x15C] = KeyRightSuper
-	_glfw.win32.keycodes[0x150] = KeyDown
-	_glfw.win32.keycodes[0x14B] = KeyLeft
-	_glfw.win32.keycodes[0x14D] = KeyRight
-	_glfw.win32.keycodes[0x148] = KeyUp
+	_glfw.windowState.keycodes[0x00E] = KeyBackspace
+	_glfw.windowState.keycodes[0x153] = KeyDelete
+	_glfw.windowState.keycodes[0x14F] = KeyEnd
+	_glfw.windowState.keycodes[0x01C] = KeyEnter
+	_glfw.windowState.keycodes[0x001] = KeyEscape
+	_glfw.windowState.keycodes[0x147] = KeyHome
+	_glfw.windowState.keycodes[0x152] = KeyInsert
+	_glfw.windowState.keycodes[0x15D] = KeyMenu
+	_glfw.windowState.keycodes[0x151] = KeyPageDown
+	_glfw.windowState.keycodes[0x149] = KeyPageUp
+	_glfw.windowState.keycodes[0x045] = KeyPause
+	_glfw.windowState.keycodes[0x039] = KeySpace
+	_glfw.windowState.keycodes[0x00F] = KeyTab
+	_glfw.windowState.keycodes[0x03A] = KeyCapsLock
+	_glfw.windowState.keycodes[0x145] = KeyNumLock
+	_glfw.windowState.keycodes[0x046] = KeyScrollLock
+	_glfw.windowState.keycodes[0x03B] = KeyF1
+	_glfw.windowState.keycodes[0x03C] = KeyF2
+	_glfw.windowState.keycodes[0x03D] = KeyF3
+	_glfw.windowState.keycodes[0x03E] = KeyF4
+	_glfw.windowState.keycodes[0x03F] = KeyF5
+	_glfw.windowState.keycodes[0x040] = KeyF6
+	_glfw.windowState.keycodes[0x041] = KeyF7
+	_glfw.windowState.keycodes[0x042] = KeyF8
+	_glfw.windowState.keycodes[0x043] = KeyF9
+	_glfw.windowState.keycodes[0x044] = KeyF10
+	_glfw.windowState.keycodes[0x057] = KeyF11
+	_glfw.windowState.keycodes[0x058] = KeyF12
+	_glfw.windowState.keycodes[0x064] = KeyF13
+	_glfw.windowState.keycodes[0x065] = KeyF14
+	_glfw.windowState.keycodes[0x066] = KeyF15
+	_glfw.windowState.keycodes[0x067] = KeyF16
+	_glfw.windowState.keycodes[0x068] = KeyF17
+	_glfw.windowState.keycodes[0x069] = KeyF18
+	_glfw.windowState.keycodes[0x06A] = KeyF19
+	_glfw.windowState.keycodes[0x06B] = KeyF20
+	_glfw.windowState.keycodes[0x06C] = KeyF21
+	_glfw.windowState.keycodes[0x06D] = KeyF22
+	_glfw.windowState.keycodes[0x06E] = KeyF23
+	_glfw.windowState.keycodes[0x076] = KeyF24
+	_glfw.windowState.keycodes[0x038] = KeyLeftAlt
+	_glfw.windowState.keycodes[0x01D] = KeyLeftControl
+	_glfw.windowState.keycodes[0x02A] = KeyLeftShift
+	_glfw.windowState.keycodes[0x15B] = KeyLeftSuper
+	_glfw.windowState.keycodes[0x137] = KeyPrintScreen
+	_glfw.windowState.keycodes[0x138] = KeyRightAlt
+	_glfw.windowState.keycodes[0x11D] = KeyRightControl
+	_glfw.windowState.keycodes[0x036] = KeyRightShift
+	_glfw.windowState.keycodes[0x15C] = KeyRightSuper
+	_glfw.windowState.keycodes[0x150] = KeyDown
+	_glfw.windowState.keycodes[0x14B] = KeyLeft
+	_glfw.windowState.keycodes[0x14D] = KeyRight
+	_glfw.windowState.keycodes[0x148] = KeyUp
 
-	_glfw.win32.keycodes[0x052] = KeyKP0
-	_glfw.win32.keycodes[0x04F] = KeyKP1
-	_glfw.win32.keycodes[0x050] = KeyKP2
-	_glfw.win32.keycodes[0x051] = KeyKP3
-	_glfw.win32.keycodes[0x04B] = KeyKP4
-	_glfw.win32.keycodes[0x04C] = KeyKP5
-	_glfw.win32.keycodes[0x04D] = KeyKP6
-	_glfw.win32.keycodes[0x047] = KeyKP7
-	_glfw.win32.keycodes[0x048] = KeyKP8
-	_glfw.win32.keycodes[0x049] = KeyKP9
-	_glfw.win32.keycodes[0x04E] = KeyKPAdd
-	_glfw.win32.keycodes[0x053] = KeyKPDecimal
-	_glfw.win32.keycodes[0x135] = KeyKPDivide
-	_glfw.win32.keycodes[0x11C] = KeyKPEnter
-	_glfw.win32.keycodes[0x059] = KeyKPEqual
-	_glfw.win32.keycodes[0x037] = KeyKPMultiply
-	_glfw.win32.keycodes[0x04A] = KeyKPSubtract
+	_glfw.windowState.keycodes[0x052] = KeyKP0
+	_glfw.windowState.keycodes[0x04F] = KeyKP1
+	_glfw.windowState.keycodes[0x050] = KeyKP2
+	_glfw.windowState.keycodes[0x051] = KeyKP3
+	_glfw.windowState.keycodes[0x04B] = KeyKP4
+	_glfw.windowState.keycodes[0x04C] = KeyKP5
+	_glfw.windowState.keycodes[0x04D] = KeyKP6
+	_glfw.windowState.keycodes[0x047] = KeyKP7
+	_glfw.windowState.keycodes[0x048] = KeyKP8
+	_glfw.windowState.keycodes[0x049] = KeyKP9
+	_glfw.windowState.keycodes[0x04E] = KeyKPAdd
+	_glfw.windowState.keycodes[0x053] = KeyKPDecimal
+	_glfw.windowState.keycodes[0x135] = KeyKPDivide
+	_glfw.windowState.keycodes[0x11C] = KeyKPEnter
+	_glfw.windowState.keycodes[0x059] = KeyKPEqual
+	_glfw.windowState.keycodes[0x037] = KeyKPMultiply
+	_glfw.windowState.keycodes[0x04A] = KeyKPSubtract
 
 	for scancode := 0; scancode < 512; scancode++ {
-		if _glfw.win32.keycodes[scancode] > 0 {
-			_glfw.win32.scancodes[_glfw.win32.keycodes[scancode]] = scancode
+		if _glfw.windowState.keycodes[scancode] > 0 {
+			_glfw.windowState.scancodes[_glfw.windowState.keycodes[scancode]] = scancode
 		}
 	}
 }
@@ -157,14 +157,14 @@ func updateKeyNamesWin32() {
 		return
 	}
 
-	for i := range _glfw.win32.keynames {
-		_glfw.win32.keynames[i] = ""
+	for i := range _glfw.windowState.keynames {
+		_glfw.windowState.keynames[i] = ""
 	}
 
 	var state [256]byte
 
 	for key := KeySpace; key <= KeyLast; key++ {
-		scancode := _glfw.win32.scancodes[key]
+		scancode := _glfw.windowState.scancodes[key]
 		if scancode == -1 {
 			continue
 		}
@@ -193,21 +193,21 @@ func updateKeyNamesWin32() {
 			continue
 		}
 
-		_glfw.win32.keynames[key] = windows.UTF16ToString(chars[:length])
+		_glfw.windowState.keynames[key] = windows.UTF16ToString(chars[:length])
 	}
 }
 
 func createHelperWindow() error {
-	h, err := _CreateWindowExW(_WS_EX_OVERLAPPEDWINDOW, _GLFW_WNDCLASSNAME, "GLFW message window", _WS_CLIPSIBLINGS|_WS_CLIPCHILDREN, 0, 0, 1, 1, 0, 0, _glfw.win32.instance, nil)
+	h, err := _CreateWindowExW(_WS_EX_OVERLAPPEDWINDOW, _GLFW_WNDCLASSNAME, "GLFW message window", _WS_CLIPSIBLINGS|_WS_CLIPCHILDREN, 0, 0, 1, 1, 0, 0, _glfw.windowState.instance, nil)
 	if err != nil {
 		return err
 	}
 
-	_glfw.win32.helperWindowHandle = h
+	_glfw.windowState.helperWindowHandle = h
 
 	// HACK: The command to the first ShowWindow call is ignored if the parent
 	//       process passed along a STARTUPINFO, so clear that with a no-op call
-	_ShowWindow(_glfw.win32.helperWindowHandle, _SW_HIDE)
+	_ShowWindow(_glfw.windowState.helperWindowHandle, _SW_HIDE)
 
 	// Register for HID device notifications
 	if !microsoftgdk.IsXbox() {
@@ -222,15 +222,15 @@ func createHelperWindow() error {
 		dbi.dbcc_size = uint32(unsafe.Sizeof(dbi))
 		dbi.dbcc_devicetype = _DBT_DEVTYP_DEVICEINTERFACE
 		dbi.dbcc_classguid = _GUID_DEVINTERFACE_HID
-		notify, err := _RegisterDeviceNotificationW(windows.Handle(_glfw.win32.helperWindowHandle), unsafe.Pointer(&dbi), _DEVICE_NOTIFY_WINDOW_HANDLE)
+		notify, err := _RegisterDeviceNotificationW(windows.Handle(_glfw.windowState.helperWindowHandle), unsafe.Pointer(&dbi), _DEVICE_NOTIFY_WINDOW_HANDLE)
 		if err != nil {
 			return err
 		}
-		_glfw.win32.deviceNotificationHandle = notify
+		_glfw.windowState.deviceNotificationHandle = notify
 	}
 
 	var msg _MSG
-	for _PeekMessageW(&msg, _glfw.win32.helperWindowHandle, 0, 0, _PM_REMOVE) {
+	for _PeekMessageW(&msg, _glfw.windowState.helperWindowHandle, 0, 0, _PM_REMOVE) {
 		_TranslateMessage(&msg)
 		_DispatchMessageW(&msg)
 	}
@@ -281,7 +281,7 @@ func platformInit() error {
 	if err != nil {
 		return err
 	}
-	_glfw.win32.instance = _HINSTANCE(m)
+	_glfw.windowState.instance = _HINSTANCE(m)
 
 	createKeyTables()
 	updateKeyNamesWin32()
@@ -335,15 +335,15 @@ func platformInit() error {
 }
 
 func platformTerminate() error {
-	if _glfw.win32.deviceNotificationHandle != 0 {
-		if err := _UnregisterDeviceNotification(_glfw.win32.deviceNotificationHandle); err != nil {
+	if _glfw.windowState.deviceNotificationHandle != 0 {
+		if err := _UnregisterDeviceNotification(_glfw.windowState.deviceNotificationHandle); err != nil {
 			return err
 		}
 	}
 
-	if _glfw.win32.helperWindowHandle != 0 {
+	if _glfw.windowState.helperWindowHandle != 0 {
 		if !microsoftgdk.IsXbox() {
-			if err := _DestroyWindow(_glfw.win32.helperWindowHandle); err != nil {
+			if err := _DestroyWindow(_glfw.windowState.helperWindowHandle); err != nil {
 				return err
 			}
 		}

--- a/internal/goglfw/win32monitor_windows.go
+++ b/internal/goglfw/win32monitor_windows.go
@@ -16,8 +16,8 @@ import (
 
 func monitorCallback(handle _HMONITOR, dc _HDC, rect *_RECT, monitor *Monitor /* _LPARAM */) uintptr /* _BOOL */ {
 	if mi, ok := _GetMonitorInfoW_Ex(handle); ok {
-		if windows.UTF16ToString(mi.szDevice[:]) == monitor.win32.adapterName {
-			monitor.win32.handle = handle
+		if windows.UTF16ToString(mi.szDevice[:]) == monitor.state.adapterName {
+			monitor.state.handle = handle
 		}
 	}
 	return 1
@@ -47,12 +47,12 @@ func createMonitor(adapter *_DISPLAY_DEVICEW, display *_DISPLAY_DEVICEW) (*Monit
 	}
 
 	if adapter.StateFlags&_DISPLAY_DEVICE_MODESPRUNED != 0 {
-		monitor.win32.modesPruned = true
+		monitor.state.modesPruned = true
 	}
 
-	monitor.win32.adapterName = adapterDeviceName
+	monitor.state.adapterName = adapterDeviceName
 	if display != nil {
-		monitor.win32.displayName = windows.UTF16ToString(display.DeviceName[:])
+		monitor.state.displayName = windows.UTF16ToString(display.DeviceName[:])
 	}
 
 	rect := _RECT{
@@ -103,7 +103,7 @@ adapterLoop:
 			}
 
 			for i, monitor := range disconnected {
-				if monitor != nil && monitor.win32.displayName == windows.UTF16ToString(display.DeviceName[:]) {
+				if monitor != nil && monitor.state.displayName == windows.UTF16ToString(display.DeviceName[:]) {
 					disconnected[i] = nil
 					err := _EnumDisplayMonitors(0, nil, monitorCallbackPtr, _LPARAM(unsafe.Pointer(_glfw.monitors[i])))
 					if err != nil {
@@ -132,7 +132,7 @@ adapterLoop:
 		//       (as sometimes happens), add it directly as a monitor
 		if !found {
 			for i, monitor := range disconnected {
-				if monitor != nil && monitor.win32.displayName == windows.UTF16ToString(adapter.DeviceName[:]) {
+				if monitor != nil && monitor.state.displayName == windows.UTF16ToString(adapter.DeviceName[:]) {
 					disconnected[i] = nil
 					continue adapterLoop
 				}
@@ -184,9 +184,9 @@ func (m *Monitor) setVideoModeWin32(desired *VidMode) error {
 	if dm.dmBitsPerPel < 15 || dm.dmBitsPerPel >= 24 {
 		dm.dmBitsPerPel = 32
 	}
-	switch _ChangeDisplaySettingsExW(m.win32.adapterName, &dm, 0, _CDS_FULLSCREEN, nil) {
+	switch _ChangeDisplaySettingsExW(m.state.adapterName, &dm, 0, _CDS_FULLSCREEN, nil) {
 	case _DISP_CHANGE_SUCCESSFUL:
-		m.win32.modeChanged = true
+		m.state.modeChanged = true
 		return nil
 	case _DISP_CHANGE_BADDUALVIEW:
 		return errors.New("goglfw: the system uses DualView at Monitor.setVideoModeWin32")
@@ -208,9 +208,9 @@ func (m *Monitor) setVideoModeWin32(desired *VidMode) error {
 }
 
 func (m *Monitor) restoreVideoModeWin32() {
-	if m.win32.modeChanged {
-		_ChangeDisplaySettingsExW(m.win32.adapterName, nil, 0, _CDS_FULLSCREEN, nil)
-		m.win32.modeChanged = false
+	if m.state.modeChanged {
+		_ChangeDisplaySettingsExW(m.state.adapterName, nil, 0, _CDS_FULLSCREEN, nil)
+		m.state.modeChanged = false
 	}
 }
 
@@ -244,7 +244,7 @@ func (m *Monitor) platformGetMonitorPos() (xpos, ypos int, ok bool) {
 		return 0, 0, true
 	}
 
-	dm, ok := _EnumDisplaySettingsExW(m.win32.adapterName, _ENUM_CURRENT_SETTINGS, _EDS_ROTATEDMODE)
+	dm, ok := _EnumDisplaySettingsExW(m.state.adapterName, _ENUM_CURRENT_SETTINGS, _EDS_ROTATEDMODE)
 	if !ok {
 		return 0, 0, false
 	}
@@ -256,7 +256,7 @@ func (m *Monitor) platformGetMonitorContentScale() (xscale, yscale float32, err 
 		return 1, 1, nil
 	}
 
-	return getMonitorContentScaleWin32(m.win32.handle)
+	return getMonitorContentScaleWin32(m.state.handle)
 }
 
 func (m *Monitor) platformGetMonitorWorkarea() (xpos, ypos, width, height int) {
@@ -265,7 +265,7 @@ func (m *Monitor) platformGetMonitorWorkarea() (xpos, ypos, width, height int) {
 		return 0, 0, w, h
 	}
 
-	mi, ok := _GetMonitorInfoW(m.win32.handle)
+	mi, ok := _GetMonitorInfoW(m.state.handle)
 	if !ok {
 		return 0, 0, 0, 0
 	}
@@ -280,7 +280,7 @@ func (m *Monitor) platformAppendVideoModes(monitors []*VidMode) ([]*VidMode, err
 	origLen := len(monitors)
 loop:
 	for modeIndex := uint32(0); ; modeIndex++ {
-		dm, ok := _EnumDisplaySettingsW(m.win32.adapterName, modeIndex)
+		dm, ok := _EnumDisplaySettingsW(m.state.adapterName, modeIndex)
 		if !ok {
 			break
 		}
@@ -307,9 +307,9 @@ loop:
 			}
 		}
 
-		if m.win32.modesPruned {
+		if m.state.modesPruned {
 			// Skip modes not supported by the connected displays
-			if _ChangeDisplaySettingsExW(m.win32.adapterName, &dm, 0, _CDS_TEST, nil) != _DISP_CHANGE_SUCCESSFUL {
+			if _ChangeDisplaySettingsExW(m.state.adapterName, &dm, 0, _CDS_TEST, nil) != _DISP_CHANGE_SUCCESSFUL {
 				continue
 			}
 		}
@@ -330,7 +330,7 @@ func (m *Monitor) platformGetVideoMode() *VidMode {
 		return m.modes[0]
 	}
 
-	dm, _ := _EnumDisplaySettingsW(m.win32.adapterName, _ENUM_CURRENT_SETTINGS)
+	dm, _ := _EnumDisplaySettingsW(m.state.adapterName, _ENUM_CURRENT_SETTINGS)
 	r, g, b := splitBPP(int(dm.dmBitsPerPel))
 	return &VidMode{
 		Width:       int(dm.dmPelsWidth),
@@ -346,12 +346,12 @@ func (m *Monitor) in32Adapter() (string, error) {
 	if !_glfw.initialized {
 		return "", NotInitialized
 	}
-	return m.win32.adapterName, nil
+	return m.state.adapterName, nil
 }
 
 func (m *Monitor) win32Monitor() (string, error) {
 	if !_glfw.initialized {
 		return "", NotInitialized
 	}
-	return m.win32.displayName, nil
+	return m.state.displayName, nil
 }

--- a/internal/goglfw/win32platform_windows.go
+++ b/internal/goglfw/win32platform_windows.go
@@ -5,9 +5,97 @@
 
 package goglfw
 
+import "golang.org/x/sys/windows"
+
 const (
 	_GLFW_WNDCLASSNAME = "GLFW30"
 )
+
+type platformWindowState struct {
+	handle    windows.HWND
+	bigIcon   _HICON
+	smallIcon _HICON
+
+	cursorTracked  bool
+	frameAction    bool
+	iconified      bool
+	maximized      bool
+	transparent    bool // Whether to enable framebuffer transparency on DWM
+	scaleToMonitor bool
+
+	// Cached size used to filter out duplicate events
+	width  int
+	height int
+
+	// The last received cursor position, regardless of source
+	lastCursorPosX int
+	lastCursorPosY int
+
+	// The last recevied high surrogate when decoding pairs of UTF-16 messages
+	highSurrogate uint16
+}
+
+type platformContextState struct {
+	dc       _HDC
+	handle   _HGLRC
+	interval int
+}
+
+type platformMonitorState struct {
+	handle _HMONITOR
+
+	// This size matches the static size of DISPLAY_DEVICE.DeviceName
+	adapterName string
+	displayName string
+	modesPruned bool
+	modeChanged bool
+}
+
+type platformCursorState struct {
+	handle _HCURSOR
+}
+
+type platformTLSState struct {
+	allocated bool
+	index     uint32
+}
+
+type platformLibraryWindowState struct {
+	instance                 _HINSTANCE
+	helperWindowHandle       windows.HWND
+	deviceNotificationHandle _HDEVNOTIFY
+	acquiredMonitorCount     int
+	clipboardString          string
+	keycodes                 [512]Key
+	scancodes                [KeyLast + 1]int
+	keynames                 [KeyLast + 1]string
+
+	// Where to place the cursor when re-enabled
+	restoreCursorPosX float64
+	restoreCursorPosY float64
+
+	// The window whose disabled cursor mode is active
+	disabledCursorWindow *Window
+	rawInput             []byte
+	mouseTrailSize       uint32
+}
+
+type platformLibraryContextState struct {
+	inited bool
+
+	EXT_swap_control               bool
+	EXT_colorspace                 bool
+	ARB_multisample                bool
+	ARB_framebuffer_sRGB           bool
+	EXT_framebuffer_sRGB           bool
+	ARB_pixel_format               bool
+	ARB_create_context             bool
+	ARB_create_context_profile     bool
+	EXT_create_context_es2_profile bool
+	ARB_create_context_robustness  bool
+	ARB_create_context_no_error    bool
+	ARB_context_flush_control      bool
+}
 
 func _IsWindowsXPOrGreater() bool {
 	return isWindowsVersionOrGreaterWin32(uint16(_HIBYTE(_WIN32_WINNT_WINXP)), uint16(_LOBYTE(_WIN32_WINNT_WINXP)), 0)

--- a/internal/goglfw/win32thread_windows.go
+++ b/internal/goglfw/win32thread_windows.go
@@ -6,7 +6,7 @@
 package goglfw
 
 func (t *tls) create() error {
-	if t.state.allocated {
+	if t.platform.allocated {
 		panic("goglfw: TLS must not be allocated")
 	}
 
@@ -14,34 +14,34 @@ func (t *tls) create() error {
 	if err != nil {
 		return err
 	}
-	t.state.index = i
-	t.state.allocated = true
+	t.platform.index = i
+	t.platform.allocated = true
 	return nil
 }
 
 func (t *tls) destroy() error {
-	if t.state.allocated {
-		if err := _TlsFree(t.state.index); err != nil {
+	if t.platform.allocated {
+		if err := _TlsFree(t.platform.index); err != nil {
 			return err
 		}
 	}
-	t.state.allocated = false
-	t.state.index = 0
+	t.platform.allocated = false
+	t.platform.index = 0
 	return nil
 }
 
 func (t *tls) get() (uintptr, error) {
-	if !t.state.allocated {
+	if !t.platform.allocated {
 		panic("goglfw: TLS must be allocated")
 	}
 
-	return _TlsGetValue(t.state.index)
+	return _TlsGetValue(t.platform.index)
 }
 
 func (t *tls) set(value uintptr) error {
-	if !t.state.allocated {
+	if !t.platform.allocated {
 		panic("goglfw: TLS must be allocated")
 	}
 
-	return _TlsSetValue(t.state.index, value)
+	return _TlsSetValue(t.platform.index, value)
 }

--- a/internal/goglfw/win32thread_windows.go
+++ b/internal/goglfw/win32thread_windows.go
@@ -6,7 +6,7 @@
 package goglfw
 
 func (t *tls) create() error {
-	if t.win32.allocated {
+	if t.state.allocated {
 		panic("goglfw: TLS must not be allocated")
 	}
 
@@ -14,34 +14,34 @@ func (t *tls) create() error {
 	if err != nil {
 		return err
 	}
-	t.win32.index = i
-	t.win32.allocated = true
+	t.state.index = i
+	t.state.allocated = true
 	return nil
 }
 
 func (t *tls) destroy() error {
-	if t.win32.allocated {
-		if err := _TlsFree(t.win32.index); err != nil {
+	if t.state.allocated {
+		if err := _TlsFree(t.state.index); err != nil {
 			return err
 		}
 	}
-	t.win32.allocated = false
-	t.win32.index = 0
+	t.state.allocated = false
+	t.state.index = 0
 	return nil
 }
 
 func (t *tls) get() (uintptr, error) {
-	if !t.win32.allocated {
+	if !t.state.allocated {
 		panic("goglfw: TLS must be allocated")
 	}
 
-	return _TlsGetValue(t.win32.index)
+	return _TlsGetValue(t.state.index)
 }
 
 func (t *tls) set(value uintptr) error {
-	if !t.win32.allocated {
+	if !t.state.allocated {
 		panic("goglfw: TLS must be allocated")
 	}
 
-	return _TlsSetValue(t.win32.index, value)
+	return _TlsSetValue(t.state.index, value)
 }

--- a/internal/goglfw/win32window_windows.go
+++ b/internal/goglfw/win32window_windows.go
@@ -154,7 +154,7 @@ func (w *Window) applyAspectRatio(edge int, area *_RECT) error {
 
 	var dpi uint32 = _USER_DEFAULT_SCREEN_DPI
 	if isWindows10AnniversaryUpdateOrGreaterWin32() {
-		dpi = _GetDpiForWindow(w.state.handle)
+		dpi = _GetDpiForWindow(w.platform.handle)
 	}
 
 	xoff, yoff, err := getFullWindowSize(w.getWindowStyle(), w.getWindowExStyle(), 0, 0, dpi)
@@ -176,7 +176,7 @@ func (w *Window) applyAspectRatio(edge int, area *_RECT) error {
 func (w *Window) updateCursorImage() error {
 	if w.cursorMode == CursorNormal {
 		if w.cursor != nil {
-			_SetCursor(w.cursor.state.handle)
+			_SetCursor(w.cursor.platform.handle)
 		} else {
 			cursor, err := _LoadCursorW(0, _IDC_ARROW)
 			if err != nil {
@@ -195,7 +195,7 @@ func (w *Window) clientToScreen(rect _RECT) (_RECT, error) {
 		x: rect.left,
 		y: rect.top,
 	}
-	if err := _ClientToScreen(w.state.handle, &point); err != nil {
+	if err := _ClientToScreen(w.platform.handle, &point); err != nil {
 		return _RECT{}, err
 	}
 	rect.left = point.x
@@ -205,7 +205,7 @@ func (w *Window) clientToScreen(rect _RECT) (_RECT, error) {
 		x: rect.right,
 		y: rect.bottom,
 	}
-	if err := _ClientToScreen(w.state.handle, &point); err != nil {
+	if err := _ClientToScreen(w.platform.handle, &point); err != nil {
 		return _RECT{}, err
 	}
 	rect.right = point.x
@@ -215,7 +215,7 @@ func (w *Window) clientToScreen(rect _RECT) (_RECT, error) {
 
 func updateClipRect(window *Window) error {
 	if window != nil {
-		clipRect, err := _GetClientRect(window.state.handle)
+		clipRect, err := _GetClientRect(window.platform.handle)
 		if err != nil {
 			return err
 		}
@@ -242,7 +242,7 @@ func (w *Window) enableRawMouseMotion() error {
 			usUsagePage: 0x01,
 			usUsage:     0x02,
 			dwFlags:     0,
-			hwndTarget:  w.state.handle,
+			hwndTarget:  w.platform.handle,
 		},
 	}
 	return _RegisterRawInputDevices(rid)
@@ -261,12 +261,12 @@ func (w *Window) disableRawMouseMotion() error {
 }
 
 func (w *Window) disableCursor() error {
-	_glfw.windowState.disabledCursorWindow = w
+	_glfw.platformWindow.disabledCursorWindow = w
 	x, y, err := w.platformGetCursorPos()
 	if err != nil {
 		return err
 	}
-	_glfw.windowState.restoreCursorPosX, _glfw.windowState.restoreCursorPosY = x, y
+	_glfw.platformWindow.restoreCursorPosX, _glfw.platformWindow.restoreCursorPosY = x, y
 	if err := w.updateCursorImage(); err != nil {
 		return err
 	}
@@ -290,11 +290,11 @@ func (w *Window) enableCursor() error {
 			return err
 		}
 	}
-	_glfw.windowState.disabledCursorWindow = nil
+	_glfw.platformWindow.disabledCursorWindow = nil
 	if err := updateClipRect(nil); err != nil {
 		return err
 	}
-	if err := w.platformSetCursorPos(_glfw.windowState.restoreCursorPosX, _glfw.windowState.restoreCursorPosY); err != nil {
+	if err := w.platformSetCursorPos(_glfw.platformWindow.restoreCursorPosX, _glfw.platformWindow.restoreCursorPosY); err != nil {
 		return err
 	}
 	if err := w.updateCursorImage(); err != nil {
@@ -315,10 +315,10 @@ func (w *Window) cursorInContentArea() (bool, error) {
 		}
 		return false, err
 	}
-	if _WindowFromPoint(pos) != w.state.handle {
+	if _WindowFromPoint(pos) != w.platform.handle {
 		return false, nil
 	}
-	area, err := _GetClientRect(w.state.handle)
+	area, err := _GetClientRect(w.platform.handle)
 	if err != nil {
 		return false, err
 	}
@@ -330,7 +330,7 @@ func (w *Window) cursorInContentArea() (bool, error) {
 }
 
 func (w *Window) updateWindowStyles() error {
-	s, err := _GetWindowLongW(w.state.handle, _GWL_STYLE)
+	s, err := _GetWindowLongW(w.platform.handle, _GWL_STYLE)
 	if err != nil {
 		return err
 	}
@@ -338,13 +338,13 @@ func (w *Window) updateWindowStyles() error {
 	style &^= _WS_OVERLAPPEDWINDOW | _WS_POPUP
 	style |= w.getWindowStyle()
 
-	rect, err := _GetClientRect(w.state.handle)
+	rect, err := _GetClientRect(w.platform.handle)
 	if err != nil {
 		return err
 	}
 
 	if isWindows10AnniversaryUpdateOrGreaterWin32() {
-		if err := _AdjustWindowRectExForDpi(&rect, style, false, w.getWindowExStyle(), _GetDpiForWindow(w.state.handle)); err != nil {
+		if err := _AdjustWindowRectExForDpi(&rect, style, false, w.getWindowExStyle(), _GetDpiForWindow(w.platform.handle)); err != nil {
 			return err
 		}
 	} else {
@@ -357,10 +357,10 @@ func (w *Window) updateWindowStyles() error {
 	if err != nil {
 		return err
 	}
-	if _, err := _SetWindowLongW(w.state.handle, _GWL_STYLE, int32(style)); err != nil {
+	if _, err := _SetWindowLongW(w.platform.handle, _GWL_STYLE, int32(style)); err != nil {
 		return err
 	}
-	if err := _SetWindowPos(w.state.handle, _HWND_TOP, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, _SWP_FRAMECHANGED|_SWP_NOACTIVATE|_SWP_NOZORDER); err != nil {
+	if err := _SetWindowPos(w.platform.handle, _HWND_TOP, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, _SWP_FRAMECHANGED|_SWP_NOACTIVATE|_SWP_NOZORDER); err != nil {
 		return err
 	}
 
@@ -406,7 +406,7 @@ func (w *Window) updateFramebufferTransparency() error {
 		}
 
 		// Ignore an error from DWM functions as they might not be implemented e.g. on Proton (#2113).
-		_ = _DwmEnableBlurBehindWindow(w.state.handle, &bb)
+		_ = _DwmEnableBlurBehindWindow(w.platform.handle, &bb)
 	} else {
 		// HACK: Disable framebuffer transparency on Windows 7 when the
 		//       colorization color is opaque, because otherwise the window
@@ -417,7 +417,7 @@ func (w *Window) updateFramebufferTransparency() error {
 		}
 
 		// Ignore an error from DWM functions as they might not be implemented e.g. on Proton (#2113).
-		_ = _DwmEnableBlurBehindWindow(w.state.handle, &bb)
+		_ = _DwmEnableBlurBehindWindow(w.platform.handle, &bb)
 	}
 	return nil
 }
@@ -446,7 +446,7 @@ func getKeyMods() ModifierKey {
 }
 
 func (w *Window) fitToMonitor() error {
-	mi, ok := _GetMonitorInfoW(w.monitor.state.handle)
+	mi, ok := _GetMonitorInfoW(w.monitor.platform.handle)
 	if !ok {
 		return nil
 	}
@@ -456,7 +456,7 @@ func (w *Window) fitToMonitor() error {
 	} else {
 		hWndInsertAfter = _HWND_NOTOPMOST
 	}
-	if err := _SetWindowPos(w.state.handle, hWndInsertAfter,
+	if err := _SetWindowPos(w.platform.handle, hWndInsertAfter,
 		mi.rcMonitor.left,
 		mi.rcMonitor.top,
 		mi.rcMonitor.right-mi.rcMonitor.left,
@@ -468,13 +468,13 @@ func (w *Window) fitToMonitor() error {
 }
 
 func (w *Window) acquireMonitor() error {
-	if _glfw.windowState.acquiredMonitorCount == 0 {
+	if _glfw.platformWindow.acquiredMonitorCount == 0 {
 		_SetThreadExecutionState(_ES_CONTINUOUS | _ES_DISPLAY_REQUIRED)
 
 		// HACK: When mouse trails are enabled the cursor becomes invisible when
 		//       the OpenGL ICD switches to page flipping
 		if _IsWindowsXPOrGreater() {
-			if err := _SystemParametersInfoW(_SPI_GETMOUSETRAILS, 0, uintptr(unsafe.Pointer(&_glfw.windowState.mouseTrailSize)), 0); err != nil {
+			if err := _SystemParametersInfoW(_SPI_GETMOUSETRAILS, 0, uintptr(unsafe.Pointer(&_glfw.platformWindow.mouseTrailSize)), 0); err != nil {
 				return err
 			}
 			if err := _SystemParametersInfoW(_SPI_SETMOUSETRAILS, 0, 0, 0); err != nil {
@@ -484,7 +484,7 @@ func (w *Window) acquireMonitor() error {
 	}
 
 	if w.monitor.window == nil {
-		_glfw.windowState.acquiredMonitorCount++
+		_glfw.platformWindow.acquiredMonitorCount++
 	}
 
 	if err := w.monitor.setVideoModeWin32(&w.videoMode); err != nil {
@@ -499,13 +499,13 @@ func (w *Window) releaseMonitor() error {
 		return nil
 	}
 
-	_glfw.windowState.acquiredMonitorCount--
-	if _glfw.windowState.acquiredMonitorCount == 0 {
+	_glfw.platformWindow.acquiredMonitorCount--
+	if _glfw.platformWindow.acquiredMonitorCount == 0 {
 		_SetThreadExecutionState(_ES_CONTINUOUS)
 
 		// HACK: Restore mouse trail length saved in acquireMonitor
 		if _IsWindowsXPOrGreater() {
-			if err := _SystemParametersInfoW(_SPI_SETMOUSETRAILS, _glfw.windowState.mouseTrailSize, 0, 0); err != nil {
+			if err := _SystemParametersInfoW(_SPI_SETMOUSETRAILS, _glfw.platformWindow.mouseTrailSize, 0, 0); err != nil {
 				return err
 			}
 		}
@@ -517,7 +517,7 @@ func (w *Window) releaseMonitor() error {
 }
 
 func (w *Window) maximizeWindowManually() error {
-	mi, _ := _GetMonitorInfoW(_MonitorFromWindow(w.state.handle, _MONITOR_DEFAULTTONEAREST))
+	mi, _ := _GetMonitorInfoW(_MonitorFromWindow(w.platform.handle, _MONITOR_DEFAULTTONEAREST))
 
 	rect := mi.rcWork
 
@@ -530,24 +530,24 @@ func (w *Window) maximizeWindowManually() error {
 		}
 	}
 
-	s, err := _GetWindowLongW(w.state.handle, _GWL_STYLE)
+	s, err := _GetWindowLongW(w.platform.handle, _GWL_STYLE)
 	if err != nil {
 		return err
 	}
 	style := uint32(s)
 	style |= _WS_MAXIMIZE
-	if _, err := _SetWindowLongW(w.state.handle, _GWL_STYLE, int32(style)); err != nil {
+	if _, err := _SetWindowLongW(w.platform.handle, _GWL_STYLE, int32(style)); err != nil {
 		return err
 	}
 
 	if w.decorated {
-		s, err := _GetWindowLongW(w.state.handle, _GWL_EXSTYLE)
+		s, err := _GetWindowLongW(w.platform.handle, _GWL_EXSTYLE)
 		if err != nil {
 			return err
 		}
 		exStyle := uint32(s)
 		if isWindows10AnniversaryUpdateOrGreaterWin32() {
-			dpi := _GetDpiForWindow(w.state.handle)
+			dpi := _GetDpiForWindow(w.platform.handle)
 			if err := _AdjustWindowRectExForDpi(&rect, style, false, exStyle, dpi); err != nil {
 				return err
 			}
@@ -572,7 +572,7 @@ func (w *Window) maximizeWindowManually() error {
 		}
 	}
 
-	if err := _SetWindowPos(w.state.handle, _HWND_TOP,
+	if err := _SetWindowPos(w.platform.handle, _HWND_TOP,
 		rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top,
 		_SWP_NOACTIVATE|_SWP_NOZORDER|_SWP_FRAMECHANGED); err != nil {
 		return err
@@ -620,21 +620,21 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		//       clicking a caption button
 		if _HIWORD(uint32(lParam)) == _WM_LBUTTONDOWN {
 			if _LOWORD(uint32(lParam)) != _HTCLIENT {
-				window.state.frameAction = true
+				window.platform.frameAction = true
 			}
 		}
 
 	case _WM_CAPTURECHANGED:
 		// HACK: Disable the cursor once the caption button action has been
 		//       completed or cancelled
-		if lParam == 0 && window.state.frameAction {
+		if lParam == 0 && window.platform.frameAction {
 			if window.cursorMode == CursorDisabled {
 				if err := window.disableCursor(); err != nil {
 					_glfw.errors = append(_glfw.errors, err)
 					return 0
 				}
 			}
-			window.state.frameAction = false
+			window.platform.frameAction = false
 		}
 
 	case _WM_SETFOCUS:
@@ -642,7 +642,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 
 		// HACK: Do not disable cursor while the user is interacting with
 		//       a caption button
-		if window.state.frameAction {
+		if window.platform.frameAction {
 			break
 		}
 
@@ -695,13 +695,13 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 
 	case _WM_CHAR, _WM_SYSCHAR:
 		if wParam >= 0xd800 && wParam <= 0xdbff {
-			window.state.highSurrogate = uint16(wParam)
+			window.platform.highSurrogate = uint16(wParam)
 		} else {
 			var codepoint rune
 
 			if wParam >= 0xdc00 && wParam <= 0xdfff {
-				if window.state.highSurrogate != 0 {
-					codepoint += (rune(window.state.highSurrogate) - 0xd800) << 10
+				if window.platform.highSurrogate != 0 {
+					codepoint += (rune(window.platform.highSurrogate) - 0xd800) << 10
 					codepoint += (rune(wParam) & 0xffff) - 0xdc00
 					codepoint += 0x10000
 				}
@@ -709,7 +709,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 				codepoint = rune(wParam) & 0xffff
 			}
 
-			window.state.highSurrogate = 0
+			window.platform.highSurrogate = 0
 			window.inputChar(codepoint, getKeyMods(), uMsg != _WM_SYSCHAR)
 		}
 
@@ -758,7 +758,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 			scancode = 0x36
 		}
 
-		key := _glfw.windowState.keycodes[scancode]
+		key := _glfw.platformWindow.keycodes[scancode]
 
 		// The Ctrl keys require special handling
 		if wParam == _VK_CONTROL {
@@ -861,25 +861,25 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		x := _GET_X_LPARAM(lParam)
 		y := _GET_Y_LPARAM(lParam)
 
-		if !window.state.cursorTracked {
+		if !window.platform.cursorTracked {
 			var tme _TRACKMOUSEEVENT
 			tme.cbSize = uint32(unsafe.Sizeof(tme))
 			tme.dwFlags = _TME_LEAVE
-			tme.hwndTrack = window.state.handle
+			tme.hwndTrack = window.platform.handle
 			if err := _TrackMouseEvent(&tme); err != nil {
 				_glfw.errors = append(_glfw.errors, err)
 				return 0
 			}
 
-			window.state.cursorTracked = true
+			window.platform.cursorTracked = true
 			window.inputCursorEnter(true)
 		}
 
 		if window.cursorMode == CursorDisabled {
-			dx := x - window.state.lastCursorPosX
-			dy := y - window.state.lastCursorPosY
+			dx := x - window.platform.lastCursorPosX
+			dy := y - window.platform.lastCursorPosY
 
-			if _glfw.windowState.disabledCursorWindow != window {
+			if _glfw.platformWindow.disabledCursorWindow != window {
 				break
 			}
 			if window.rawMouseMotion {
@@ -891,13 +891,13 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 			window.inputCursorPos(float64(x), float64(y))
 		}
 
-		window.state.lastCursorPosX = x
-		window.state.lastCursorPosY = y
+		window.platform.lastCursorPosX = x
+		window.platform.lastCursorPosY = y
 
 		return 0
 
 	case _WM_INPUT:
-		if _glfw.windowState.disabledCursorWindow != window {
+		if _glfw.platformWindow.disabledCursorWindow != window {
 			break
 		}
 		if !window.rawMouseMotion {
@@ -910,22 +910,22 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 			_glfw.errors = append(_glfw.errors, err)
 			return 0
 		}
-		if size > uint32(len(_glfw.windowState.rawInput)) {
-			_glfw.windowState.rawInput = make([]byte, size)
+		if size > uint32(len(_glfw.platformWindow.rawInput)) {
+			_glfw.platformWindow.rawInput = make([]byte, size)
 		}
 
-		size = uint32(len(_glfw.windowState.rawInput))
-		if _, err := _GetRawInputData(ri, _RID_INPUT, unsafe.Pointer(&_glfw.windowState.rawInput[0]), &size); err != nil {
+		size = uint32(len(_glfw.platformWindow.rawInput))
+		if _, err := _GetRawInputData(ri, _RID_INPUT, unsafe.Pointer(&_glfw.platformWindow.rawInput[0]), &size); err != nil {
 			_glfw.errors = append(_glfw.errors, err)
 			return 0
 			// TODO: break?
 		}
 
 		var dx, dy int
-		data := (*_RAWINPUT)(unsafe.Pointer(&_glfw.windowState.rawInput[0]))
+		data := (*_RAWINPUT)(unsafe.Pointer(&_glfw.platformWindow.rawInput[0]))
 		if data.mouse.usFlags&_MOUSE_MOVE_ABSOLUTE != 0 {
-			dx = int(data.mouse.lLastX) - window.state.lastCursorPosX
-			dy = int(data.mouse.lLastY) - window.state.lastCursorPosY
+			dx = int(data.mouse.lLastX) - window.platform.lastCursorPosX
+			dy = int(data.mouse.lLastY) - window.platform.lastCursorPosY
 		} else {
 			dx = int(data.mouse.lLastX)
 			dy = int(data.mouse.lLastY)
@@ -933,11 +933,11 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 
 		window.inputCursorPos(window.virtualCursorPosX+float64(dx), window.virtualCursorPosY+float64(dy))
 
-		window.state.lastCursorPosX += dx
-		window.state.lastCursorPosY += dy
+		window.platform.lastCursorPosX += dx
+		window.platform.lastCursorPosY += dy
 
 	case _WM_MOUSELEAVE:
-		window.state.cursorTracked = false
+		window.platform.cursorTracked = false
 		window.inputCursorEnter(false)
 		return 0
 
@@ -952,7 +952,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		return 0
 
 	case _WM_ENTERSIZEMOVE, _WM_ENTERMENULOOP:
-		if window.state.frameAction {
+		if window.platform.frameAction {
 			break
 		}
 
@@ -966,7 +966,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		}
 
 	case _WM_EXITSIZEMOVE, _WM_EXITMENULOOP:
-		if window.state.frameAction {
+		if window.platform.frameAction {
 			break
 		}
 
@@ -983,32 +983,32 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		width := int(_LOWORD(uint32(lParam)))
 		height := int(_HIWORD(uint32(lParam)))
 		iconified := wParam == _SIZE_MINIMIZED
-		maximized := wParam == _SIZE_MAXIMIZED || (window.state.maximized && wParam != _SIZE_RESTORED)
+		maximized := wParam == _SIZE_MAXIMIZED || (window.platform.maximized && wParam != _SIZE_RESTORED)
 
-		if _glfw.windowState.disabledCursorWindow == window {
+		if _glfw.platformWindow.disabledCursorWindow == window {
 			if err := updateClipRect(window); err != nil {
 				_glfw.errors = append(_glfw.errors, err)
 				return 0
 			}
 		}
 
-		if window.state.iconified != iconified {
+		if window.platform.iconified != iconified {
 			window.inputWindowIconify(iconified)
 		}
 
-		if window.state.maximized != maximized {
+		if window.platform.maximized != maximized {
 			window.inputWindowMaximize(maximized)
 		}
 
-		if width != window.state.width || height != window.state.height {
-			window.state.width = width
-			window.state.height = height
+		if width != window.platform.width || height != window.platform.height {
+			window.platform.width = width
+			window.platform.height = height
 
 			window.inputFramebufferSize(width, height)
 			window.inputWindowSize(width, height)
 		}
 
-		if window.monitor != nil && window.state.iconified != iconified {
+		if window.monitor != nil && window.platform.iconified != iconified {
 			if iconified {
 				if err := window.releaseMonitor(); err != nil {
 					_glfw.errors = append(_glfw.errors, err)
@@ -1026,12 +1026,12 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 			}
 		}
 
-		window.state.iconified = iconified
-		window.state.maximized = maximized
+		window.platform.iconified = iconified
+		window.platform.maximized = maximized
 		return 0
 
 	case _WM_MOVE:
-		if _glfw.windowState.disabledCursorWindow == window {
+		if _glfw.platformWindow.disabledCursorWindow == window {
 			if err := updateClipRect(window); err != nil {
 				_glfw.errors = append(_glfw.errors, err)
 				return 0
@@ -1063,7 +1063,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		}
 
 		if isWindows10AnniversaryUpdateOrGreaterWin32() {
-			dpi = _GetDpiForWindow(window.state.handle)
+			dpi = _GetDpiForWindow(window.platform.handle)
 		}
 
 		xoff, yoff, err := getFullWindowSize(window.getWindowStyle(), window.getWindowExStyle(), 0, 0, dpi)
@@ -1083,7 +1083,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		}
 
 		if !window.decorated {
-			mh := _MonitorFromWindow(window.state.handle, _MONITOR_DEFAULTTONEAREST)
+			mh := _MonitorFromWindow(window.platform.handle, _MONITOR_DEFAULTTONEAREST)
 			mi, _ := _GetMonitorInfoW(mh)
 
 			mmi.ptMaxPosition.x = mi.rcWork.left - mi.rcMonitor.left
@@ -1108,7 +1108,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		}
 
 	case _WM_DWMCOMPOSITIONCHANGED, _WM_DWMCOLORIZATIONCOLORCHANGED:
-		if window.state.transparent {
+		if window.platform.transparent {
 			if err := window.updateFramebufferTransparency(); err != nil {
 				_glfw.errors = append(_glfw.errors, err)
 				return 0
@@ -1117,7 +1117,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		return 0
 
 	case _WM_GETDPISCALEDSIZE:
-		if window.state.scaleToMonitor {
+		if window.platform.scaleToMonitor {
 			break
 		}
 
@@ -1126,7 +1126,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 			var source, target _RECT
 			size := (*_SIZE)(unsafe.Pointer(lParam))
 
-			if err := _AdjustWindowRectExForDpi(&source, window.getWindowStyle(), false, window.getWindowExStyle(), _GetDpiForWindow(window.state.handle)); err != nil {
+			if err := _AdjustWindowRectExForDpi(&source, window.getWindowStyle(), false, window.getWindowExStyle(), _GetDpiForWindow(window.platform.handle)); err != nil {
 				_glfw.errors = append(_glfw.errors, err)
 				return 0
 			}
@@ -1146,9 +1146,9 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 
 		// Resize windowed mode windows that either permit rescaling or that
 		// need it to compensate for non-client area scaling
-		if window.monitor == nil && (window.state.scaleToMonitor || isWindows10CreatorsUpdateOrGreaterWin32()) {
+		if window.monitor == nil && (window.platform.scaleToMonitor || isWindows10CreatorsUpdateOrGreaterWin32()) {
 			suggested := (*_RECT)(unsafe.Pointer(lParam))
-			if err := _SetWindowPos(window.state.handle, _HWND_TOP,
+			if err := _SetWindowPos(window.platform.handle, _HWND_TOP,
 				suggested.left,
 				suggested.top,
 				suggested.right-suggested.left,
@@ -1206,7 +1206,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 
 	var xpos, ypos, fullWidth, fullHeight int32
 	if w.monitor != nil {
-		mi, ok := _GetMonitorInfoW(w.monitor.state.handle)
+		mi, ok := _GetMonitorInfoW(w.monitor.platform.handle)
 		if !ok {
 			return fmt.Errorf("goglfw: GetMonitorInfoW failed")
 		}
@@ -1221,7 +1221,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 		xpos = _CW_USEDEFAULT
 		ypos = _CW_USEDEFAULT
 
-		w.state.maximized = wndconfig.maximized
+		w.platform.maximized = wndconfig.maximized
 		if wndconfig.maximized {
 			style |= _WS_MAXIMIZE
 		}
@@ -1236,27 +1236,27 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 	h, err := _CreateWindowExW(exStyle, _GLFW_WNDCLASSNAME, wndconfig.title, style, xpos, ypos, fullWidth, fullHeight,
 		0, // No parent window
 		0, // No window menu
-		_glfw.windowState.instance, unsafe.Pointer(wndconfig))
+		_glfw.platformWindow.instance, unsafe.Pointer(wndconfig))
 	if err != nil {
 		return err
 	}
-	w.state.handle = h
+	w.platform.handle = h
 
-	handleToWindow[w.state.handle] = w
+	handleToWindow[w.platform.handle] = w
 
 	if !microsoftgdk.IsXbox() && _IsWindows7OrGreater() {
-		if err := _ChangeWindowMessageFilterEx(w.state.handle, _WM_DROPFILES, _MSGFLT_ALLOW, nil); err != nil {
+		if err := _ChangeWindowMessageFilterEx(w.platform.handle, _WM_DROPFILES, _MSGFLT_ALLOW, nil); err != nil {
 			return err
 		}
-		if err := _ChangeWindowMessageFilterEx(w.state.handle, _WM_COPYDATA, _MSGFLT_ALLOW, nil); err != nil {
+		if err := _ChangeWindowMessageFilterEx(w.platform.handle, _WM_COPYDATA, _MSGFLT_ALLOW, nil); err != nil {
 			return err
 		}
-		if err := _ChangeWindowMessageFilterEx(w.state.handle, _WM_COPYGLOBALDATA, _MSGFLT_ALLOW, nil); err != nil {
+		if err := _ChangeWindowMessageFilterEx(w.platform.handle, _WM_COPYGLOBALDATA, _MSGFLT_ALLOW, nil); err != nil {
 			return err
 		}
 	}
 
-	w.state.scaleToMonitor = wndconfig.scaleToMonitor
+	w.platform.scaleToMonitor = wndconfig.scaleToMonitor
 
 	// Adjust window rect to account for DPI scaling of the window frame and
 	// (if enabled) DPI scaling of the content area
@@ -1268,7 +1268,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 			right:  int32(wndconfig.width),
 			bottom: int32(wndconfig.height),
 		}
-		mh := _MonitorFromWindow(w.state.handle, _MONITOR_DEFAULTTONEAREST)
+		mh := _MonitorFromWindow(w.platform.handle, _MONITOR_DEFAULTTONEAREST)
 
 		// Adjust window rect to account for DPI scaling of the window frame and
 		// (if enabled) DPI scaling of the content area
@@ -1292,7 +1292,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 		}
 
 		if isWindows10AnniversaryUpdateOrGreaterWin32() {
-			if err := _AdjustWindowRectExForDpi(&rect, style, false, exStyle, _GetDpiForWindow(w.state.handle)); err != nil {
+			if err := _AdjustWindowRectExForDpi(&rect, style, false, exStyle, _GetDpiForWindow(w.platform.handle)); err != nil {
 				return err
 			}
 		} else {
@@ -1302,7 +1302,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 		}
 
 		// Only update the restored window rect as the window may be maximized
-		wp, err := _GetWindowPlacement(w.state.handle)
+		wp, err := _GetWindowPlacement(w.platform.handle)
 		if err != nil {
 			return err
 		}
@@ -1310,7 +1310,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 
 		wp.rcNormalPosition = rect
 		wp.showCmd = _SW_HIDE
-		if err := _SetWindowPlacement(w.state.handle, &wp); err != nil {
+		if err := _SetWindowPlacement(w.platform.handle, &wp); err != nil {
 			return err
 		}
 
@@ -1319,7 +1319,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 
 		if wndconfig.maximized && !wndconfig.decorated {
 			mi, _ := _GetMonitorInfoW(mh)
-			if err := _SetWindowPos(w.state.handle, _HWND_TOP,
+			if err := _SetWindowPos(w.platform.handle, _HWND_TOP,
 				mi.rcWork.left, mi.rcWork.top, mi.rcWork.right-mi.rcWork.left, mi.rcWork.bottom-mi.rcWork.top,
 				_SWP_NOACTIVATE|_SWP_NOZORDER); err != nil {
 				return err
@@ -1328,21 +1328,21 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 	}
 
 	if !microsoftgdk.IsXbox() {
-		_DragAcceptFiles(w.state.handle, true)
+		_DragAcceptFiles(w.platform.handle, true)
 	}
 
 	if fbconfig.transparent {
 		if err := w.updateFramebufferTransparency(); err != nil {
 			return err
 		}
-		w.state.transparent = true
+		w.platform.transparent = true
 	}
 
 	width, height, err := w.platformGetWindowSize()
 	if err != nil {
 		return err
 	}
-	w.state.width, w.state.height = width, height
+	w.platform.width, w.platform.height = width, height
 
 	return nil
 }
@@ -1352,7 +1352,7 @@ func registerWindowClassWin32() error {
 	wc.cbSize = uint32(unsafe.Sizeof(wc))
 	wc.style = _CS_HREDRAW | _CS_VREDRAW | _CS_OWNDC
 	wc.lpfnWndProc = _WNDPROC(windowProcPtr)
-	wc.hInstance = _glfw.windowState.instance
+	wc.hInstance = _glfw.platformWindow.instance
 	cursor, err := _LoadCursorW(0, _IDC_ARROW)
 	if err != nil {
 		return err
@@ -1383,7 +1383,7 @@ func registerWindowClassWin32() error {
 }
 
 func unregisterWindowClassWin32() error {
-	if err := _UnregisterClassW(_GLFW_WNDCLASSNAME, _glfw.windowState.instance); err != nil {
+	if err := _UnregisterClassW(_GLFW_WNDCLASSNAME, _glfw.platformWindow.instance); err != nil {
 		return err
 	}
 	return nil
@@ -1451,28 +1451,28 @@ func (w *Window) platformDestroyWindow() error {
 		}
 	}
 
-	if _glfw.windowState.disabledCursorWindow == w {
-		_glfw.windowState.disabledCursorWindow = nil
+	if _glfw.platformWindow.disabledCursorWindow == w {
+		_glfw.platformWindow.disabledCursorWindow = nil
 	}
 
-	if w.state.handle != 0 {
+	if w.platform.handle != 0 {
 		if !microsoftgdk.IsXbox() {
-			if err := _DestroyWindow(w.state.handle); err != nil {
+			if err := _DestroyWindow(w.platform.handle); err != nil {
 				return err
 			}
 		}
-		delete(handleToWindow, w.state.handle)
-		w.state.handle = 0
+		delete(handleToWindow, w.platform.handle)
+		w.platform.handle = 0
 	}
 
-	if w.state.bigIcon != 0 {
-		if err := _DestroyIcon(w.state.bigIcon); err != nil {
+	if w.platform.bigIcon != 0 {
+		if err := _DestroyIcon(w.platform.bigIcon); err != nil {
 			return err
 		}
 	}
 
-	if w.state.smallIcon != 0 {
-		if err := _DestroyIcon(w.state.smallIcon); err != nil {
+	if w.platform.smallIcon != 0 {
+		if err := _DestroyIcon(w.platform.smallIcon); err != nil {
 			return err
 		}
 	}
@@ -1484,7 +1484,7 @@ func (w *Window) platformSetWindowTitle(title string) error {
 	if microsoftgdk.IsXbox() {
 		return nil
 	}
-	return _SetWindowTextW(w.state.handle, title)
+	return _SetWindowTextW(w.platform.handle, title)
 }
 
 func (w *Window) platformSetWindowIcon(images []*Image) error {
@@ -1520,36 +1520,36 @@ func (w *Window) platformSetWindowIcon(images []*Image) error {
 			return err
 		}
 	} else {
-		i, err := _GetClassLongPtrW(w.state.handle, _GCLP_HICON)
+		i, err := _GetClassLongPtrW(w.platform.handle, _GCLP_HICON)
 		if err != nil {
 			return err
 		}
 		bigIcon = _HICON(i)
-		i, err = _GetClassLongPtrW(w.state.handle, _GCLP_HICONSM)
+		i, err = _GetClassLongPtrW(w.platform.handle, _GCLP_HICONSM)
 		if err != nil {
 			return err
 		}
 		smallIcon = _HICON(i)
 	}
 
-	_SendMessageW(w.state.handle, _WM_SETICON, _ICON_BIG, _LPARAM(bigIcon))
-	_SendMessageW(w.state.handle, _WM_SETICON, _ICON_SMALL, _LPARAM(smallIcon))
+	_SendMessageW(w.platform.handle, _WM_SETICON, _ICON_BIG, _LPARAM(bigIcon))
+	_SendMessageW(w.platform.handle, _WM_SETICON, _ICON_SMALL, _LPARAM(smallIcon))
 
-	if w.state.bigIcon != 0 {
-		if err := _DestroyIcon(w.state.bigIcon); err != nil {
+	if w.platform.bigIcon != 0 {
+		if err := _DestroyIcon(w.platform.bigIcon); err != nil {
 			return err
 		}
 	}
 
-	if w.state.smallIcon != 0 {
-		if err := _DestroyIcon(w.state.smallIcon); err != nil {
+	if w.platform.smallIcon != 0 {
+		if err := _DestroyIcon(w.platform.smallIcon); err != nil {
 			return err
 		}
 	}
 
 	if len(images) > 0 {
-		w.state.bigIcon = bigIcon
-		w.state.smallIcon = smallIcon
+		w.platform.bigIcon = bigIcon
+		w.platform.smallIcon = smallIcon
 	}
 	return nil
 }
@@ -1560,7 +1560,7 @@ func (w *Window) platformGetWindowPos() (xpos, ypos int, err error) {
 	}
 
 	var pos _POINT
-	if err := _ClientToScreen(w.state.handle, &pos); err != nil {
+	if err := _ClientToScreen(w.platform.handle, &pos); err != nil {
 		return 0, 0, err
 	}
 	return int(pos.x), int(pos.y), nil
@@ -1578,7 +1578,7 @@ func (w *Window) platformSetWindowPos(xpos, ypos int) error {
 		bottom: int32(ypos),
 	}
 	if isWindows10AnniversaryUpdateOrGreaterWin32() {
-		if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.state.handle)); err != nil {
+		if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.platform.handle)); err != nil {
 			return err
 		}
 	} else {
@@ -1587,14 +1587,14 @@ func (w *Window) platformSetWindowPos(xpos, ypos int) error {
 		}
 	}
 
-	if err := _SetWindowPos(w.state.handle, 0, rect.left, rect.top, 0, 0, _SWP_NOACTIVATE|_SWP_NOZORDER|_SWP_NOSIZE); err != nil {
+	if err := _SetWindowPos(w.platform.handle, 0, rect.left, rect.top, 0, 0, _SWP_NOACTIVATE|_SWP_NOZORDER|_SWP_NOSIZE); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (w *Window) platformGetWindowSize() (width, height int, err error) {
-	area, err := _GetClientRect(w.state.handle)
+	area, err := _GetClientRect(w.platform.handle)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -1620,7 +1620,7 @@ func (w *Window) platformSetWindowSize(width, height int) error {
 		}
 
 		if isWindows10AnniversaryUpdateOrGreaterWin32() {
-			if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.state.handle)); err != nil {
+			if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.platform.handle)); err != nil {
 				return err
 			}
 		} else {
@@ -1629,7 +1629,7 @@ func (w *Window) platformSetWindowSize(width, height int) error {
 			}
 		}
 
-		if err := _SetWindowPos(w.state.handle, _HWND_TOP,
+		if err := _SetWindowPos(w.platform.handle, _HWND_TOP,
 			0, 0, rect.right-rect.left, rect.bottom-rect.top,
 			_SWP_NOACTIVATE|_SWP_NOOWNERZORDER|_SWP_NOMOVE|_SWP_NOZORDER); err != nil {
 			return err
@@ -1644,11 +1644,11 @@ func (w *Window) platformSetWindowSizeLimits(minwidth, minheight, maxwidth, maxh
 		return nil
 	}
 
-	area, err := _GetWindowRect(w.state.handle)
+	area, err := _GetWindowRect(w.platform.handle)
 	if err != nil {
 		return err
 	}
-	if err := _MoveWindow(w.state.handle, area.left, area.top, area.right-area.left, area.bottom-area.top, true); err != nil {
+	if err := _MoveWindow(w.platform.handle, area.left, area.top, area.right-area.left, area.bottom-area.top, true); err != nil {
 		return err
 	}
 	return nil
@@ -1659,14 +1659,14 @@ func (w *Window) platformSetWindowAspectRatio(numer, denom int) error {
 		return nil
 	}
 
-	area, err := _GetWindowRect(w.state.handle)
+	area, err := _GetWindowRect(w.platform.handle)
 	if err != nil {
 		return err
 	}
 	if err := w.applyAspectRatio(_WMSZ_BOTTOMRIGHT, &area); err != nil {
 		return err
 	}
-	if err := _MoveWindow(w.state.handle, area.left, area.top, area.right-area.left, area.bottom-area.top, true); err != nil {
+	if err := _MoveWindow(w.platform.handle, area.left, area.top, area.right-area.left, area.bottom-area.top, true); err != nil {
 		return err
 	}
 	return nil
@@ -1689,7 +1689,7 @@ func (w *Window) platformGetWindowFrameSize() (left, top, right, bottom int, err
 		bottom: int32(height),
 	}
 	if isWindows10AnniversaryUpdateOrGreaterWin32() {
-		if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.state.handle)); err != nil {
+		if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.platform.handle)); err != nil {
 			return 0, 0, 0, 0, err
 		}
 	} else {
@@ -1702,21 +1702,21 @@ func (w *Window) platformGetWindowFrameSize() (left, top, right, bottom int, err
 }
 
 func (w *Window) platformGetWindowContentScale() (xscale, yscale float32, err error) {
-	handle := _MonitorFromWindow(w.state.handle, _MONITOR_DEFAULTTONEAREST)
+	handle := _MonitorFromWindow(w.platform.handle, _MONITOR_DEFAULTTONEAREST)
 	return getMonitorContentScaleWin32(handle)
 }
 
 func (w *Window) platformIconifyWindow() {
-	_ShowWindow(w.state.handle, _SW_MINIMIZE)
+	_ShowWindow(w.platform.handle, _SW_MINIMIZE)
 }
 
 func (w *Window) platformRestoreWindow() {
-	_ShowWindow(w.state.handle, _SW_RESTORE)
+	_ShowWindow(w.platform.handle, _SW_RESTORE)
 }
 
 func (w *Window) platformMaximizeWindow() error {
-	if _IsWindowVisible(w.state.handle) {
-		_ShowWindow(w.state.handle, _SW_MAXIMIZE)
+	if _IsWindowVisible(w.platform.handle) {
+		_ShowWindow(w.platform.handle, _SW_MAXIMIZE)
 	} else {
 		if err := w.maximizeWindowManually(); err != nil {
 			return err
@@ -1726,15 +1726,15 @@ func (w *Window) platformMaximizeWindow() error {
 }
 
 func (w *Window) platformShowWindow() {
-	_ShowWindow(w.state.handle, _SW_SHOWNA)
+	_ShowWindow(w.platform.handle, _SW_SHOWNA)
 }
 
 func (w *Window) platformHideWindow() {
-	_ShowWindow(w.state.handle, _SW_HIDE)
+	_ShowWindow(w.platform.handle, _SW_HIDE)
 }
 
 func (w *Window) platformRequestWindowAttention() {
-	_FlashWindow(w.state.handle, true)
+	_FlashWindow(w.platform.handle, true)
 }
 
 func (w *Window) platformFocusWindow() error {
@@ -1742,11 +1742,11 @@ func (w *Window) platformFocusWindow() error {
 		return nil
 	}
 
-	if err := _BringWindowToTop(w.state.handle); err != nil {
+	if err := _BringWindowToTop(w.platform.handle); err != nil {
 		return err
 	}
-	_SetForegroundWindow(w.state.handle)
-	if _, err := _SetFocus(w.state.handle); err != nil {
+	_SetForegroundWindow(w.platform.handle)
+	if _, err := _SetFocus(w.platform.handle); err != nil {
 		return err
 	}
 	return nil
@@ -1771,7 +1771,7 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 				bottom: int32(ypos + height),
 			}
 			if isWindows10AnniversaryUpdateOrGreaterWin32() {
-				if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.state.handle)); err != nil {
+				if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.platform.handle)); err != nil {
 					return err
 				}
 			} else {
@@ -1780,7 +1780,7 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 				}
 			}
 
-			if err := _SetWindowPos(w.state.handle, _HWND_TOP,
+			if err := _SetWindowPos(w.platform.handle, _HWND_TOP,
 				rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top,
 				_SWP_NOCOPYBITS|_SWP_NOACTIVATE|_SWP_NOZORDER); err != nil {
 				return err
@@ -1801,14 +1801,14 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 	if w.monitor != nil {
 		var flags uint32 = _SWP_SHOWWINDOW | _SWP_NOACTIVATE | _SWP_NOCOPYBITS
 		if w.decorated {
-			s, err := _GetWindowLongW(w.state.handle, _GWL_STYLE)
+			s, err := _GetWindowLongW(w.platform.handle, _GWL_STYLE)
 			if err != nil {
 				return err
 			}
 			style := uint32(s)
 			style &^= _WS_OVERLAPPEDWINDOW
 			style |= w.getWindowStyle()
-			if _, err := _SetWindowLongW(w.state.handle, _GWL_STYLE, int32(style)); err != nil {
+			if _, err := _SetWindowLongW(w.platform.handle, _GWL_STYLE, int32(style)); err != nil {
 				return err
 			}
 			flags |= _SWP_FRAMECHANGED
@@ -1818,12 +1818,12 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 			return err
 		}
 
-		mi, _ := _GetMonitorInfoW(w.monitor.state.handle)
+		mi, _ := _GetMonitorInfoW(w.monitor.platform.handle)
 		var hWnd windows.HWND = _HWND_NOTOPMOST
 		if w.floating {
 			hWnd = _HWND_TOPMOST
 		}
-		if err := _SetWindowPos(w.state.handle, hWnd,
+		if err := _SetWindowPos(w.platform.handle, hWnd,
 			mi.rcMonitor.left,
 			mi.rcMonitor.top,
 			mi.rcMonitor.right-mi.rcMonitor.left,
@@ -1834,14 +1834,14 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 	} else {
 		var flags uint32 = _SWP_NOACTIVATE | _SWP_NOCOPYBITS
 		if w.decorated {
-			s, err := _GetWindowLongW(w.state.handle, _GWL_STYLE)
+			s, err := _GetWindowLongW(w.platform.handle, _GWL_STYLE)
 			if err != nil {
 				return err
 			}
 			style := uint32(s)
 			style &^= _WS_POPUP
 			style |= w.getWindowStyle()
-			if _, err := _SetWindowLongW(w.state.handle, _GWL_STYLE, int32(style)); err != nil {
+			if _, err := _SetWindowLongW(w.platform.handle, _GWL_STYLE, int32(style)); err != nil {
 				return err
 			}
 			flags |= _SWP_FRAMECHANGED
@@ -1856,7 +1856,7 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 		if isWindows10AnniversaryUpdateOrGreaterWin32() {
 			if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(),
 				false, w.getWindowExStyle(),
-				_GetDpiForWindow(w.state.handle)); err != nil {
+				_GetDpiForWindow(w.platform.handle)); err != nil {
 				return err
 			}
 		} else {
@@ -1872,7 +1872,7 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 		} else {
 			after = _HWND_NOTOPMOST
 		}
-		if err := _SetWindowPos(w.state.handle, after,
+		if err := _SetWindowPos(w.platform.handle, after,
 			rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top,
 			flags); err != nil {
 			return err
@@ -1886,28 +1886,28 @@ func (w *Window) platformWindowFocused() bool {
 	if microsoftgdk.IsXbox() {
 		return true
 	}
-	return w.state.handle == _GetActiveWindow()
+	return w.platform.handle == _GetActiveWindow()
 }
 
 func (w *Window) platformWindowIconified() bool {
 	if microsoftgdk.IsXbox() {
 		return false
 	}
-	return _IsIconic(w.state.handle)
+	return _IsIconic(w.platform.handle)
 }
 
 func (w *Window) platformWindowVisible() bool {
 	if microsoftgdk.IsXbox() {
 		return true
 	}
-	return _IsWindowVisible(w.state.handle)
+	return _IsWindowVisible(w.platform.handle)
 }
 
 func (w *Window) platformWindowMaximized() bool {
 	if microsoftgdk.IsXbox() {
 		return false
 	}
-	return _IsZoomed(w.state.handle)
+	return _IsZoomed(w.platform.handle)
 }
 
 func (w *Window) platformWindowHovered() (bool, error) {
@@ -1922,7 +1922,7 @@ func (w *Window) platformFramebufferTransparent() bool {
 		return false
 	}
 
-	if !w.state.transparent {
+	if !w.platform.transparent {
 		return false
 	}
 
@@ -1962,17 +1962,17 @@ func (w *Window) platformSetWindowFloating(enabled bool) error {
 	if enabled {
 		after = _HWND_TOPMOST
 	}
-	return _SetWindowPos(w.state.handle, after, 0, 0, 0, 0, _SWP_NOACTIVATE|_SWP_NOMOVE|_SWP_NOSIZE)
+	return _SetWindowPos(w.platform.handle, after, 0, 0, 0, 0, _SWP_NOACTIVATE|_SWP_NOMOVE|_SWP_NOSIZE)
 }
 
 func (w *Window) platformGetWindowOpacity() (float32, error) {
-	style, err := _GetWindowLongW(w.state.handle, _GWL_EXSTYLE)
+	style, err := _GetWindowLongW(w.platform.handle, _GWL_EXSTYLE)
 	if err != nil {
 		return 0, err
 	}
 
 	if style&_WS_EX_LAYERED != 0 {
-		_, alpha, flags, err := _GetLayeredWindowAttributes(w.state.handle)
+		_, alpha, flags, err := _GetLayeredWindowAttributes(w.platform.handle)
 		if err != nil {
 			return 0, err
 		}
@@ -1988,24 +1988,24 @@ func (w *Window) platformGetWindowOpacity() (float32, error) {
 func (w *Window) platformSetWindowOpacity(opacity float32) error {
 	if opacity < 1 {
 		alpha := byte(255 * opacity)
-		style, err := _GetWindowLongW(w.state.handle, _GWL_EXSTYLE)
+		style, err := _GetWindowLongW(w.platform.handle, _GWL_EXSTYLE)
 		if err != nil {
 			return err
 		}
 		style |= _WS_EX_LAYERED
-		if _, err := _SetWindowLongW(w.state.handle, _GWL_EXSTYLE, style); err != nil {
+		if _, err := _SetWindowLongW(w.platform.handle, _GWL_EXSTYLE, style); err != nil {
 			return err
 		}
-		if err := _SetLayeredWindowAttributes(w.state.handle, 0, alpha, _LWA_ALPHA); err != nil {
+		if err := _SetLayeredWindowAttributes(w.platform.handle, 0, alpha, _LWA_ALPHA); err != nil {
 			return err
 		}
 	} else {
-		style, err := _GetWindowLongW(w.state.handle, _GWL_EXSTYLE)
+		style, err := _GetWindowLongW(w.platform.handle, _GWL_EXSTYLE)
 		if err != nil {
 			return err
 		}
 		style &^= _WS_EX_LAYERED
-		if _, err := _SetWindowLongW(w.state.handle, _GWL_EXSTYLE, style); err != nil {
+		if _, err := _SetWindowLongW(w.platform.handle, _GWL_EXSTYLE, style); err != nil {
 			return err
 		}
 	}
@@ -2014,7 +2014,7 @@ func (w *Window) platformSetWindowOpacity(opacity float32) error {
 }
 
 func (w *Window) platformSetRawMouseMotion(enabled bool) error {
-	if _glfw.windowState.disabledCursorWindow != w {
+	if _glfw.platformWindow.disabledCursorWindow != w {
 		return nil
 	}
 
@@ -2057,7 +2057,7 @@ func platformPollEvents() error {
 	var handle windows.HWND
 	if microsoftgdk.IsXbox() {
 		// Assume that there is always exactly one active window.
-		handle = _glfw.windows[0].state.handle
+		handle = _glfw.windows[0].platform.handle
 	} else {
 		handle = _GetActiveWindow()
 	}
@@ -2083,7 +2083,7 @@ func platformPollEvents() error {
 			for i := range keys {
 				vk := keys[i].VK
 				key := keys[i].Key
-				scancode := _glfw.windowState.scancodes[key]
+				scancode := _glfw.platformWindow.scancodes[key]
 
 				if uint32(_GetKeyState(int32(vk)))&0x8000 != 0 {
 					continue
@@ -2096,7 +2096,7 @@ func platformPollEvents() error {
 		}
 	}
 
-	if window := _glfw.windowState.disabledCursorWindow; window != nil {
+	if window := _glfw.platformWindow.disabledCursorWindow; window != nil {
 		width, height, err := window.platformGetWindowSize()
 		if err != nil {
 			return err
@@ -2104,7 +2104,7 @@ func platformPollEvents() error {
 
 		// NOTE: Re-center the cursor only if it has moved since the last call,
 		//       to avoid breaking glfwWaitEvents with WM_MOUSEMOVE
-		if window.state.lastCursorPosX != width/2 || window.state.lastCursorPosY != height/2 {
+		if window.platform.lastCursorPosX != width/2 || window.platform.lastCursorPosY != height/2 {
 			if err := window.platformSetCursorPos(float64(width/2), float64(height/2)); err != nil {
 				return err
 			}
@@ -2135,7 +2135,7 @@ func platformWaitEventsTimeout(timeout float64) error {
 }
 
 func platformPostEmptyEvent() error {
-	return _PostMessageW(_glfw.windowState.helperWindowHandle, _WM_NULL, 0, 0)
+	return _PostMessageW(_glfw.platformWindow.helperWindowHandle, _WM_NULL, 0, 0)
 }
 
 func (w *Window) platformGetCursorPos() (xpos, ypos float64, err error) {
@@ -2147,7 +2147,7 @@ func (w *Window) platformGetCursorPos() (xpos, ypos float64, err error) {
 		return 0, 0, err
 	}
 	if !microsoftgdk.IsXbox() {
-		if err := _ScreenToClient(w.state.handle, &pos); err != nil {
+		if err := _ScreenToClient(w.platform.handle, &pos); err != nil {
 			return 0, 0, err
 		}
 	}
@@ -2161,11 +2161,11 @@ func (w *Window) platformSetCursorPos(xpos, ypos float64) error {
 	}
 
 	// Store the new position so it can be recognized later
-	w.state.lastCursorPosX = int(pos.x)
-	w.state.lastCursorPosY = int(pos.y)
+	w.platform.lastCursorPosX = int(pos.x)
+	w.platform.lastCursorPosY = int(pos.y)
 
 	if !microsoftgdk.IsXbox() {
-		if err := _ClientToScreen(w.state.handle, &pos); err != nil {
+		if err := _ClientToScreen(w.platform.handle, &pos); err != nil {
 			return err
 		}
 	}
@@ -2185,7 +2185,7 @@ func (w *Window) platformSetCursorMode(mode int) error {
 		return nil
 	}
 
-	if _glfw.windowState.disabledCursorWindow == w {
+	if _glfw.platformWindow.disabledCursorWindow == w {
 		if err := w.enableCursor(); err != nil {
 			return err
 		}
@@ -2206,14 +2206,14 @@ func (w *Window) platformSetCursorMode(mode int) error {
 }
 
 func platformGetScancodeName(scancode int) (string, error) {
-	if scancode < 0 || scancode > (_KF_EXTENDED|0xff) || _glfw.windowState.keycodes[scancode] == KeyUnknown {
+	if scancode < 0 || scancode > (_KF_EXTENDED|0xff) || _glfw.platformWindow.keycodes[scancode] == KeyUnknown {
 		return "", fmt.Errorf("glwfwin: invalid scancode %d: %w", scancode, InvalidValue)
 	}
-	return _glfw.windowState.keynames[_glfw.windowState.keycodes[scancode]], nil
+	return _glfw.platformWindow.keynames[_glfw.platformWindow.keycodes[scancode]], nil
 }
 
 func platformGetKeyScancode(key Key) int {
-	return _glfw.windowState.scancodes[key]
+	return _glfw.platformWindow.scancodes[key]
 }
 
 func (c *Cursor) platformCreateStandardCursor(shape StandardCursor) error {
@@ -2243,14 +2243,14 @@ func (c *Cursor) platformCreateStandardCursor(shape StandardCursor) error {
 	if err != nil {
 		return err
 	}
-	c.state.handle = _HCURSOR(h)
+	c.platform.handle = _HCURSOR(h)
 
 	return nil
 }
 
 func (c *Cursor) platformDestroyCursor() error {
-	if c.state.handle != 0 {
-		if err := _DestroyIcon(_HICON(c.state.handle)); err != nil {
+	if c.platform.handle != 0 {
+		if err := _DestroyIcon(_HICON(c.platform.handle)); err != nil {
 			return err
 		}
 	}
@@ -2282,5 +2282,5 @@ func (w *Window) GetWin32Window() (windows.HWND, error) {
 	if !_glfw.initialized {
 		return 0, NotInitialized
 	}
-	return w.state.handle, nil
+	return w.platform.handle, nil
 }

--- a/internal/goglfw/win32window_windows.go
+++ b/internal/goglfw/win32window_windows.go
@@ -154,7 +154,7 @@ func (w *Window) applyAspectRatio(edge int, area *_RECT) error {
 
 	var dpi uint32 = _USER_DEFAULT_SCREEN_DPI
 	if isWindows10AnniversaryUpdateOrGreaterWin32() {
-		dpi = _GetDpiForWindow(w.win32.handle)
+		dpi = _GetDpiForWindow(w.state.handle)
 	}
 
 	xoff, yoff, err := getFullWindowSize(w.getWindowStyle(), w.getWindowExStyle(), 0, 0, dpi)
@@ -176,7 +176,7 @@ func (w *Window) applyAspectRatio(edge int, area *_RECT) error {
 func (w *Window) updateCursorImage() error {
 	if w.cursorMode == CursorNormal {
 		if w.cursor != nil {
-			_SetCursor(w.cursor.win32.handle)
+			_SetCursor(w.cursor.state.handle)
 		} else {
 			cursor, err := _LoadCursorW(0, _IDC_ARROW)
 			if err != nil {
@@ -195,7 +195,7 @@ func (w *Window) clientToScreen(rect _RECT) (_RECT, error) {
 		x: rect.left,
 		y: rect.top,
 	}
-	if err := _ClientToScreen(w.win32.handle, &point); err != nil {
+	if err := _ClientToScreen(w.state.handle, &point); err != nil {
 		return _RECT{}, err
 	}
 	rect.left = point.x
@@ -205,7 +205,7 @@ func (w *Window) clientToScreen(rect _RECT) (_RECT, error) {
 		x: rect.right,
 		y: rect.bottom,
 	}
-	if err := _ClientToScreen(w.win32.handle, &point); err != nil {
+	if err := _ClientToScreen(w.state.handle, &point); err != nil {
 		return _RECT{}, err
 	}
 	rect.right = point.x
@@ -215,7 +215,7 @@ func (w *Window) clientToScreen(rect _RECT) (_RECT, error) {
 
 func updateClipRect(window *Window) error {
 	if window != nil {
-		clipRect, err := _GetClientRect(window.win32.handle)
+		clipRect, err := _GetClientRect(window.state.handle)
 		if err != nil {
 			return err
 		}
@@ -242,7 +242,7 @@ func (w *Window) enableRawMouseMotion() error {
 			usUsagePage: 0x01,
 			usUsage:     0x02,
 			dwFlags:     0,
-			hwndTarget:  w.win32.handle,
+			hwndTarget:  w.state.handle,
 		},
 	}
 	return _RegisterRawInputDevices(rid)
@@ -261,12 +261,12 @@ func (w *Window) disableRawMouseMotion() error {
 }
 
 func (w *Window) disableCursor() error {
-	_glfw.win32.disabledCursorWindow = w
+	_glfw.windowState.disabledCursorWindow = w
 	x, y, err := w.platformGetCursorPos()
 	if err != nil {
 		return err
 	}
-	_glfw.win32.restoreCursorPosX, _glfw.win32.restoreCursorPosY = x, y
+	_glfw.windowState.restoreCursorPosX, _glfw.windowState.restoreCursorPosY = x, y
 	if err := w.updateCursorImage(); err != nil {
 		return err
 	}
@@ -290,11 +290,11 @@ func (w *Window) enableCursor() error {
 			return err
 		}
 	}
-	_glfw.win32.disabledCursorWindow = nil
+	_glfw.windowState.disabledCursorWindow = nil
 	if err := updateClipRect(nil); err != nil {
 		return err
 	}
-	if err := w.platformSetCursorPos(_glfw.win32.restoreCursorPosX, _glfw.win32.restoreCursorPosY); err != nil {
+	if err := w.platformSetCursorPos(_glfw.windowState.restoreCursorPosX, _glfw.windowState.restoreCursorPosY); err != nil {
 		return err
 	}
 	if err := w.updateCursorImage(); err != nil {
@@ -315,10 +315,10 @@ func (w *Window) cursorInContentArea() (bool, error) {
 		}
 		return false, err
 	}
-	if _WindowFromPoint(pos) != w.win32.handle {
+	if _WindowFromPoint(pos) != w.state.handle {
 		return false, nil
 	}
-	area, err := _GetClientRect(w.win32.handle)
+	area, err := _GetClientRect(w.state.handle)
 	if err != nil {
 		return false, err
 	}
@@ -330,7 +330,7 @@ func (w *Window) cursorInContentArea() (bool, error) {
 }
 
 func (w *Window) updateWindowStyles() error {
-	s, err := _GetWindowLongW(w.win32.handle, _GWL_STYLE)
+	s, err := _GetWindowLongW(w.state.handle, _GWL_STYLE)
 	if err != nil {
 		return err
 	}
@@ -338,13 +338,13 @@ func (w *Window) updateWindowStyles() error {
 	style &^= _WS_OVERLAPPEDWINDOW | _WS_POPUP
 	style |= w.getWindowStyle()
 
-	rect, err := _GetClientRect(w.win32.handle)
+	rect, err := _GetClientRect(w.state.handle)
 	if err != nil {
 		return err
 	}
 
 	if isWindows10AnniversaryUpdateOrGreaterWin32() {
-		if err := _AdjustWindowRectExForDpi(&rect, style, false, w.getWindowExStyle(), _GetDpiForWindow(w.win32.handle)); err != nil {
+		if err := _AdjustWindowRectExForDpi(&rect, style, false, w.getWindowExStyle(), _GetDpiForWindow(w.state.handle)); err != nil {
 			return err
 		}
 	} else {
@@ -357,10 +357,10 @@ func (w *Window) updateWindowStyles() error {
 	if err != nil {
 		return err
 	}
-	if _, err := _SetWindowLongW(w.win32.handle, _GWL_STYLE, int32(style)); err != nil {
+	if _, err := _SetWindowLongW(w.state.handle, _GWL_STYLE, int32(style)); err != nil {
 		return err
 	}
-	if err := _SetWindowPos(w.win32.handle, _HWND_TOP, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, _SWP_FRAMECHANGED|_SWP_NOACTIVATE|_SWP_NOZORDER); err != nil {
+	if err := _SetWindowPos(w.state.handle, _HWND_TOP, rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, _SWP_FRAMECHANGED|_SWP_NOACTIVATE|_SWP_NOZORDER); err != nil {
 		return err
 	}
 
@@ -406,7 +406,7 @@ func (w *Window) updateFramebufferTransparency() error {
 		}
 
 		// Ignore an error from DWM functions as they might not be implemented e.g. on Proton (#2113).
-		_ = _DwmEnableBlurBehindWindow(w.win32.handle, &bb)
+		_ = _DwmEnableBlurBehindWindow(w.state.handle, &bb)
 	} else {
 		// HACK: Disable framebuffer transparency on Windows 7 when the
 		//       colorization color is opaque, because otherwise the window
@@ -417,7 +417,7 @@ func (w *Window) updateFramebufferTransparency() error {
 		}
 
 		// Ignore an error from DWM functions as they might not be implemented e.g. on Proton (#2113).
-		_ = _DwmEnableBlurBehindWindow(w.win32.handle, &bb)
+		_ = _DwmEnableBlurBehindWindow(w.state.handle, &bb)
 	}
 	return nil
 }
@@ -446,7 +446,7 @@ func getKeyMods() ModifierKey {
 }
 
 func (w *Window) fitToMonitor() error {
-	mi, ok := _GetMonitorInfoW(w.monitor.win32.handle)
+	mi, ok := _GetMonitorInfoW(w.monitor.state.handle)
 	if !ok {
 		return nil
 	}
@@ -456,7 +456,7 @@ func (w *Window) fitToMonitor() error {
 	} else {
 		hWndInsertAfter = _HWND_NOTOPMOST
 	}
-	if err := _SetWindowPos(w.win32.handle, hWndInsertAfter,
+	if err := _SetWindowPos(w.state.handle, hWndInsertAfter,
 		mi.rcMonitor.left,
 		mi.rcMonitor.top,
 		mi.rcMonitor.right-mi.rcMonitor.left,
@@ -468,13 +468,13 @@ func (w *Window) fitToMonitor() error {
 }
 
 func (w *Window) acquireMonitor() error {
-	if _glfw.win32.acquiredMonitorCount == 0 {
+	if _glfw.windowState.acquiredMonitorCount == 0 {
 		_SetThreadExecutionState(_ES_CONTINUOUS | _ES_DISPLAY_REQUIRED)
 
 		// HACK: When mouse trails are enabled the cursor becomes invisible when
 		//       the OpenGL ICD switches to page flipping
 		if _IsWindowsXPOrGreater() {
-			if err := _SystemParametersInfoW(_SPI_GETMOUSETRAILS, 0, uintptr(unsafe.Pointer(&_glfw.win32.mouseTrailSize)), 0); err != nil {
+			if err := _SystemParametersInfoW(_SPI_GETMOUSETRAILS, 0, uintptr(unsafe.Pointer(&_glfw.windowState.mouseTrailSize)), 0); err != nil {
 				return err
 			}
 			if err := _SystemParametersInfoW(_SPI_SETMOUSETRAILS, 0, 0, 0); err != nil {
@@ -484,7 +484,7 @@ func (w *Window) acquireMonitor() error {
 	}
 
 	if w.monitor.window == nil {
-		_glfw.win32.acquiredMonitorCount++
+		_glfw.windowState.acquiredMonitorCount++
 	}
 
 	if err := w.monitor.setVideoModeWin32(&w.videoMode); err != nil {
@@ -499,13 +499,13 @@ func (w *Window) releaseMonitor() error {
 		return nil
 	}
 
-	_glfw.win32.acquiredMonitorCount--
-	if _glfw.win32.acquiredMonitorCount == 0 {
+	_glfw.windowState.acquiredMonitorCount--
+	if _glfw.windowState.acquiredMonitorCount == 0 {
 		_SetThreadExecutionState(_ES_CONTINUOUS)
 
 		// HACK: Restore mouse trail length saved in acquireMonitor
 		if _IsWindowsXPOrGreater() {
-			if err := _SystemParametersInfoW(_SPI_SETMOUSETRAILS, _glfw.win32.mouseTrailSize, 0, 0); err != nil {
+			if err := _SystemParametersInfoW(_SPI_SETMOUSETRAILS, _glfw.windowState.mouseTrailSize, 0, 0); err != nil {
 				return err
 			}
 		}
@@ -517,7 +517,7 @@ func (w *Window) releaseMonitor() error {
 }
 
 func (w *Window) maximizeWindowManually() error {
-	mi, _ := _GetMonitorInfoW(_MonitorFromWindow(w.win32.handle, _MONITOR_DEFAULTTONEAREST))
+	mi, _ := _GetMonitorInfoW(_MonitorFromWindow(w.state.handle, _MONITOR_DEFAULTTONEAREST))
 
 	rect := mi.rcWork
 
@@ -530,24 +530,24 @@ func (w *Window) maximizeWindowManually() error {
 		}
 	}
 
-	s, err := _GetWindowLongW(w.win32.handle, _GWL_STYLE)
+	s, err := _GetWindowLongW(w.state.handle, _GWL_STYLE)
 	if err != nil {
 		return err
 	}
 	style := uint32(s)
 	style |= _WS_MAXIMIZE
-	if _, err := _SetWindowLongW(w.win32.handle, _GWL_STYLE, int32(style)); err != nil {
+	if _, err := _SetWindowLongW(w.state.handle, _GWL_STYLE, int32(style)); err != nil {
 		return err
 	}
 
 	if w.decorated {
-		s, err := _GetWindowLongW(w.win32.handle, _GWL_EXSTYLE)
+		s, err := _GetWindowLongW(w.state.handle, _GWL_EXSTYLE)
 		if err != nil {
 			return err
 		}
 		exStyle := uint32(s)
 		if isWindows10AnniversaryUpdateOrGreaterWin32() {
-			dpi := _GetDpiForWindow(w.win32.handle)
+			dpi := _GetDpiForWindow(w.state.handle)
 			if err := _AdjustWindowRectExForDpi(&rect, style, false, exStyle, dpi); err != nil {
 				return err
 			}
@@ -572,7 +572,7 @@ func (w *Window) maximizeWindowManually() error {
 		}
 	}
 
-	if err := _SetWindowPos(w.win32.handle, _HWND_TOP,
+	if err := _SetWindowPos(w.state.handle, _HWND_TOP,
 		rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top,
 		_SWP_NOACTIVATE|_SWP_NOZORDER|_SWP_FRAMECHANGED); err != nil {
 		return err
@@ -620,21 +620,21 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		//       clicking a caption button
 		if _HIWORD(uint32(lParam)) == _WM_LBUTTONDOWN {
 			if _LOWORD(uint32(lParam)) != _HTCLIENT {
-				window.win32.frameAction = true
+				window.state.frameAction = true
 			}
 		}
 
 	case _WM_CAPTURECHANGED:
 		// HACK: Disable the cursor once the caption button action has been
 		//       completed or cancelled
-		if lParam == 0 && window.win32.frameAction {
+		if lParam == 0 && window.state.frameAction {
 			if window.cursorMode == CursorDisabled {
 				if err := window.disableCursor(); err != nil {
 					_glfw.errors = append(_glfw.errors, err)
 					return 0
 				}
 			}
-			window.win32.frameAction = false
+			window.state.frameAction = false
 		}
 
 	case _WM_SETFOCUS:
@@ -642,7 +642,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 
 		// HACK: Do not disable cursor while the user is interacting with
 		//       a caption button
-		if window.win32.frameAction {
+		if window.state.frameAction {
 			break
 		}
 
@@ -695,13 +695,13 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 
 	case _WM_CHAR, _WM_SYSCHAR:
 		if wParam >= 0xd800 && wParam <= 0xdbff {
-			window.win32.highSurrogate = uint16(wParam)
+			window.state.highSurrogate = uint16(wParam)
 		} else {
 			var codepoint rune
 
 			if wParam >= 0xdc00 && wParam <= 0xdfff {
-				if window.win32.highSurrogate != 0 {
-					codepoint += (rune(window.win32.highSurrogate) - 0xd800) << 10
+				if window.state.highSurrogate != 0 {
+					codepoint += (rune(window.state.highSurrogate) - 0xd800) << 10
 					codepoint += (rune(wParam) & 0xffff) - 0xdc00
 					codepoint += 0x10000
 				}
@@ -709,7 +709,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 				codepoint = rune(wParam) & 0xffff
 			}
 
-			window.win32.highSurrogate = 0
+			window.state.highSurrogate = 0
 			window.inputChar(codepoint, getKeyMods(), uMsg != _WM_SYSCHAR)
 		}
 
@@ -758,7 +758,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 			scancode = 0x36
 		}
 
-		key := _glfw.win32.keycodes[scancode]
+		key := _glfw.windowState.keycodes[scancode]
 
 		// The Ctrl keys require special handling
 		if wParam == _VK_CONTROL {
@@ -861,25 +861,25 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		x := _GET_X_LPARAM(lParam)
 		y := _GET_Y_LPARAM(lParam)
 
-		if !window.win32.cursorTracked {
+		if !window.state.cursorTracked {
 			var tme _TRACKMOUSEEVENT
 			tme.cbSize = uint32(unsafe.Sizeof(tme))
 			tme.dwFlags = _TME_LEAVE
-			tme.hwndTrack = window.win32.handle
+			tme.hwndTrack = window.state.handle
 			if err := _TrackMouseEvent(&tme); err != nil {
 				_glfw.errors = append(_glfw.errors, err)
 				return 0
 			}
 
-			window.win32.cursorTracked = true
+			window.state.cursorTracked = true
 			window.inputCursorEnter(true)
 		}
 
 		if window.cursorMode == CursorDisabled {
-			dx := x - window.win32.lastCursorPosX
-			dy := y - window.win32.lastCursorPosY
+			dx := x - window.state.lastCursorPosX
+			dy := y - window.state.lastCursorPosY
 
-			if _glfw.win32.disabledCursorWindow != window {
+			if _glfw.windowState.disabledCursorWindow != window {
 				break
 			}
 			if window.rawMouseMotion {
@@ -891,13 +891,13 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 			window.inputCursorPos(float64(x), float64(y))
 		}
 
-		window.win32.lastCursorPosX = x
-		window.win32.lastCursorPosY = y
+		window.state.lastCursorPosX = x
+		window.state.lastCursorPosY = y
 
 		return 0
 
 	case _WM_INPUT:
-		if _glfw.win32.disabledCursorWindow != window {
+		if _glfw.windowState.disabledCursorWindow != window {
 			break
 		}
 		if !window.rawMouseMotion {
@@ -910,22 +910,22 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 			_glfw.errors = append(_glfw.errors, err)
 			return 0
 		}
-		if size > uint32(len(_glfw.win32.rawInput)) {
-			_glfw.win32.rawInput = make([]byte, size)
+		if size > uint32(len(_glfw.windowState.rawInput)) {
+			_glfw.windowState.rawInput = make([]byte, size)
 		}
 
-		size = uint32(len(_glfw.win32.rawInput))
-		if _, err := _GetRawInputData(ri, _RID_INPUT, unsafe.Pointer(&_glfw.win32.rawInput[0]), &size); err != nil {
+		size = uint32(len(_glfw.windowState.rawInput))
+		if _, err := _GetRawInputData(ri, _RID_INPUT, unsafe.Pointer(&_glfw.windowState.rawInput[0]), &size); err != nil {
 			_glfw.errors = append(_glfw.errors, err)
 			return 0
 			// TODO: break?
 		}
 
 		var dx, dy int
-		data := (*_RAWINPUT)(unsafe.Pointer(&_glfw.win32.rawInput[0]))
+		data := (*_RAWINPUT)(unsafe.Pointer(&_glfw.windowState.rawInput[0]))
 		if data.mouse.usFlags&_MOUSE_MOVE_ABSOLUTE != 0 {
-			dx = int(data.mouse.lLastX) - window.win32.lastCursorPosX
-			dy = int(data.mouse.lLastY) - window.win32.lastCursorPosY
+			dx = int(data.mouse.lLastX) - window.state.lastCursorPosX
+			dy = int(data.mouse.lLastY) - window.state.lastCursorPosY
 		} else {
 			dx = int(data.mouse.lLastX)
 			dy = int(data.mouse.lLastY)
@@ -933,11 +933,11 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 
 		window.inputCursorPos(window.virtualCursorPosX+float64(dx), window.virtualCursorPosY+float64(dy))
 
-		window.win32.lastCursorPosX += dx
-		window.win32.lastCursorPosY += dy
+		window.state.lastCursorPosX += dx
+		window.state.lastCursorPosY += dy
 
 	case _WM_MOUSELEAVE:
-		window.win32.cursorTracked = false
+		window.state.cursorTracked = false
 		window.inputCursorEnter(false)
 		return 0
 
@@ -952,7 +952,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		return 0
 
 	case _WM_ENTERSIZEMOVE, _WM_ENTERMENULOOP:
-		if window.win32.frameAction {
+		if window.state.frameAction {
 			break
 		}
 
@@ -966,7 +966,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		}
 
 	case _WM_EXITSIZEMOVE, _WM_EXITMENULOOP:
-		if window.win32.frameAction {
+		if window.state.frameAction {
 			break
 		}
 
@@ -983,32 +983,32 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		width := int(_LOWORD(uint32(lParam)))
 		height := int(_HIWORD(uint32(lParam)))
 		iconified := wParam == _SIZE_MINIMIZED
-		maximized := wParam == _SIZE_MAXIMIZED || (window.win32.maximized && wParam != _SIZE_RESTORED)
+		maximized := wParam == _SIZE_MAXIMIZED || (window.state.maximized && wParam != _SIZE_RESTORED)
 
-		if _glfw.win32.disabledCursorWindow == window {
+		if _glfw.windowState.disabledCursorWindow == window {
 			if err := updateClipRect(window); err != nil {
 				_glfw.errors = append(_glfw.errors, err)
 				return 0
 			}
 		}
 
-		if window.win32.iconified != iconified {
+		if window.state.iconified != iconified {
 			window.inputWindowIconify(iconified)
 		}
 
-		if window.win32.maximized != maximized {
+		if window.state.maximized != maximized {
 			window.inputWindowMaximize(maximized)
 		}
 
-		if width != window.win32.width || height != window.win32.height {
-			window.win32.width = width
-			window.win32.height = height
+		if width != window.state.width || height != window.state.height {
+			window.state.width = width
+			window.state.height = height
 
 			window.inputFramebufferSize(width, height)
 			window.inputWindowSize(width, height)
 		}
 
-		if window.monitor != nil && window.win32.iconified != iconified {
+		if window.monitor != nil && window.state.iconified != iconified {
 			if iconified {
 				if err := window.releaseMonitor(); err != nil {
 					_glfw.errors = append(_glfw.errors, err)
@@ -1026,12 +1026,12 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 			}
 		}
 
-		window.win32.iconified = iconified
-		window.win32.maximized = maximized
+		window.state.iconified = iconified
+		window.state.maximized = maximized
 		return 0
 
 	case _WM_MOVE:
-		if _glfw.win32.disabledCursorWindow == window {
+		if _glfw.windowState.disabledCursorWindow == window {
 			if err := updateClipRect(window); err != nil {
 				_glfw.errors = append(_glfw.errors, err)
 				return 0
@@ -1063,7 +1063,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		}
 
 		if isWindows10AnniversaryUpdateOrGreaterWin32() {
-			dpi = _GetDpiForWindow(window.win32.handle)
+			dpi = _GetDpiForWindow(window.state.handle)
 		}
 
 		xoff, yoff, err := getFullWindowSize(window.getWindowStyle(), window.getWindowExStyle(), 0, 0, dpi)
@@ -1083,7 +1083,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		}
 
 		if !window.decorated {
-			mh := _MonitorFromWindow(window.win32.handle, _MONITOR_DEFAULTTONEAREST)
+			mh := _MonitorFromWindow(window.state.handle, _MONITOR_DEFAULTTONEAREST)
 			mi, _ := _GetMonitorInfoW(mh)
 
 			mmi.ptMaxPosition.x = mi.rcWork.left - mi.rcMonitor.left
@@ -1108,7 +1108,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		}
 
 	case _WM_DWMCOMPOSITIONCHANGED, _WM_DWMCOLORIZATIONCOLORCHANGED:
-		if window.win32.transparent {
+		if window.state.transparent {
 			if err := window.updateFramebufferTransparency(); err != nil {
 				_glfw.errors = append(_glfw.errors, err)
 				return 0
@@ -1117,7 +1117,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 		return 0
 
 	case _WM_GETDPISCALEDSIZE:
-		if window.win32.scaleToMonitor {
+		if window.state.scaleToMonitor {
 			break
 		}
 
@@ -1126,7 +1126,7 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 			var source, target _RECT
 			size := (*_SIZE)(unsafe.Pointer(lParam))
 
-			if err := _AdjustWindowRectExForDpi(&source, window.getWindowStyle(), false, window.getWindowExStyle(), _GetDpiForWindow(window.win32.handle)); err != nil {
+			if err := _AdjustWindowRectExForDpi(&source, window.getWindowStyle(), false, window.getWindowExStyle(), _GetDpiForWindow(window.state.handle)); err != nil {
 				_glfw.errors = append(_glfw.errors, err)
 				return 0
 			}
@@ -1146,9 +1146,9 @@ func windowProc(hWnd windows.HWND, uMsg uint32, wParam _WPARAM, lParam _LPARAM) 
 
 		// Resize windowed mode windows that either permit rescaling or that
 		// need it to compensate for non-client area scaling
-		if window.monitor == nil && (window.win32.scaleToMonitor || isWindows10CreatorsUpdateOrGreaterWin32()) {
+		if window.monitor == nil && (window.state.scaleToMonitor || isWindows10CreatorsUpdateOrGreaterWin32()) {
 			suggested := (*_RECT)(unsafe.Pointer(lParam))
-			if err := _SetWindowPos(window.win32.handle, _HWND_TOP,
+			if err := _SetWindowPos(window.state.handle, _HWND_TOP,
 				suggested.left,
 				suggested.top,
 				suggested.right-suggested.left,
@@ -1206,7 +1206,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 
 	var xpos, ypos, fullWidth, fullHeight int32
 	if w.monitor != nil {
-		mi, ok := _GetMonitorInfoW(w.monitor.win32.handle)
+		mi, ok := _GetMonitorInfoW(w.monitor.state.handle)
 		if !ok {
 			return fmt.Errorf("goglfw: GetMonitorInfoW failed")
 		}
@@ -1221,7 +1221,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 		xpos = _CW_USEDEFAULT
 		ypos = _CW_USEDEFAULT
 
-		w.win32.maximized = wndconfig.maximized
+		w.state.maximized = wndconfig.maximized
 		if wndconfig.maximized {
 			style |= _WS_MAXIMIZE
 		}
@@ -1236,27 +1236,27 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 	h, err := _CreateWindowExW(exStyle, _GLFW_WNDCLASSNAME, wndconfig.title, style, xpos, ypos, fullWidth, fullHeight,
 		0, // No parent window
 		0, // No window menu
-		_glfw.win32.instance, unsafe.Pointer(wndconfig))
+		_glfw.windowState.instance, unsafe.Pointer(wndconfig))
 	if err != nil {
 		return err
 	}
-	w.win32.handle = h
+	w.state.handle = h
 
-	handleToWindow[w.win32.handle] = w
+	handleToWindow[w.state.handle] = w
 
 	if !microsoftgdk.IsXbox() && _IsWindows7OrGreater() {
-		if err := _ChangeWindowMessageFilterEx(w.win32.handle, _WM_DROPFILES, _MSGFLT_ALLOW, nil); err != nil {
+		if err := _ChangeWindowMessageFilterEx(w.state.handle, _WM_DROPFILES, _MSGFLT_ALLOW, nil); err != nil {
 			return err
 		}
-		if err := _ChangeWindowMessageFilterEx(w.win32.handle, _WM_COPYDATA, _MSGFLT_ALLOW, nil); err != nil {
+		if err := _ChangeWindowMessageFilterEx(w.state.handle, _WM_COPYDATA, _MSGFLT_ALLOW, nil); err != nil {
 			return err
 		}
-		if err := _ChangeWindowMessageFilterEx(w.win32.handle, _WM_COPYGLOBALDATA, _MSGFLT_ALLOW, nil); err != nil {
+		if err := _ChangeWindowMessageFilterEx(w.state.handle, _WM_COPYGLOBALDATA, _MSGFLT_ALLOW, nil); err != nil {
 			return err
 		}
 	}
 
-	w.win32.scaleToMonitor = wndconfig.scaleToMonitor
+	w.state.scaleToMonitor = wndconfig.scaleToMonitor
 
 	// Adjust window rect to account for DPI scaling of the window frame and
 	// (if enabled) DPI scaling of the content area
@@ -1268,7 +1268,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 			right:  int32(wndconfig.width),
 			bottom: int32(wndconfig.height),
 		}
-		mh := _MonitorFromWindow(w.win32.handle, _MONITOR_DEFAULTTONEAREST)
+		mh := _MonitorFromWindow(w.state.handle, _MONITOR_DEFAULTTONEAREST)
 
 		// Adjust window rect to account for DPI scaling of the window frame and
 		// (if enabled) DPI scaling of the content area
@@ -1292,7 +1292,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 		}
 
 		if isWindows10AnniversaryUpdateOrGreaterWin32() {
-			if err := _AdjustWindowRectExForDpi(&rect, style, false, exStyle, _GetDpiForWindow(w.win32.handle)); err != nil {
+			if err := _AdjustWindowRectExForDpi(&rect, style, false, exStyle, _GetDpiForWindow(w.state.handle)); err != nil {
 				return err
 			}
 		} else {
@@ -1302,7 +1302,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 		}
 
 		// Only update the restored window rect as the window may be maximized
-		wp, err := _GetWindowPlacement(w.win32.handle)
+		wp, err := _GetWindowPlacement(w.state.handle)
 		if err != nil {
 			return err
 		}
@@ -1310,7 +1310,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 
 		wp.rcNormalPosition = rect
 		wp.showCmd = _SW_HIDE
-		if err := _SetWindowPlacement(w.win32.handle, &wp); err != nil {
+		if err := _SetWindowPlacement(w.state.handle, &wp); err != nil {
 			return err
 		}
 
@@ -1319,7 +1319,7 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 
 		if wndconfig.maximized && !wndconfig.decorated {
 			mi, _ := _GetMonitorInfoW(mh)
-			if err := _SetWindowPos(w.win32.handle, _HWND_TOP,
+			if err := _SetWindowPos(w.state.handle, _HWND_TOP,
 				mi.rcWork.left, mi.rcWork.top, mi.rcWork.right-mi.rcWork.left, mi.rcWork.bottom-mi.rcWork.top,
 				_SWP_NOACTIVATE|_SWP_NOZORDER); err != nil {
 				return err
@@ -1328,21 +1328,21 @@ func (w *Window) createNativeWindow(wndconfig *wndconfig, fbconfig *fbconfig) er
 	}
 
 	if !microsoftgdk.IsXbox() {
-		_DragAcceptFiles(w.win32.handle, true)
+		_DragAcceptFiles(w.state.handle, true)
 	}
 
 	if fbconfig.transparent {
 		if err := w.updateFramebufferTransparency(); err != nil {
 			return err
 		}
-		w.win32.transparent = true
+		w.state.transparent = true
 	}
 
 	width, height, err := w.platformGetWindowSize()
 	if err != nil {
 		return err
 	}
-	w.win32.width, w.win32.height = width, height
+	w.state.width, w.state.height = width, height
 
 	return nil
 }
@@ -1352,7 +1352,7 @@ func registerWindowClassWin32() error {
 	wc.cbSize = uint32(unsafe.Sizeof(wc))
 	wc.style = _CS_HREDRAW | _CS_VREDRAW | _CS_OWNDC
 	wc.lpfnWndProc = _WNDPROC(windowProcPtr)
-	wc.hInstance = _glfw.win32.instance
+	wc.hInstance = _glfw.windowState.instance
 	cursor, err := _LoadCursorW(0, _IDC_ARROW)
 	if err != nil {
 		return err
@@ -1383,7 +1383,7 @@ func registerWindowClassWin32() error {
 }
 
 func unregisterWindowClassWin32() error {
-	if err := _UnregisterClassW(_GLFW_WNDCLASSNAME, _glfw.win32.instance); err != nil {
+	if err := _UnregisterClassW(_GLFW_WNDCLASSNAME, _glfw.windowState.instance); err != nil {
 		return err
 	}
 	return nil
@@ -1451,28 +1451,28 @@ func (w *Window) platformDestroyWindow() error {
 		}
 	}
 
-	if _glfw.win32.disabledCursorWindow == w {
-		_glfw.win32.disabledCursorWindow = nil
+	if _glfw.windowState.disabledCursorWindow == w {
+		_glfw.windowState.disabledCursorWindow = nil
 	}
 
-	if w.win32.handle != 0 {
+	if w.state.handle != 0 {
 		if !microsoftgdk.IsXbox() {
-			if err := _DestroyWindow(w.win32.handle); err != nil {
+			if err := _DestroyWindow(w.state.handle); err != nil {
 				return err
 			}
 		}
-		delete(handleToWindow, w.win32.handle)
-		w.win32.handle = 0
+		delete(handleToWindow, w.state.handle)
+		w.state.handle = 0
 	}
 
-	if w.win32.bigIcon != 0 {
-		if err := _DestroyIcon(w.win32.bigIcon); err != nil {
+	if w.state.bigIcon != 0 {
+		if err := _DestroyIcon(w.state.bigIcon); err != nil {
 			return err
 		}
 	}
 
-	if w.win32.smallIcon != 0 {
-		if err := _DestroyIcon(w.win32.smallIcon); err != nil {
+	if w.state.smallIcon != 0 {
+		if err := _DestroyIcon(w.state.smallIcon); err != nil {
 			return err
 		}
 	}
@@ -1484,7 +1484,7 @@ func (w *Window) platformSetWindowTitle(title string) error {
 	if microsoftgdk.IsXbox() {
 		return nil
 	}
-	return _SetWindowTextW(w.win32.handle, title)
+	return _SetWindowTextW(w.state.handle, title)
 }
 
 func (w *Window) platformSetWindowIcon(images []*Image) error {
@@ -1520,36 +1520,36 @@ func (w *Window) platformSetWindowIcon(images []*Image) error {
 			return err
 		}
 	} else {
-		i, err := _GetClassLongPtrW(w.win32.handle, _GCLP_HICON)
+		i, err := _GetClassLongPtrW(w.state.handle, _GCLP_HICON)
 		if err != nil {
 			return err
 		}
 		bigIcon = _HICON(i)
-		i, err = _GetClassLongPtrW(w.win32.handle, _GCLP_HICONSM)
+		i, err = _GetClassLongPtrW(w.state.handle, _GCLP_HICONSM)
 		if err != nil {
 			return err
 		}
 		smallIcon = _HICON(i)
 	}
 
-	_SendMessageW(w.win32.handle, _WM_SETICON, _ICON_BIG, _LPARAM(bigIcon))
-	_SendMessageW(w.win32.handle, _WM_SETICON, _ICON_SMALL, _LPARAM(smallIcon))
+	_SendMessageW(w.state.handle, _WM_SETICON, _ICON_BIG, _LPARAM(bigIcon))
+	_SendMessageW(w.state.handle, _WM_SETICON, _ICON_SMALL, _LPARAM(smallIcon))
 
-	if w.win32.bigIcon != 0 {
-		if err := _DestroyIcon(w.win32.bigIcon); err != nil {
+	if w.state.bigIcon != 0 {
+		if err := _DestroyIcon(w.state.bigIcon); err != nil {
 			return err
 		}
 	}
 
-	if w.win32.smallIcon != 0 {
-		if err := _DestroyIcon(w.win32.smallIcon); err != nil {
+	if w.state.smallIcon != 0 {
+		if err := _DestroyIcon(w.state.smallIcon); err != nil {
 			return err
 		}
 	}
 
 	if len(images) > 0 {
-		w.win32.bigIcon = bigIcon
-		w.win32.smallIcon = smallIcon
+		w.state.bigIcon = bigIcon
+		w.state.smallIcon = smallIcon
 	}
 	return nil
 }
@@ -1560,7 +1560,7 @@ func (w *Window) platformGetWindowPos() (xpos, ypos int, err error) {
 	}
 
 	var pos _POINT
-	if err := _ClientToScreen(w.win32.handle, &pos); err != nil {
+	if err := _ClientToScreen(w.state.handle, &pos); err != nil {
 		return 0, 0, err
 	}
 	return int(pos.x), int(pos.y), nil
@@ -1578,7 +1578,7 @@ func (w *Window) platformSetWindowPos(xpos, ypos int) error {
 		bottom: int32(ypos),
 	}
 	if isWindows10AnniversaryUpdateOrGreaterWin32() {
-		if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.win32.handle)); err != nil {
+		if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.state.handle)); err != nil {
 			return err
 		}
 	} else {
@@ -1587,14 +1587,14 @@ func (w *Window) platformSetWindowPos(xpos, ypos int) error {
 		}
 	}
 
-	if err := _SetWindowPos(w.win32.handle, 0, rect.left, rect.top, 0, 0, _SWP_NOACTIVATE|_SWP_NOZORDER|_SWP_NOSIZE); err != nil {
+	if err := _SetWindowPos(w.state.handle, 0, rect.left, rect.top, 0, 0, _SWP_NOACTIVATE|_SWP_NOZORDER|_SWP_NOSIZE); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (w *Window) platformGetWindowSize() (width, height int, err error) {
-	area, err := _GetClientRect(w.win32.handle)
+	area, err := _GetClientRect(w.state.handle)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -1620,7 +1620,7 @@ func (w *Window) platformSetWindowSize(width, height int) error {
 		}
 
 		if isWindows10AnniversaryUpdateOrGreaterWin32() {
-			if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.win32.handle)); err != nil {
+			if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.state.handle)); err != nil {
 				return err
 			}
 		} else {
@@ -1629,7 +1629,7 @@ func (w *Window) platformSetWindowSize(width, height int) error {
 			}
 		}
 
-		if err := _SetWindowPos(w.win32.handle, _HWND_TOP,
+		if err := _SetWindowPos(w.state.handle, _HWND_TOP,
 			0, 0, rect.right-rect.left, rect.bottom-rect.top,
 			_SWP_NOACTIVATE|_SWP_NOOWNERZORDER|_SWP_NOMOVE|_SWP_NOZORDER); err != nil {
 			return err
@@ -1644,11 +1644,11 @@ func (w *Window) platformSetWindowSizeLimits(minwidth, minheight, maxwidth, maxh
 		return nil
 	}
 
-	area, err := _GetWindowRect(w.win32.handle)
+	area, err := _GetWindowRect(w.state.handle)
 	if err != nil {
 		return err
 	}
-	if err := _MoveWindow(w.win32.handle, area.left, area.top, area.right-area.left, area.bottom-area.top, true); err != nil {
+	if err := _MoveWindow(w.state.handle, area.left, area.top, area.right-area.left, area.bottom-area.top, true); err != nil {
 		return err
 	}
 	return nil
@@ -1659,14 +1659,14 @@ func (w *Window) platformSetWindowAspectRatio(numer, denom int) error {
 		return nil
 	}
 
-	area, err := _GetWindowRect(w.win32.handle)
+	area, err := _GetWindowRect(w.state.handle)
 	if err != nil {
 		return err
 	}
 	if err := w.applyAspectRatio(_WMSZ_BOTTOMRIGHT, &area); err != nil {
 		return err
 	}
-	if err := _MoveWindow(w.win32.handle, area.left, area.top, area.right-area.left, area.bottom-area.top, true); err != nil {
+	if err := _MoveWindow(w.state.handle, area.left, area.top, area.right-area.left, area.bottom-area.top, true); err != nil {
 		return err
 	}
 	return nil
@@ -1689,7 +1689,7 @@ func (w *Window) platformGetWindowFrameSize() (left, top, right, bottom int, err
 		bottom: int32(height),
 	}
 	if isWindows10AnniversaryUpdateOrGreaterWin32() {
-		if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.win32.handle)); err != nil {
+		if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.state.handle)); err != nil {
 			return 0, 0, 0, 0, err
 		}
 	} else {
@@ -1702,21 +1702,21 @@ func (w *Window) platformGetWindowFrameSize() (left, top, right, bottom int, err
 }
 
 func (w *Window) platformGetWindowContentScale() (xscale, yscale float32, err error) {
-	handle := _MonitorFromWindow(w.win32.handle, _MONITOR_DEFAULTTONEAREST)
+	handle := _MonitorFromWindow(w.state.handle, _MONITOR_DEFAULTTONEAREST)
 	return getMonitorContentScaleWin32(handle)
 }
 
 func (w *Window) platformIconifyWindow() {
-	_ShowWindow(w.win32.handle, _SW_MINIMIZE)
+	_ShowWindow(w.state.handle, _SW_MINIMIZE)
 }
 
 func (w *Window) platformRestoreWindow() {
-	_ShowWindow(w.win32.handle, _SW_RESTORE)
+	_ShowWindow(w.state.handle, _SW_RESTORE)
 }
 
 func (w *Window) platformMaximizeWindow() error {
-	if _IsWindowVisible(w.win32.handle) {
-		_ShowWindow(w.win32.handle, _SW_MAXIMIZE)
+	if _IsWindowVisible(w.state.handle) {
+		_ShowWindow(w.state.handle, _SW_MAXIMIZE)
 	} else {
 		if err := w.maximizeWindowManually(); err != nil {
 			return err
@@ -1726,15 +1726,15 @@ func (w *Window) platformMaximizeWindow() error {
 }
 
 func (w *Window) platformShowWindow() {
-	_ShowWindow(w.win32.handle, _SW_SHOWNA)
+	_ShowWindow(w.state.handle, _SW_SHOWNA)
 }
 
 func (w *Window) platformHideWindow() {
-	_ShowWindow(w.win32.handle, _SW_HIDE)
+	_ShowWindow(w.state.handle, _SW_HIDE)
 }
 
 func (w *Window) platformRequestWindowAttention() {
-	_FlashWindow(w.win32.handle, true)
+	_FlashWindow(w.state.handle, true)
 }
 
 func (w *Window) platformFocusWindow() error {
@@ -1742,11 +1742,11 @@ func (w *Window) platformFocusWindow() error {
 		return nil
 	}
 
-	if err := _BringWindowToTop(w.win32.handle); err != nil {
+	if err := _BringWindowToTop(w.state.handle); err != nil {
 		return err
 	}
-	_SetForegroundWindow(w.win32.handle)
-	if _, err := _SetFocus(w.win32.handle); err != nil {
+	_SetForegroundWindow(w.state.handle)
+	if _, err := _SetFocus(w.state.handle); err != nil {
 		return err
 	}
 	return nil
@@ -1771,7 +1771,7 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 				bottom: int32(ypos + height),
 			}
 			if isWindows10AnniversaryUpdateOrGreaterWin32() {
-				if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.win32.handle)); err != nil {
+				if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(), false, w.getWindowExStyle(), _GetDpiForWindow(w.state.handle)); err != nil {
 					return err
 				}
 			} else {
@@ -1780,7 +1780,7 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 				}
 			}
 
-			if err := _SetWindowPos(w.win32.handle, _HWND_TOP,
+			if err := _SetWindowPos(w.state.handle, _HWND_TOP,
 				rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top,
 				_SWP_NOCOPYBITS|_SWP_NOACTIVATE|_SWP_NOZORDER); err != nil {
 				return err
@@ -1801,14 +1801,14 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 	if w.monitor != nil {
 		var flags uint32 = _SWP_SHOWWINDOW | _SWP_NOACTIVATE | _SWP_NOCOPYBITS
 		if w.decorated {
-			s, err := _GetWindowLongW(w.win32.handle, _GWL_STYLE)
+			s, err := _GetWindowLongW(w.state.handle, _GWL_STYLE)
 			if err != nil {
 				return err
 			}
 			style := uint32(s)
 			style &^= _WS_OVERLAPPEDWINDOW
 			style |= w.getWindowStyle()
-			if _, err := _SetWindowLongW(w.win32.handle, _GWL_STYLE, int32(style)); err != nil {
+			if _, err := _SetWindowLongW(w.state.handle, _GWL_STYLE, int32(style)); err != nil {
 				return err
 			}
 			flags |= _SWP_FRAMECHANGED
@@ -1818,12 +1818,12 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 			return err
 		}
 
-		mi, _ := _GetMonitorInfoW(w.monitor.win32.handle)
+		mi, _ := _GetMonitorInfoW(w.monitor.state.handle)
 		var hWnd windows.HWND = _HWND_NOTOPMOST
 		if w.floating {
 			hWnd = _HWND_TOPMOST
 		}
-		if err := _SetWindowPos(w.win32.handle, hWnd,
+		if err := _SetWindowPos(w.state.handle, hWnd,
 			mi.rcMonitor.left,
 			mi.rcMonitor.top,
 			mi.rcMonitor.right-mi.rcMonitor.left,
@@ -1834,14 +1834,14 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 	} else {
 		var flags uint32 = _SWP_NOACTIVATE | _SWP_NOCOPYBITS
 		if w.decorated {
-			s, err := _GetWindowLongW(w.win32.handle, _GWL_STYLE)
+			s, err := _GetWindowLongW(w.state.handle, _GWL_STYLE)
 			if err != nil {
 				return err
 			}
 			style := uint32(s)
 			style &^= _WS_POPUP
 			style |= w.getWindowStyle()
-			if _, err := _SetWindowLongW(w.win32.handle, _GWL_STYLE, int32(style)); err != nil {
+			if _, err := _SetWindowLongW(w.state.handle, _GWL_STYLE, int32(style)); err != nil {
 				return err
 			}
 			flags |= _SWP_FRAMECHANGED
@@ -1856,7 +1856,7 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 		if isWindows10AnniversaryUpdateOrGreaterWin32() {
 			if err := _AdjustWindowRectExForDpi(&rect, w.getWindowStyle(),
 				false, w.getWindowExStyle(),
-				_GetDpiForWindow(w.win32.handle)); err != nil {
+				_GetDpiForWindow(w.state.handle)); err != nil {
 				return err
 			}
 		} else {
@@ -1872,7 +1872,7 @@ func (w *Window) platformSetWindowMonitor(monitor *Monitor, xpos, ypos, width, h
 		} else {
 			after = _HWND_NOTOPMOST
 		}
-		if err := _SetWindowPos(w.win32.handle, after,
+		if err := _SetWindowPos(w.state.handle, after,
 			rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top,
 			flags); err != nil {
 			return err
@@ -1886,28 +1886,28 @@ func (w *Window) platformWindowFocused() bool {
 	if microsoftgdk.IsXbox() {
 		return true
 	}
-	return w.win32.handle == _GetActiveWindow()
+	return w.state.handle == _GetActiveWindow()
 }
 
 func (w *Window) platformWindowIconified() bool {
 	if microsoftgdk.IsXbox() {
 		return false
 	}
-	return _IsIconic(w.win32.handle)
+	return _IsIconic(w.state.handle)
 }
 
 func (w *Window) platformWindowVisible() bool {
 	if microsoftgdk.IsXbox() {
 		return true
 	}
-	return _IsWindowVisible(w.win32.handle)
+	return _IsWindowVisible(w.state.handle)
 }
 
 func (w *Window) platformWindowMaximized() bool {
 	if microsoftgdk.IsXbox() {
 		return false
 	}
-	return _IsZoomed(w.win32.handle)
+	return _IsZoomed(w.state.handle)
 }
 
 func (w *Window) platformWindowHovered() (bool, error) {
@@ -1922,7 +1922,7 @@ func (w *Window) platformFramebufferTransparent() bool {
 		return false
 	}
 
-	if !w.win32.transparent {
+	if !w.state.transparent {
 		return false
 	}
 
@@ -1962,17 +1962,17 @@ func (w *Window) platformSetWindowFloating(enabled bool) error {
 	if enabled {
 		after = _HWND_TOPMOST
 	}
-	return _SetWindowPos(w.win32.handle, after, 0, 0, 0, 0, _SWP_NOACTIVATE|_SWP_NOMOVE|_SWP_NOSIZE)
+	return _SetWindowPos(w.state.handle, after, 0, 0, 0, 0, _SWP_NOACTIVATE|_SWP_NOMOVE|_SWP_NOSIZE)
 }
 
 func (w *Window) platformGetWindowOpacity() (float32, error) {
-	style, err := _GetWindowLongW(w.win32.handle, _GWL_EXSTYLE)
+	style, err := _GetWindowLongW(w.state.handle, _GWL_EXSTYLE)
 	if err != nil {
 		return 0, err
 	}
 
 	if style&_WS_EX_LAYERED != 0 {
-		_, alpha, flags, err := _GetLayeredWindowAttributes(w.win32.handle)
+		_, alpha, flags, err := _GetLayeredWindowAttributes(w.state.handle)
 		if err != nil {
 			return 0, err
 		}
@@ -1988,24 +1988,24 @@ func (w *Window) platformGetWindowOpacity() (float32, error) {
 func (w *Window) platformSetWindowOpacity(opacity float32) error {
 	if opacity < 1 {
 		alpha := byte(255 * opacity)
-		style, err := _GetWindowLongW(w.win32.handle, _GWL_EXSTYLE)
+		style, err := _GetWindowLongW(w.state.handle, _GWL_EXSTYLE)
 		if err != nil {
 			return err
 		}
 		style |= _WS_EX_LAYERED
-		if _, err := _SetWindowLongW(w.win32.handle, _GWL_EXSTYLE, style); err != nil {
+		if _, err := _SetWindowLongW(w.state.handle, _GWL_EXSTYLE, style); err != nil {
 			return err
 		}
-		if err := _SetLayeredWindowAttributes(w.win32.handle, 0, alpha, _LWA_ALPHA); err != nil {
+		if err := _SetLayeredWindowAttributes(w.state.handle, 0, alpha, _LWA_ALPHA); err != nil {
 			return err
 		}
 	} else {
-		style, err := _GetWindowLongW(w.win32.handle, _GWL_EXSTYLE)
+		style, err := _GetWindowLongW(w.state.handle, _GWL_EXSTYLE)
 		if err != nil {
 			return err
 		}
 		style &^= _WS_EX_LAYERED
-		if _, err := _SetWindowLongW(w.win32.handle, _GWL_EXSTYLE, style); err != nil {
+		if _, err := _SetWindowLongW(w.state.handle, _GWL_EXSTYLE, style); err != nil {
 			return err
 		}
 	}
@@ -2014,7 +2014,7 @@ func (w *Window) platformSetWindowOpacity(opacity float32) error {
 }
 
 func (w *Window) platformSetRawMouseMotion(enabled bool) error {
-	if _glfw.win32.disabledCursorWindow != w {
+	if _glfw.windowState.disabledCursorWindow != w {
 		return nil
 	}
 
@@ -2057,7 +2057,7 @@ func platformPollEvents() error {
 	var handle windows.HWND
 	if microsoftgdk.IsXbox() {
 		// Assume that there is always exactly one active window.
-		handle = _glfw.windows[0].win32.handle
+		handle = _glfw.windows[0].state.handle
 	} else {
 		handle = _GetActiveWindow()
 	}
@@ -2083,7 +2083,7 @@ func platformPollEvents() error {
 			for i := range keys {
 				vk := keys[i].VK
 				key := keys[i].Key
-				scancode := _glfw.win32.scancodes[key]
+				scancode := _glfw.windowState.scancodes[key]
 
 				if uint32(_GetKeyState(int32(vk)))&0x8000 != 0 {
 					continue
@@ -2096,7 +2096,7 @@ func platformPollEvents() error {
 		}
 	}
 
-	if window := _glfw.win32.disabledCursorWindow; window != nil {
+	if window := _glfw.windowState.disabledCursorWindow; window != nil {
 		width, height, err := window.platformGetWindowSize()
 		if err != nil {
 			return err
@@ -2104,7 +2104,7 @@ func platformPollEvents() error {
 
 		// NOTE: Re-center the cursor only if it has moved since the last call,
 		//       to avoid breaking glfwWaitEvents with WM_MOUSEMOVE
-		if window.win32.lastCursorPosX != width/2 || window.win32.lastCursorPosY != height/2 {
+		if window.state.lastCursorPosX != width/2 || window.state.lastCursorPosY != height/2 {
 			if err := window.platformSetCursorPos(float64(width/2), float64(height/2)); err != nil {
 				return err
 			}
@@ -2135,7 +2135,7 @@ func platformWaitEventsTimeout(timeout float64) error {
 }
 
 func platformPostEmptyEvent() error {
-	return _PostMessageW(_glfw.win32.helperWindowHandle, _WM_NULL, 0, 0)
+	return _PostMessageW(_glfw.windowState.helperWindowHandle, _WM_NULL, 0, 0)
 }
 
 func (w *Window) platformGetCursorPos() (xpos, ypos float64, err error) {
@@ -2147,7 +2147,7 @@ func (w *Window) platformGetCursorPos() (xpos, ypos float64, err error) {
 		return 0, 0, err
 	}
 	if !microsoftgdk.IsXbox() {
-		if err := _ScreenToClient(w.win32.handle, &pos); err != nil {
+		if err := _ScreenToClient(w.state.handle, &pos); err != nil {
 			return 0, 0, err
 		}
 	}
@@ -2161,11 +2161,11 @@ func (w *Window) platformSetCursorPos(xpos, ypos float64) error {
 	}
 
 	// Store the new position so it can be recognized later
-	w.win32.lastCursorPosX = int(pos.x)
-	w.win32.lastCursorPosY = int(pos.y)
+	w.state.lastCursorPosX = int(pos.x)
+	w.state.lastCursorPosY = int(pos.y)
 
 	if !microsoftgdk.IsXbox() {
-		if err := _ClientToScreen(w.win32.handle, &pos); err != nil {
+		if err := _ClientToScreen(w.state.handle, &pos); err != nil {
 			return err
 		}
 	}
@@ -2185,7 +2185,7 @@ func (w *Window) platformSetCursorMode(mode int) error {
 		return nil
 	}
 
-	if _glfw.win32.disabledCursorWindow == w {
+	if _glfw.windowState.disabledCursorWindow == w {
 		if err := w.enableCursor(); err != nil {
 			return err
 		}
@@ -2206,14 +2206,14 @@ func (w *Window) platformSetCursorMode(mode int) error {
 }
 
 func platformGetScancodeName(scancode int) (string, error) {
-	if scancode < 0 || scancode > (_KF_EXTENDED|0xff) || _glfw.win32.keycodes[scancode] == KeyUnknown {
+	if scancode < 0 || scancode > (_KF_EXTENDED|0xff) || _glfw.windowState.keycodes[scancode] == KeyUnknown {
 		return "", fmt.Errorf("glwfwin: invalid scancode %d: %w", scancode, InvalidValue)
 	}
-	return _glfw.win32.keynames[_glfw.win32.keycodes[scancode]], nil
+	return _glfw.windowState.keynames[_glfw.windowState.keycodes[scancode]], nil
 }
 
 func platformGetKeyScancode(key Key) int {
-	return _glfw.win32.scancodes[key]
+	return _glfw.windowState.scancodes[key]
 }
 
 func (c *Cursor) platformCreateStandardCursor(shape StandardCursor) error {
@@ -2243,14 +2243,14 @@ func (c *Cursor) platformCreateStandardCursor(shape StandardCursor) error {
 	if err != nil {
 		return err
 	}
-	c.win32.handle = _HCURSOR(h)
+	c.state.handle = _HCURSOR(h)
 
 	return nil
 }
 
 func (c *Cursor) platformDestroyCursor() error {
-	if c.win32.handle != 0 {
-		if err := _DestroyIcon(_HICON(c.win32.handle)); err != nil {
+	if c.state.handle != 0 {
+		if err := _DestroyIcon(_HICON(c.state.handle)); err != nil {
 			return err
 		}
 	}
@@ -2282,5 +2282,5 @@ func (w *Window) GetWin32Window() (windows.HWND, error) {
 	if !_glfw.initialized {
 		return 0, NotInitialized
 	}
-	return w.win32.handle, nil
+	return w.state.handle, nil
 }


### PR DESCRIPTION
# What issue is this addressing?
Updates #2546

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
Many of the structs found in internal.h (internal_windows.go) contain defines such as GLFW_WIN32_WINDOW_STATE which gets replaced with a struct defined in win32platform_windows.go (win32_platform.h).

Originally, these structs where directly placed inside of internal_windows.go. However, to make it easier to add macOS and Linux these cannot be in this file.

This commit separates the windows specific structs into the respective windows file and updates the field to be named state.
