### PR TITLE
Make runes a parameter.

### DIFF
--- a/mobile/ebitenmobileview/input.go
+++ b/mobile/ebitenmobileview/input.go
@@ -27,7 +27,6 @@ type position struct {
 
 var (
 	keys    = map[ui.Key]struct{}{}
-	runes   []rune
 	touches = map[ui.TouchID]position{}
 )
 
@@ -35,7 +34,7 @@ var (
 	touchSlice []ui.TouchForInput
 )
 
-func updateInput() {
+func updateInput(runes []rune) {
 	touchSlice = touchSlice[:0]
 	for id, position := range touches {
 		touchSlice = append(touchSlice, ui.TouchForInput{

--- a/mobile/ebitenmobileview/input_android.go
+++ b/mobile/ebitenmobileview/input_android.go
@@ -123,10 +123,10 @@ func UpdateTouchesOnAndroid(action int, id int, x, y int) {
 	switch action {
 	case 0x00, 0x05, 0x02: // ACTION_DOWN, ACTION_POINTER_DOWN, ACTION_MOVE
 		touches[ui.TouchID(id)] = position{x, y}
-		updateInput()
+		updateInput(nil)
 	case 0x01, 0x06: // ACTION_UP, ACTION_POINTER_UP
 		delete(touches, ui.TouchID(id))
-		updateInput()
+		updateInput(nil)
 	}
 }
 
@@ -142,10 +142,11 @@ func OnKeyDownOnAndroid(keyCode int, unicodeChar int, source int, deviceID int) 
 	case source&sourceKeyboard == sourceKeyboard:
 		if key, ok := androidKeyToUIKey[keyCode]; ok {
 			keys[key] = struct{}{}
+			var runes []rune
 			if r := rune(unicodeChar); r != 0 && unicode.IsPrint(r) {
 				runes = []rune{r}
 			}
-			updateInput()
+			updateInput(runes)
 		}
 	}
 }
@@ -162,7 +163,7 @@ func OnKeyUpOnAndroid(keyCode int, source int, deviceID int) {
 	case source&sourceKeyboard == sourceKeyboard:
 		if key, ok := androidKeyToUIKey[keyCode]; ok {
 			delete(keys, key)
-			updateInput()
+			updateInput(nil)
 		}
 	}
 }

--- a/mobile/ebitenmobileview/input_ios.go
+++ b/mobile/ebitenmobileview/input_ios.go
@@ -49,14 +49,12 @@ func UpdateTouchesOnIOS(phase int, ptr int64, x, y int) {
 	case C.UITouchPhaseBegan, C.UITouchPhaseMoved, C.UITouchPhaseStationary:
 		id := getIDFromPtr(ptr)
 		touches[ui.TouchID(id)] = position{x, y}
-		runes = nil
-		updateInput()
+		updateInput(nil)
 	case C.UITouchPhaseEnded, C.UITouchPhaseCancelled:
 		id := getIDFromPtr(ptr)
 		delete(ptrToID, ptr)
 		delete(touches, ui.TouchID(id))
-		runes = nil
-		updateInput()
+		updateInput(nil)
 	default:
 		panic(fmt.Sprintf("ebitenmobileview: invalid phase: %d", phase))
 	}
@@ -68,7 +66,7 @@ func UpdatePressesOnIOS(phase int, keyCode int, keyString string) {
 		if key, ok := iosKeyToUIKey[keyCode]; ok {
 			keys[key] = struct{}{}
 		}
-		runes = nil
+		var runes []rune
 		if phase == C.UITouchPhaseBegan {
 			for _, r := range keyString {
 				if !unicode.IsPrint(r) {
@@ -77,13 +75,12 @@ func UpdatePressesOnIOS(phase int, keyCode int, keyString string) {
 				runes = append(runes, r)
 			}
 		}
-		updateInput()
+		updateInput(runes)
 	case C.UITouchPhaseEnded, C.UITouchPhaseCancelled:
 		if key, ok := iosKeyToUIKey[keyCode]; ok {
 			delete(keys, key)
 		}
-		runes = nil
-		updateInput()
+		updateInput(nil)
 	default:
 		panic(fmt.Sprintf("ebitenmobileview: invalid phase: %d", phase))
 	}


### PR DESCRIPTION
This prevents duplicate input characters due to concurrent touch events.

# What issue is this addressing?
Closes #2682

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
`updateInput` currently receives `runes` in a global variable as a hidden parameter. Some calls do not clear it though, but leave the previous value in it - in particular calls on behalf of touch or key release events.