### PR TITLE
Fixes DeleteVertexArrays removing entry from textures in webgl driver

### DIFF
--- a/internal/graphicsdriver/opengl/gl/default_js.go
+++ b/internal/graphicsdriver/opengl/gl/default_js.go
@@ -367,7 +367,7 @@ func (c *defaultContext) DeleteTexture(texture uint32) {
 
 func (c *defaultContext) DeleteVertexArray(array uint32) {
 	c.fnDeleteVertexArray.Invoke(c.vertexArrays.get(array))
-	c.textures.delete(array)
+	c.vertexArrays.delete(array)
 }
 
 func (c *defaultContext) Disable(cap uint32) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->
Unsure if this is connected with any existing issues.

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
This is just what appears to be a typo in the WebGL driver that is deleting the mapping between a uint32 ID and a JavaScript value  for vertexArrays from the value store for the textures instead. This seems like it would potentially cause a crash if the numbers aligned.

I'm not sure exactly how to test this! I don't believe anything would happen to the vertexArrays lookups other than the map taking up a small amount more space, but if a live texture has the same ID as a deleted vertex array, I believe the map lookup would panic and crash.

