### PR TITLE
internal/ui: show window after first draw on glfw

### DIFF
--- a/internal/ui/ui_glfw.go
+++ b/internal/ui/ui_glfw.go
@@ -1329,8 +1329,7 @@ func (u *UserInterface) update() (float64, float64, error) {
 	if u.bufferOnceSwapped {
 		var err error
 		u.showWindowOnce.Do(func() {
-			// Show the window after first buffer swap to avoid flash of white on Windows.
-			// On macOS this delay was already the behavior; it now the default for all glfw platforms.
+			// Show the window after first buffer swap to avoid flash of white especially on Windows.
 			if err = u.window.Show(); err != nil {
 				return
 			}


### PR DESCRIPTION
# What issue is this addressing?

#2725

## What type of issue is this addressing?

Issue #2725 is written as a feature request but it looks like that request was only made because the feature would mitigate a bug it describes (white flash of window background before content is shown on Windows). This PR removes the need for the feature by resolving that bug.

## What this PR does | solves

The PR delays window.Show until after the first buffer swap, which was already the way it was done under macOS. This avoids the window appearing before its contents have been initialized by the user.