### PR TITLE
removeDuplicatedRegions: change from O((n+m)^2) to O(n*m + m^2).

### DIFF
--- a/internal/restorable/export_test.go
+++ b/internal/restorable/export_test.go
@@ -18,6 +18,6 @@ import (
 	"image"
 )
 
-func RemoveDuplicatedRegions(regions []image.Rectangle) int {
-	return removeDuplicatedRegions(regions)
+func AppendRegionRemovingDuplicates(regions *[]image.Rectangle, region image.Rectangle) {
+	appendRegionRemovingDuplicates(regions, region)
 }

--- a/internal/restorable/rect_test.go
+++ b/internal/restorable/rect_test.go
@@ -37,94 +37,129 @@ func areEqualRectangles(a, b []image.Rectangle) bool {
 
 func TestRemoveDuplicatedRegions(t *testing.T) {
 	cases := []struct {
-		In  []image.Rectangle
-		Out []image.Rectangle
+		Regions    []image.Rectangle
+		NewRegions []image.Rectangle
+		Expected   []image.Rectangle
 	}{
 		{
-			In:  nil,
-			Out: nil,
+			Regions:    nil,
+			NewRegions: nil,
+			Expected:   nil,
 		},
 		{
-			In: []image.Rectangle{
+			NewRegions: []image.Rectangle{
 				image.Rect(0, 0, 2, 2),
 			},
-			Out: []image.Rectangle{
+			Expected: []image.Rectangle{
 				image.Rect(0, 0, 2, 2),
 			},
 		},
 		{
-			In: []image.Rectangle{
+			NewRegions: []image.Rectangle{
 				image.Rect(0, 0, 2, 2),
 				image.Rect(0, 0, 1, 1),
 			},
-			Out: []image.Rectangle{
+			Expected: []image.Rectangle{
 				image.Rect(0, 0, 2, 2),
 			},
 		},
 		{
-			In: []image.Rectangle{
+			NewRegions: []image.Rectangle{
 				image.Rect(0, 0, 1, 1),
 				image.Rect(0, 0, 2, 2),
 			},
-			Out: []image.Rectangle{
+			Expected: []image.Rectangle{
 				image.Rect(0, 0, 2, 2),
 			},
 		},
 		{
-			In: []image.Rectangle{
+			NewRegions: []image.Rectangle{
 				image.Rect(0, 0, 1, 3),
 				image.Rect(0, 0, 2, 2),
 				image.Rect(0, 0, 3, 1),
 			},
-			Out: []image.Rectangle{
+			Expected: []image.Rectangle{
 				image.Rect(0, 0, 1, 3),
 				image.Rect(0, 0, 2, 2),
 				image.Rect(0, 0, 3, 1),
 			},
 		},
 		{
-			In: []image.Rectangle{
+			NewRegions: []image.Rectangle{
 				image.Rect(0, 0, 1, 3),
 				image.Rect(0, 0, 2, 2),
 				image.Rect(0, 0, 3, 1),
 				image.Rect(0, 0, 4, 4),
 			},
-			Out: []image.Rectangle{
+			Expected: []image.Rectangle{
 				image.Rect(0, 0, 4, 4),
 			},
 		},
 		{
-			In: []image.Rectangle{
+			NewRegions: []image.Rectangle{
 				image.Rect(0, 0, 1, 3),
 				image.Rect(0, 0, 2, 2),
 				image.Rect(0, 0, 3, 1),
 				image.Rect(0, 0, 4, 4),
 				image.Rect(1, 1, 2, 2),
 			},
-			Out: []image.Rectangle{
+			Expected: []image.Rectangle{
 				image.Rect(0, 0, 4, 4),
 			},
 		},
 		{
-			In: []image.Rectangle{
+			NewRegions: []image.Rectangle{
 				image.Rect(0, 0, 1, 3),
 				image.Rect(0, 0, 2, 2),
 				image.Rect(0, 0, 3, 1),
 				image.Rect(0, 0, 4, 4),
 				image.Rect(0, 0, 5, 5),
 			},
-			Out: []image.Rectangle{
+			Expected: []image.Rectangle{
+				image.Rect(0, 0, 5, 5),
+			},
+		},
+		{
+			Regions: []image.Rectangle{
+				image.Rect(0, 0, 1, 3),
+				image.Rect(0, 0, 2, 2),
+				image.Rect(0, 0, 3, 1),
+				image.Rect(0, 0, 4, 4),
+			},
+			NewRegions: []image.Rectangle{
+				image.Rect(0, 0, 5, 5),
+			},
+			Expected: []image.Rectangle{
+				image.Rect(0, 0, 5, 5),
+			},
+		},
+		{
+			Regions: []image.Rectangle{
+				image.Rect(0, 0, 2, 2),
+				image.Rect(0, 0, 3, 1),
+				image.Rect(0, 0, 4, 4),
+				image.Rect(0, 0, 5, 5),
+			},
+			NewRegions: []image.Rectangle{
+				image.Rect(0, 0, 1, 3),
+			},
+			Expected: []image.Rectangle{
+				image.Rect(0, 0, 2, 2),
+				image.Rect(0, 0, 3, 1),
+				image.Rect(0, 0, 4, 4),
 				image.Rect(0, 0, 5, 5),
 			},
 		},
 	}
 
 	for _, c := range cases {
-		n := restorable.RemoveDuplicatedRegions(c.In)
-		got := c.In[:n]
-		want := c.Out
+		got := c.Regions
+		for _, r := range c.NewRegions {
+			restorable.AppendRegionRemovingDuplicates(&got, r)
+		}
+		want := c.Expected
 		if !areEqualRectangles(got, want) {
-			t.Errorf("restorable.RemoveDuplicatedRegions(%#v): got: %#v, want: %#v", c.In, got, want)
+			t.Errorf("restorable.RemoveDuplicatedRegions(%#v): got: %#v, want: %#v", c.NewRegions, got, want)
 		}
 	}
 }


### PR DESCRIPTION
# What issue is this addressing?
Closes #2626

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
This is achieved by replacing the function by one that only adds a single new region, and only considers duplicates between the previously existing region and the one newly added one, thereby removing previously redundant checking of each previously existing region against each other.

This speeds up AAAAXY loading on a Moto G7 Play from 52.27 seconds to 8.15 seconds.

Same profiling info as for https://github.com/hajimehoshi/ebiten/pull/2627 applies here too - the new code doesn't appear in the profile graph at all.