### PR TITLE
add Image.SubImageInto method

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -4582,3 +4582,29 @@ func TestImageDrawImageAfterDeallocation(t *testing.T) {
 		}
 	}
 }
+
+func TestSubImageIntoZeroAlloc(t *testing.T) {
+	i := ebiten.NewImage(1, 1)
+	var s ebiten.Image
+	allocs := testing.AllocsPerRun(1, func() {
+		i.SubImageInto(&s, image.Rect(0, 0, 1, 1))
+	})
+	if allocs != 0 {
+		t.Fatalf("have %d allocs, wanted 0", int(allocs))
+	}
+}
+
+func BenchmarkSubImageInto(b *testing.B) {
+	img := ebiten.NewImage(1, 1)
+	var subimg ebiten.Image
+	for i := 0; i < b.N; i++ {
+		img.SubImageInto(&subimg, image.Rect(0, 0, 1, 1))
+	}
+}
+
+func BenchmarkSubImage(b *testing.B) {
+	img := ebiten.NewImage(1, 1)
+	for i := 0; i < b.N; i++ {
+		img.SubImage(image.Rect(0, 0, 1, 1))
+	}
+}


### PR DESCRIPTION
Instead of allocating the result on heap for the user, allow the caller side to decide whether it should be heap-allocated or stack-allocated.

This new method allows us to have a zero-alloc SubImage routine for the use cases where we don't want to make an extra allocation.

The performance difference is measurable (comparison is done with benchstat):

	name             old time/op    new time/op    delta
	SubImage-12     203ns ± 2%      33ns ± 2%   -83.91%  (p=0.000 n=20+19)

	name             old alloc/op   new alloc/op   delta
	SubImage-12      112B ± 0%        0B       -100.00%  (p=0.000 n=20+20)

Using SubImage is `~203ns`, SubImageInto is `~33ns`. SubImage does 1 allocation, SubImageInto does none.

SubImage is rewritten in a way to avoid the code duplication. It should work identically to the previous contract (it returns nil if `i` is disposed, etc.)

Fixes #2902

<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?

https://github.com/hajimehoshi/ebiten/issues/2902

## What _type_ of issue is this addressing?

Feature.

## What this PR does | solves

It introduces a more efficient way of making subimages.
