### PR TITLE
internal/ui: bug fix: adjustWindowPosition ignores decorated state

### DIFF
--- a/internal/ui/ui_windows.go
+++ b/internal/ui/ui_windows.go
@@ -122,12 +122,18 @@ func (u *UserInterface) adjustWindowPosition(x, y int, monitor *Monitor) (int, i
 	if x < mx {
 		x = mx
 	}
-	t, err := _GetSystemMetrics(_SM_CYCAPTION)
-	if err != nil {
-		panic(err)
+
+	yOffset := 0
+	decorated, err := u.window.GetAttrib(glfw.Decorated)
+	if err != nil || decorated != glfw.False {
+		captionHeight, err := _GetSystemMetrics(_SM_CYCAPTION)
+		if err != nil {
+			panic(err)
+		}
+		yOffset = int(captionHeight)
 	}
-	if y < my+int(t) {
-		y = my + int(t)
+	if y < my+yOffset {
+		y = my + yOffset
 	}
 	return x, y
 }


### PR DESCRIPTION
fix #3118

Tested on win11, but I'm not sure if my implementation/code style ok.
Feel free to scrap it.

# What issue is this addressing?
Closes #3118

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Fixes #3118
