### PR TITLE
internal/ui: crash by dropping an HTML element onto the canvas

### DIFF
--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -702,7 +702,6 @@ func (u *UserInterface) setCanvasEventHandlers(v js.Value) {
 	}))
 }
 
-// appendDroppedFiles will only take the first file, all other files that was drop will get thrown
 func (u *UserInterface) appendDroppedFiles(data js.Value) {
 	u.dropFileM.Lock()
 	defer u.dropFileM.Unlock()
@@ -712,21 +711,16 @@ func (u *UserInterface) appendDroppedFiles(data js.Value) {
 		return
 	}
 
-	var files []*file.FileEntryFS
+loop:
 	for i := 0; i < items.Length(); i++ {
 		kind := items.Index(i).Get("kind").String()
 		switch kind {
 		case "file":
 			fs := items.Index(i).Call("webkitGetAsEntry").Get("filesystem").Get("root")
-			files = append(files, file.NewFileEntryFS(fs))
+			u.inputState.DroppedFiles = file.NewFileEntryFS(fs)
+			break loop
 		}
 	}
-
-	if len(files) <= 0 {
-		return
-	}
-
-	u.inputState.DroppedFiles = files[0]
 }
 
 func (u *UserInterface) forceUpdateOnMinimumFPSMode() {

--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -705,11 +705,7 @@ func (u *UserInterface) setCanvasEventHandlers(v js.Value) {
 func (u *UserInterface) appendDroppedFiles(data js.Value) {
 	u.dropFileM.Lock()
 	defer u.dropFileM.Unlock()
-
 	items := data.Get("items")
-	if items.Length() <= 0 {
-		return
-	}
 
 	for i := 0; i < items.Length(); i++ {
 		kind := items.Index(i).Get("kind").String()

--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -711,14 +711,13 @@ func (u *UserInterface) appendDroppedFiles(data js.Value) {
 		return
 	}
 
-loop:
 	for i := 0; i < items.Length(); i++ {
 		kind := items.Index(i).Get("kind").String()
 		switch kind {
 		case "file":
 			fs := items.Index(i).Call("webkitGetAsEntry").Get("filesystem").Get("root")
 			u.inputState.DroppedFiles = file.NewFileEntryFS(fs)
-			break loop
+			return
 		}
 	}
 }


### PR DESCRIPTION

# What issue is this addressing?
[internal/ui: crash by dropping an HTML element onto the canvas](https://github.com/hajimehoshi/ebiten/issues/3043)

## What _type_ of issue is this addressing?
The application crashes when an HTML element is dropped onto the canvas.

## What this PR does | solves
This pull request addresses the crash by implementing the following:
- Loops through all dropped items
- Only handles items with the "file" kind
- Ignores other types of dropped elements, preventing the crash

## Suggesting for future improvements
   - Convert `DroppedFiles` to an array to handle multiple file drops
   - Implement handling for all types of dropped items under the switch case

