### PR TITLE
Fix gomobile toolchain bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *~
 *.aar
 *.apk
-*.exe
 *.tar.gz
 .idea
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 *.aar
 *.apk
+*.exe
 *.tar.gz
 .idea
 .vscode

--- a/cmd/ebitenmobile/gomobile.go
+++ b/cmd/ebitenmobile/gomobile.go
@@ -166,11 +166,11 @@ import (
 	// runtime.Version() is the current executing Go version. For example, this is the version of the toolchain directive in go.mod.
 	// This might differ from the Go command version under the temporary directory.
 	// To avoid the version mismatch, set the toolchain explicitly (#3086).
-	toolchainVersion, err := toolchainParameter()
+	t, err := toolchainParameter()
 	if err != nil {
 		return tmp, err
 	}
-	if err := runGo("mod", "edit", "-toolchain="+toolchainVersion); err != nil {
+	if err := runGo("mod", "edit", "-toolchain="+t); err != nil {
 		return tmp, err
 	}
 	if err := runGo("mod", "tidy"); err != nil {
@@ -221,11 +221,11 @@ import (
 func toolchainParameter() (string, error) {
 	pattern := regexp.MustCompile(`\bgo\d+\.\d+(\.\d+)?`)
 	rawVersion := runtime.Version()
-	results := pattern.FindStringSubmatch(rawVersion)
-	if len(results ) < 1 {
+	m := pattern.FindStringSubmatch(rawVersion)
+	if len(m) < 1 {
 		return "", errors.New("runtime.Version() regex did not capture any results!")
 	}
-	return results[0], nil
+	return m[0], nil
 }
 
 func gomobileHash() (string, error) {

--- a/cmd/ebitenmobile/gomobile.go
+++ b/cmd/ebitenmobile/gomobile.go
@@ -219,10 +219,10 @@ func getToolchainParameter() string {
 	rawVersion := runtime.Version()
 	allIndexes := pattern.FindAllSubmatchIndex([]byte(rawVersion), -1)
 	if len(allIndexes) < 1 {
-		panic("runtime.Version() did not match expected format!")
+		panic("runtime.Version() regex did not capture any results!")
 	}
 	if len(allIndexes[0]) < 2 {
-		panic("runtime.Version() did not match expected format!")
+		panic("runtime.Version() regex captured a result but didn't return 2 indexes!")
 	}
 	return rawVersion[allIndexes[0][0]:allIndexes[0][1]]
 }

--- a/cmd/ebitenmobile/gomobile.go
+++ b/cmd/ebitenmobile/gomobile.go
@@ -219,7 +219,7 @@ import (
 }
 
 func toolchainParameter() (string, error) {
-	pattern := regexp.MustCompile("\\bgo\\d+\\.\\d+(\\.\\d+)?")
+	pattern := regexp.MustCompile(`\bgo\d+\.\d+(\.\d+)?`)
 	rawVersion := runtime.Version()
 	results := pattern.FindStringSubmatch(rawVersion)
 	if len(results ) < 1 {

--- a/cmd/ebitenmobile/gomobile.go
+++ b/cmd/ebitenmobile/gomobile.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	_ "embed"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -222,8 +221,8 @@ func toolchainParameter() (string, error) {
 	pattern := regexp.MustCompile(`\bgo\d+\.\d+(\.\d+)?`)
 	rawVersion := runtime.Version()
 	m := pattern.FindStringSubmatch(rawVersion)
-	if len(m) < 1 {
-		return "", errors.New("runtime.Version() regex did not capture any results!")
+	if len(m) == 0 {
+		return "", fmt.Errorf("ebitenmobile: unexpected version: %s", rawVersion)
 	}
 	return m[0], nil
 }

--- a/cmd/ebitenmobile/gomobile.go
+++ b/cmd/ebitenmobile/gomobile.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"strings"
 
 	// Add a dependency on gomobile in order to get the version via debug.ReadBuildInfo().
 	_ "github.com/ebitengine/gomobile/geom"
@@ -164,7 +165,8 @@ import (
 	// runtime.Version() is the current executing Go version. For example, this is the version of the toolchain directive in go.mod.
 	// This might differ from the Go command version under the temporary directory.
 	// To avoid the version mismatch, set the toolchain explicitly (#3086).
-	if err := runGo("mod", "edit", "-toolchain="+runtime.Version()); err != nil {
+	toolchainVersion := strings.Split(runtime.Version(), " ")[0]
+	if err := runGo("mod", "edit", "-toolchain="+toolchainVersion); err != nil {
 		return tmp, err
 	}
 	if err := runGo("mod", "tidy"); err != nil {

--- a/cmd/ebitenmobile/gomobile.go
+++ b/cmd/ebitenmobile/gomobile.go
@@ -165,7 +165,7 @@ import (
 	// runtime.Version() is the current executing Go version. For example, this is the version of the toolchain directive in go.mod.
 	// This might differ from the Go command version under the temporary directory.
 	// To avoid the version mismatch, set the toolchain explicitly (#3086).
-	toolchainVersion := strings.Split(runtime.Version(), " ")[0]
+	toolchainVersion, _, _ := strings.Cut(runtime.Version(), " ")
 	if err := runGo("mod", "edit", "-toolchain="+toolchainVersion); err != nil {
 		return tmp, err
 	}


### PR DESCRIPTION
This PR solves:

#3128

The reason this happens is that runtime.Version() returns this value when loopvar variable is set:

"go1.23.2 X:loopvar"