### PR TITLE
Add `-tags=example` in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 ## Desktops
 
 ```sh
-go run github.com/hajimehoshi/ebiten/v2/examples/rotate@latest
+go run -tags=example github.com/hajimehoshi/ebiten/v2/examples/rotate@latest
 ```
 
 ## Android


### PR DESCRIPTION
# What issue is this addressing?
N/A

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

I tried running:
```sh
go run github.com/hajimehoshi/ebiten/v2/examples/rotate@latest
```
This failed with:
```
package github.com/hajimehoshi/ebiten/v2/examples/2048: build constraints exclude all Go files in ....
```

This tiny fix brings the README to match the docs.

