### PR TITLE
Fix _GET_X_LPARAM and _GET_Y_LPARAM from api_windows.go

### DIFF
--- a/internal/goglfw/api_windows.go
+++ b/internal/goglfw/api_windows.go
@@ -367,7 +367,7 @@ type (
 )
 
 func _GET_X_LPARAM(lp _LPARAM) int {
-	return int(_LOWORD(uint32(lp)))
+	return int(int16(_LOWORD(uint32(lp))))
 }
 
 func _GET_XBUTTON_WPARAM(wParam _WPARAM) uint16 {
@@ -375,7 +375,7 @@ func _GET_XBUTTON_WPARAM(wParam _WPARAM) uint16 {
 }
 
 func _GET_Y_LPARAM(lp _LPARAM) int {
-	return int(_HIWORD(uint32(lp)))
+	return int(int16(_HIWORD(uint32(lp))))
 }
 
 func _HIWORD(dwValue uint32) uint16 {


### PR DESCRIPTION
Negative values should not disappear. For example, if _HIWORD returns 63000, then _GET_Y_LPARAM should return -2536, but now it returns 63000. This fixes that.

Here's how it's defined in windowsx.h:

`#define GET_X_LPARAM(lp)                        ((int)(short)LOWORD(lp))`
`#define GET_Y_LPARAM(lp)                        ((int)(short)HIWORD(lp))`

