### PR TITLE
feat: allow reuse canvas

### DIFF
--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -489,7 +489,12 @@ func (u *UserInterface) init() error {
 	meta.Set("content", "width=device-width, initial-scale=1")
 	document.Get("head").Call("appendChild", meta)
 
-	canvas = document.Call("createElement", "canvas")
+	// Select the first available canvas, otherwise create one.
+	// https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector
+	canvas = document.Call("querySelector", "canvas")
+	if canvas.Equal(js.Null()) {
+		canvas = document.Call("createElement", "canvas")
+	}
 	canvas.Set("width", 16)
 	canvas.Set("height", 16)
 

--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -489,11 +489,12 @@ func (u *UserInterface) init() error {
 	meta.Set("content", "width=device-width, initial-scale=1")
 	document.Get("head").Call("appendChild", meta)
 
-	// Select the first available canvas, otherwise create one.
+	// Select the first available canvas with id "gocanvas", otherwise create one.
 	// https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector
-	canvas = document.Call("querySelector", "canvas")
+	canvas = document.Call("querySelector", "#gocanvas")
 	if canvas.Equal(js.Null()) {
 		canvas = document.Call("createElement", "canvas")
+		canvas.Call("setAttribute", "id", "gocanvas")
 	}
 	canvas.Set("width", 16)
 	canvas.Set("height", 16)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->
Closes https://github.com/hajimehoshi/ebiten/issues/3017

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
<!-- Please be as descriptive as possible -->
First attempts to select a `canvas` element with `id="gocanvas"`, if one does not exist, then it is created.

This allows developers better control over the placement and sizing of the canvas element on their HTML pages.