### PR TITLE
removeDuplicatedRegions: change from O((n+m)^2) to O(n*m + m^2).

### DIFF
--- a/internal/restorable/export_test.go
+++ b/internal/restorable/export_test.go
@@ -18,6 +18,6 @@ import (
 	"image"
 )
 
-func RemoveDuplicatedRegions(regions []image.Rectangle) int {
-	return removeDuplicatedRegions(regions)
+func RemoveDuplicatedRegions(regions []image.Rectangle, alreadyCheckedUntil int) int {
+	return removeDuplicatedRegions(regions, alreadyCheckedUntil)
 }

--- a/internal/restorable/rect_test.go
+++ b/internal/restorable/rect_test.go
@@ -37,8 +37,9 @@ func areEqualRectangles(a, b []image.Rectangle) bool {
 
 func TestRemoveDuplicatedRegions(t *testing.T) {
 	cases := []struct {
-		In  []image.Rectangle
-		Out []image.Rectangle
+		In                  []image.Rectangle
+		AlreadyCheckedUntil int
+		Out                 []image.Rectangle
 	}{
 		{
 			In:  nil,
@@ -117,10 +118,41 @@ func TestRemoveDuplicatedRegions(t *testing.T) {
 				image.Rect(0, 0, 5, 5),
 			},
 		},
+		{
+			In: []image.Rectangle{
+				image.Rect(0, 0, 1, 3),
+				image.Rect(0, 0, 2, 2),
+				image.Rect(0, 0, 3, 1),
+				image.Rect(0, 0, 4, 4),
+				image.Rect(0, 0, 5, 5),
+			},
+			// Only the last rectangle will be checked against the first four.
+			AlreadyCheckedUntil: 4,
+			Out: []image.Rectangle{
+				image.Rect(0, 0, 5, 5),
+			},
+		},
+		{
+			In: []image.Rectangle{
+				image.Rect(0, 0, 2, 2),
+				image.Rect(0, 0, 3, 1),
+				image.Rect(0, 0, 4, 4),
+				image.Rect(0, 0, 5, 5),
+				image.Rect(0, 0, 1, 3),
+			},
+			// Only the last rectangle will be checked against the first four.
+			AlreadyCheckedUntil: 4,
+			Out: []image.Rectangle{
+				image.Rect(0, 0, 2, 2),
+				image.Rect(0, 0, 3, 1),
+				image.Rect(0, 0, 4, 4),
+				image.Rect(0, 0, 5, 5),
+			},
+		},
 	}
 
 	for _, c := range cases {
-		n := restorable.RemoveDuplicatedRegions(c.In)
+		n := restorable.RemoveDuplicatedRegions(c.In, c.AlreadyCheckedUntil)
 		got := c.In[:n]
 		want := c.Out
 		if !areEqualRectangles(got, want) {


### PR DESCRIPTION
# What issue is this addressing?
Closes #2626

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

This speeds up AAAAXY loading on a Moto G7 Play from 52.27 seconds to 8.06 seconds.

The usual case of removeDuplicatedRegions is number of previous rectangles being big and number of new rectangles being small. As the function is always called after adding more rectangles, one can assume that the set of pre-existing rectangles has no rectangles containing other rectangles, and thus that one only needs to search for duplicates when one of the two rectangles is a newly added one.

When adding m rectangles to an already existing list of n rectangles, this PR changes the complexity from O((n+m)^2) to O(m * (n + m)) by assuming that the already existing rectangles in the list have no duplicates.

In particular, when adding a small amount of rectangles to a large amount, this changes complexity from quadratic to linear.

That seems especially to be the case for the call from makeStale which is called when uploading textures, which happens at AAAAXY's loading screen for image and font loading/precaching.

Tested on my Moto G7 Play.

Loading screen profile before:

![initial](https://user-images.githubusercontent.com/251568/230496765-f7b886f9-af0b-4c5d-9f3c-5e4fa337c52c.svg)

Loading screen profile after:

![fixed](https://user-images.githubusercontent.com/251568/230496805-c5e32c19-9258-49c8-800b-a3f0bc3b072d.svg)
