### PR TITLE
gamepad: enhanced native standard layout support

### DIFF
--- a/internal/gamepad/gamepad_android.go
+++ b/internal/gamepad/gamepad_android.go
@@ -53,12 +53,12 @@ func (*nativeGamepadImpl) hasOwnStandardLayoutMapping() bool {
 	return false
 }
 
-func (*nativeGamepadImpl) isStandardAxisAvailableInOwnMapping(axis gamepaddb.StandardAxis) bool {
-	return false
+func (*nativeGamepadImpl) standardAxisInOwnMapping(axis gamepaddb.StandardAxis) mappingInput {
+	return nil
 }
 
-func (*nativeGamepadImpl) isStandardButtonAvailableInOwnMapping(button gamepaddb.StandardButton) bool {
-	return false
+func (*nativeGamepadImpl) standardButtonInOwnMapping(button gamepaddb.StandardButton) mappingInput {
+	return nil
 }
 
 func (g *nativeGamepadImpl) axisCount() int {
@@ -87,8 +87,11 @@ func (g *nativeGamepadImpl) isButtonPressed(button int) bool {
 	return g.buttons[button]
 }
 
-func (*nativeGamepadImpl) buttonValue(button int) float64 {
-	panic("gamepad: buttonValue is not implemented")
+func (g *nativeGamepadImpl) buttonValue(button int) float64 {
+	if g.isButtonPressed(button) {
+		return 1
+	}
+	return 0
 }
 
 func (g *nativeGamepadImpl) hatState(hat int) int {

--- a/internal/gamepad/gamepad_darwin.go
+++ b/internal/gamepad/gamepad_darwin.go
@@ -372,12 +372,12 @@ func (g *nativeGamepadImpl) hasOwnStandardLayoutMapping() bool {
 	return false
 }
 
-func (g *nativeGamepadImpl) isStandardAxisAvailableInOwnMapping(axis gamepaddb.StandardAxis) bool {
-	return false
+func (*nativeGamepadImpl) standardAxisInOwnMapping(axis gamepaddb.StandardAxis) mappingInput {
+	return nil
 }
 
-func (g *nativeGamepadImpl) isStandardButtonAvailableInOwnMapping(button gamepaddb.StandardButton) bool {
-	return false
+func (*nativeGamepadImpl) standardButtonInOwnMapping(button gamepaddb.StandardButton) mappingInput {
+	return nil
 }
 
 func (g *nativeGamepadImpl) axisCount() int {
@@ -400,7 +400,10 @@ func (g *nativeGamepadImpl) axisValue(axis int) float64 {
 }
 
 func (g *nativeGamepadImpl) buttonValue(button int) float64 {
-	panic("gamepad: buttonValue is not implemented")
+	if g.isButtonPressed(button) {
+		return 1
+	}
+	return 0
 }
 
 func (g *nativeGamepadImpl) isButtonPressed(button int) bool {

--- a/internal/gamepad/gamepad_desktop_windows.go
+++ b/internal/gamepad/gamepad_desktop_windows.go
@@ -572,12 +572,12 @@ func (*nativeGamepadDesktop) hasOwnStandardLayoutMapping() bool {
 	return false
 }
 
-func (*nativeGamepadDesktop) isStandardAxisAvailableInOwnMapping(axis gamepaddb.StandardAxis) bool {
-	return false
+func (*nativeGamepadDesktop) standardAxisInOwnMapping(axis gamepaddb.StandardAxis) mappingInput {
+	return nil
 }
 
-func (*nativeGamepadDesktop) isStandardButtonAvailableInOwnMapping(button gamepaddb.StandardButton) bool {
-	return false
+func (*nativeGamepadDesktop) standardButtonInOwnMapping(button gamepaddb.StandardButton) mappingInput {
+	return nil
 }
 
 func (g *nativeGamepadDesktop) usesDInput() bool {
@@ -757,7 +757,10 @@ func (g *nativeGamepadDesktop) isButtonPressed(button int) bool {
 }
 
 func (g *nativeGamepadDesktop) buttonValue(button int) float64 {
-	panic("gamepad: buttonValue is not implemented")
+	if g.isButtonPressed(button) {
+		return 1
+	}
+	return 0
 }
 
 func (g *nativeGamepadDesktop) hatState(hat int) int {

--- a/internal/gamepad/gamepad_ios.go
+++ b/internal/gamepad/gamepad_ios.go
@@ -58,12 +58,12 @@ func (*nativeGamepadImpl) hasOwnStandardLayoutMapping() bool {
 	return false
 }
 
-func (*nativeGamepadImpl) isStandardAxisAvailableInOwnMapping(axis gamepaddb.StandardAxis) bool {
-	return false
+func (*nativeGamepadImpl) standardAxisInOwnMapping(axis gamepaddb.StandardAxis) mappingInput {
+	return nil
 }
 
-func (*nativeGamepadImpl) isStandardButtonAvailableInOwnMapping(button gamepaddb.StandardButton) bool {
-	return false
+func (*nativeGamepadImpl) standardButtonInOwnMapping(button gamepaddb.StandardButton) mappingInput {
+	return nil
 }
 
 func (g *nativeGamepadImpl) axisCount() int {
@@ -92,8 +92,11 @@ func (g *nativeGamepadImpl) isButtonPressed(button int) bool {
 	return g.buttons[button]
 }
 
-func (*nativeGamepadImpl) buttonValue(button int) float64 {
-	panic("gamepad: buttonValue is not implemented")
+func (g *nativeGamepadImpl) buttonValue(button int) float64 {
+	if g.isButtonPressed(button) {
+		return 1
+	}
+	return 0
 }
 
 func (g *nativeGamepadImpl) hatState(hat int) int {

--- a/internal/gamepad/gamepad_js.go
+++ b/internal/gamepad/gamepad_js.go
@@ -116,18 +116,24 @@ func (g *nativeGamepadImpl) hasOwnStandardLayoutMapping() bool {
 	return g.mapping == "standard"
 }
 
-func (g *nativeGamepadImpl) isStandardAxisAvailableInOwnMapping(axis gamepaddb.StandardAxis) bool {
+func (g *nativeGamepadImpl) standardAxisInOwnMapping(axis gamepaddb.StandardAxis) mappingInput {
 	if !g.hasOwnStandardLayoutMapping() {
-		return false
+		return nil
 	}
-	return axis >= 0 && int(axis) < g.axisCount()
+	if axis < 0 || int(axis) >= g.axisCount() {
+		return nil
+	}
+	return axisMappingInput{g: g, axis: int(axis)}
 }
 
-func (g *nativeGamepadImpl) isStandardButtonAvailableInOwnMapping(button gamepaddb.StandardButton) bool {
+func (g *nativeGamepadImpl) standardButtonInOwnMapping(button gamepaddb.StandardButton) mappingInput {
 	if !g.hasOwnStandardLayoutMapping() {
-		return false
+		return nil
 	}
-	return button >= 0 && int(button) < g.buttonCount()
+	if button < 0 || int(button) >= g.buttonCount() {
+		return nil
+	}
+	return buttonMappingInput{g: g, button: int(button)}
 }
 
 func (g *nativeGamepadImpl) update(gamepads *gamepads) error {

--- a/internal/gamepad/gamepad_linux.go
+++ b/internal/gamepad/gamepad_linux.go
@@ -423,12 +423,12 @@ func (*nativeGamepadImpl) hasOwnStandardLayoutMapping() bool {
 	return false
 }
 
-func (*nativeGamepadImpl) isStandardAxisAvailableInOwnMapping(axis gamepaddb.StandardAxis) bool {
-	return false
+func (g *nativeGamepadImpl) standardAxisInOwnMapping(axis gamepaddb.StandardAxis) mappingInput {
+	return nil
 }
 
-func (*nativeGamepadImpl) isStandardButtonAvailableInOwnMapping(button gamepaddb.StandardButton) bool {
-	return false
+func (g *nativeGamepadImpl) standardButtonInOwnMapping(button gamepaddb.StandardButton) mappingInput {
+	return nil
 }
 
 func (g *nativeGamepadImpl) axisCount() int {
@@ -457,8 +457,11 @@ func (g *nativeGamepadImpl) isButtonPressed(button int) bool {
 	return g.buttons[button]
 }
 
-func (*nativeGamepadImpl) buttonValue(button int) float64 {
-	panic("gamepad: buttonValue is not implemented")
+func (g *nativeGamepadImpl) buttonValue(button int) float64 {
+	if g.isButtonPressed(button) {
+		return 1
+	}
+	return 0
 }
 
 func (g *nativeGamepadImpl) hatState(hat int) int {

--- a/internal/gamepad/gamepad_nintendosdk.go
+++ b/internal/gamepad/gamepad_nintendosdk.go
@@ -118,14 +118,20 @@ func (g *nativeGamepadImpl) hasOwnStandardLayoutMapping() bool {
 	return g.standard
 }
 
-func (g *nativeGamepadImpl) isStandardAxisAvailableInOwnMapping(axis gamepaddb.StandardAxis) bool {
+func (g *nativeGamepadImpl) standardAxisInOwnMapping(axis gamepaddb.StandardAxis) mappingInput {
 	// TODO: Implement this on the C side.
-	return axis >= 0 && int(axis) < len(g.axisValues)
+	if axis < 0 || int(axis) >= len(g.axisValues) {
+		return nil
+	}
+	return axisMappingInput{g: g, axis: int(axis)}
 }
 
-func (g *nativeGamepadImpl) isStandardButtonAvailableInOwnMapping(button gamepaddb.StandardButton) bool {
+func (g *nativeGamepadImpl) standardButtonInOwnMapping(button gamepaddb.StandardButton) mappingInput {
 	// TODO: Implement this on the C side.
-	return button >= 0 && int(button) < len(g.buttonValues)
+	if button < 0 || int(button) >= len(g.buttonValues) {
+		return nil
+	}
+	return buttonMappingInput{g: g, button: int(button)}
 }
 
 func (g *nativeGamepadImpl) axisCount() int {

--- a/internal/gamepad/gamepad_null.go
+++ b/internal/gamepad/gamepad_null.go
@@ -46,12 +46,12 @@ func (*nativeGamepadImpl) hasOwnStandardLayoutMapping() bool {
 	return false
 }
 
-func (*nativeGamepadImpl) isStandardAxisAvailableInOwnMapping(axis gamepaddb.StandardAxis) bool {
-	return false
+func (*nativeGamepadImpl) standardAxisInOwnMapping(axis gamepaddb.StandardAxis) mappingInput {
+	return nil
 }
 
-func (*nativeGamepadImpl) isStandardButtonAvailableInOwnMapping(button gamepaddb.StandardButton) bool {
-	return false
+func (*nativeGamepadImpl) standardButtonInOwnMapping(button gamepaddb.StandardButton) mappingInput {
+	return nil
 }
 
 func (*nativeGamepadImpl) axisCount() int {
@@ -75,7 +75,7 @@ func (*nativeGamepadImpl) isButtonPressed(button int) bool {
 }
 
 func (*nativeGamepadImpl) buttonValue(button int) float64 {
-	panic("gamepad: buttonValue is not implemented")
+	return 0
 }
 
 func (*nativeGamepadImpl) hatState(hat int) int {

--- a/internal/gamepaddb/gamepaddb.go
+++ b/internal/gamepaddb/gamepaddb.go
@@ -519,11 +519,13 @@ func buttonValue(id string, button StandardButton, state GamepadState) float64 {
 	return 0
 }
 
-func IsButtonPressed(id string, button StandardButton, state GamepadState) bool {
-	// Use XInput's trigger dead zone.
-	// See https://source.chromium.org/chromium/chromium/src/+/main:device/gamepad/public/cpp/gamepad.h;l=22-23;drc=6997f8a177359bb99598988ed5e900841984d242
-	const threshold = 30.0 / 255.0
+// ButtonPressedThreshold represents the value up to which a button counts as not yet pressed.
+// This has been set to match XInput's trigger dead zone.
+// See https://source.chromium.org/chromium/chromium/src/+/main:device/gamepad/public/cpp/gamepad.h;l=22-23;drc=6997f8a177359bb99598988ed5e900841984d242
+// Note: should be used with >, not >=, comparisons.
+const ButtonPressedThreshold = 30.0 / 255.0
 
+func IsButtonPressed(id string, button StandardButton, state GamepadState) bool {
 	mappingsM.RLock()
 	defer mappingsM.RUnlock()
 
@@ -540,7 +542,7 @@ func IsButtonPressed(id string, button StandardButton, state GamepadState) bool 
 	switch mapping.Type {
 	case mappingTypeAxis:
 		v := buttonValue(id, button, state)
-		return v > threshold
+		return v > ButtonPressedThreshold
 	case mappingTypeButton:
 		return state.Button(mapping.Index)
 	case mappingTypeHat:


### PR DESCRIPTION
# What issue is this addressing?
Updates #2052

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
Refactors native standard layout so standard axes and buttons can be implemented using any of axes, buttons or hats.

This is required to be able to implement a native standard layout mapping for Linux, as e.g. shoulder buttons can be backed either by an analog or digital input.

Precedes https://github.com/hajimehoshi/ebiten/pull/2587