### PR TITLE
WIP: OpenGL: use a single framebuffer instead of 1 per texture

### DIFF
--- a/internal/graphicsdriver/opengl/graphics.go
+++ b/internal/graphicsdriver/opengl/graphics.go
@@ -207,7 +207,14 @@ func (g *Graphics) DrawTriangles(dstID graphicsdriver.ImageID, srcIDs [graphics.
 
 	g.drawCalled = true
 
-	if err := destination.setViewport(); err != nil {
+	if err := destination.ensureFramebuffer(); err != nil {
+		return err
+	}
+	g.context.bindFramebuffer(destination.framebuffer.native)
+	g.context.ctx.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, uint32(destination.texture), 0)
+
+	w, h := destination.framebufferSize()
+	if err := destination.setViewport(w, h); err != nil {
 		return err
 	}
 	g.context.blend(blend)

--- a/internal/graphicsdriver/opengl/graphics.go
+++ b/internal/graphicsdriver/opengl/graphics.go
@@ -122,10 +122,11 @@ func (g *Graphics) genNextShaderID() graphicsdriver.ShaderID {
 
 func (g *Graphics) NewImage(width, height int) (graphicsdriver.Image, error) {
 	i := &Image{
-		id:       g.genNextImageID(),
-		graphics: g,
-		width:    width,
-		height:   height,
+		id:          g.genNextImageID(),
+		graphics:    g,
+		framebuffer: invalidFramebuffer,
+		width:       width,
+		height:      height,
 	}
 	w := graphics.InternalImageSize(width)
 	h := graphics.InternalImageSize(height)
@@ -210,7 +211,7 @@ func (g *Graphics) DrawTriangles(dstID graphicsdriver.ImageID, srcIDs [graphics.
 	if err := destination.ensureFramebuffer(); err != nil {
 		return err
 	}
-	g.context.bindFramebuffer(destination.framebuffer.native)
+	g.context.bindFramebuffer(destination.framebuffer)
 	g.context.ctx.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, uint32(destination.texture), 0)
 
 	w, h := destination.framebufferSize()

--- a/internal/graphicsdriver/opengl/graphics.go
+++ b/internal/graphicsdriver/opengl/graphics.go
@@ -211,6 +211,7 @@ func (g *Graphics) DrawTriangles(dstID graphicsdriver.ImageID, srcIDs [graphics.
 	if err := destination.ensureFramebuffer(); err != nil {
 		return err
 	}
+
 	g.context.bindFramebuffer(destination.framebuffer)
 	g.context.ctx.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, uint32(destination.texture), 0)
 

--- a/internal/graphicsdriver/opengl/image.go
+++ b/internal/graphicsdriver/opengl/image.go
@@ -37,7 +37,6 @@ type Image struct {
 
 // framebuffer is a wrapper of OpenGL's framebuffer.
 type framebuffer struct {
-	graphics *Graphics
 	native   framebufferNative
 	width    int
 	height   int
@@ -48,9 +47,6 @@ func (i *Image) ID() graphicsdriver.ImageID {
 }
 
 func (i *Image) Dispose() {
-	if i.framebuffer != nil {
-		i.graphics.context.deleteFramebuffer(i.framebuffer.native)
-	}
 	if i.texture != 0 {
 		i.graphics.context.deleteTexture(i.texture)
 	}
@@ -61,11 +57,8 @@ func (i *Image) Dispose() {
 	i.graphics.removeImage(i)
 }
 
-func (i *Image) setViewport() error {
-	if err := i.ensureFramebuffer(); err != nil {
-		return err
-	}
-	i.graphics.context.setViewport(i.framebuffer)
+func (i *Image) setViewport(w, h int) error {
+	i.graphics.context.setViewport(w, h, i.screen)
 	return nil
 }
 

--- a/internal/graphicsdriver/opengl/image.go
+++ b/internal/graphicsdriver/opengl/image.go
@@ -29,17 +29,10 @@ type Image struct {
 	graphics    *Graphics
 	texture     textureNative
 	stencil     renderbufferNative
-	framebuffer *framebuffer
+	framebuffer framebufferNative
 	width       int
 	height      int
 	screen      bool
-}
-
-// framebuffer is a wrapper of OpenGL's framebuffer.
-type framebuffer struct {
-	native   framebufferNative
-	width    int
-	height   int
 }
 
 func (i *Image) ID() graphicsdriver.ImageID {
@@ -85,13 +78,13 @@ func (i *Image) framebufferSize() (int, int) {
 }
 
 func (i *Image) ensureFramebuffer() error {
-	if i.framebuffer != nil {
+	if i.framebuffer != invalidFramebuffer {
 		return nil
 	}
 
 	w, h := i.framebufferSize()
 	if i.screen {
-		i.framebuffer = i.graphics.context.newScreenFramebuffer(w, h)
+		i.framebuffer = i.graphics.context.screenFramebuffer
 		return nil
 	}
 	f, err := i.graphics.context.newFramebuffer(i.texture, w, h)
@@ -117,7 +110,7 @@ func (i *Image) ensureStencilBuffer() error {
 	}
 	i.stencil = r
 
-	if err := i.graphics.context.bindStencilBuffer(i.framebuffer.native, i.stencil); err != nil {
+	if err := i.graphics.context.bindStencilBuffer(i.framebuffer, i.stencil); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?

No associated issue yet, related to: https://github.com/hajimehoshi/ebiten/issues/2930 and https://github.com/hajimehoshi/ebiten/pull/2953

## What _type_ of issue is this addressing?

Refactorization

## What this PR does | solves

This PR uses a single framebuffer instead of creating a new one for each isolated texture for OpenGL.
This is a necessary step in order to introduce MRT, since a single framebuffer should be bound (itself containing the multiple destinations textures) for the MRT draw call.

Since a framebuffer represents a logical object, that is a group of buffers in openGL, it is not necessary to mark it with a size or create one for each texture, so it also should ease the internal logic hopefully!

Notes:
- Tested on windows desktop opengl + webgl
- No performance differences observed on my current project
- Setting this variable to 0, reproduces the previous behaviour of creating multiple framebuffers: https://github.com/hajimehoshi/ebiten/pull/2959/files#diff-2b469a3c6c95206c0ebd80925ccecd6ee726289212b1585da65c9043a3731b7aR324
- The `DeleteFramebuffer` function has been removed as there shouldn't be any need to delete one, since we want to control them to be exactly 2

Edit: It's actually more recommended to swap framebuffers, instead of changing its state every frame (its color attachments). Also, I realized manipulating attachments this way introduced some complexity, and MRT can be introduced without this by using a dedicated framebuffer.

