### PR TITLE
Fix antialias region size

### DIFF
--- a/internal/ui/image.go
+++ b/internal/ui/image.go
@@ -382,14 +382,16 @@ func (i *bigOffscreenImage) drawTriangles(srcs [graphics.ShaderImageCount]*Image
 		vertices[idx+1] = (vertices[idx+1] - i.region.Y) * bigOffscreenScale
 	}
 
+	// Compute corners in dst coordinate space.
 	x0 := dstRegion.X
 	y0 := dstRegion.Y
 	x1 := dstRegion.X + dstRegion.Width
 	y1 := dstRegion.Y + dstRegion.Height
+	// Translate to i.region coordinate space, and clamp against region size.
 	x0 = max(x0-i.region.X, 0)
 	y0 = max(y0-i.region.Y, 0)
-	x1 = min(x1, i.region.X+i.region.Width)
-	y1 = min(y1, i.region.Y+i.region.Height)
+	x1 = min(x1-i.region.X, i.region.Width)
+	y1 = min(y1-i.region.Y, i.region.Height)
 	dstRegion = graphicsdriver.Region{
 		X:      x0 * bigOffscreenScale,
 		Y:      y0 * bigOffscreenScale,


### PR DESCRIPTION
# What issue is this addressing?
Closes #2679 

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Fixes coordinate transformation math on dstRegion.

Previous code had x1 and y1 shifted by exactly (i.region.X, i.region.Y), which allowed it to exceed the width and height of the destination image. iOS MTLDebugRenderCommandEncoder detects this issue and crashes.

No known test case for OpenGL or similar, as the rectangle is always strictly larger or equal to the correct rectangle.

It is POSSIBLE, but not reproduced, this this can in OpenGL cause DrawTriangles to draw on a different image than the destination image if they share an atlas. However, as this depends a lot on how the atlas is built, I am not sure if it can actually be triggered reliably, or even at all.