### PR TITLE
Android: support keypress runes even for unmapped keys

### DIFF
--- a/mobile/ebitenmobileview/input_android.go
+++ b/mobile/ebitenmobileview/input_android.go
@@ -142,12 +142,12 @@ func OnKeyDownOnAndroid(keyCode int, unicodeChar int, source int, deviceID int) 
 	case source&sourceKeyboard == sourceKeyboard:
 		if key, ok := androidKeyToUIKey[keyCode]; ok {
 			keys[key] = struct{}{}
-			var runes []rune
-			if r := rune(unicodeChar); r != 0 && unicode.IsPrint(r) {
-				runes = []rune{r}
-			}
-			updateInput(runes)
 		}
+		var runes []rune
+		if r := rune(unicodeChar); r != 0 && unicode.IsPrint(r) {
+			runes = []rune{r}
+		}
+		updateInput(runes)
 	}
 }
 
@@ -163,8 +163,8 @@ func OnKeyUpOnAndroid(keyCode int, source int, deviceID int) {
 	case source&sourceKeyboard == sourceKeyboard:
 		if key, ok := androidKeyToUIKey[keyCode]; ok {
 			delete(keys, key)
-			updateInput(nil)
 		}
+		updateInput(nil)
 	}
 }
 


### PR DESCRIPTION
# What issue is this addressing?
Closes #2684

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
It makes it possible to still receives characters from a key that Ebitengine does not know about. This can be helpful with international text entry.