### PR TITLE
Correct iteration start button in gamepad example

### DIFF
--- a/examples/gamepad/main.go
+++ b/examples/gamepad/main.go
@@ -67,7 +67,7 @@ func (g *Game) Update() error {
 		}
 
 		maxButton := ebiten.GamepadButton(ebiten.GamepadButtonCount(id))
-		for b := ebiten.GamepadButton(id); b < maxButton; b++ {
+		for b := ebiten.GamepadButton(0); b < maxButton; b++ {
 			if ebiten.IsGamepadButtonPressed(id, b) {
 				g.pressedButtons[id] = append(g.pressedButtons[id], strconv.Itoa(int(b)))
 			}


### PR DESCRIPTION

# What issue is this addressing?

Start iterating at zero instead of gamepad id (which is usually 0).

## What _type_ of issue is this addressing?

bug

## What this PR does | solves

fixes small bug ;)
