### PR TITLE
Add a debug.IsDebug check before splitting strings

### DIFF
--- a/internal/graphicscommand/commandqueue.go
+++ b/internal/graphicscommand/commandqueue.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"image"
 	"math"
-
 	"strings"
 	"sync"
 	"sync/atomic"

--- a/internal/graphicscommand/commandqueue.go
+++ b/internal/graphicscommand/commandqueue.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"image"
 	"math"
+
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -305,14 +306,16 @@ func (q *commandQueue) flush(graphicsDriver graphicsdriver.Graphics, endFrame bo
 			if err := c.Exec(q, graphicsDriver, indexOffset); err != nil {
 				return err
 			}
-			str := c.String()
-			for {
-				head, tail, ok := strings.Cut(str, "\n")
-				logger.FrameLogf("  %s\n", head)
-				if !ok {
-					break
+			if debug.IsDebug {
+				str := c.String()
+				for {
+					head, tail, ok := strings.Cut(str, "\n")
+					logger.FrameLogf("  %s\n", head)
+					if !ok {
+						break
+					}
+					str = tail
 				}
-				str = tail
 			}
 			// TODO: indexOffset should be reset if the command type is different
 			// from the previous one. This fix is needed when another drawing command is


### PR DESCRIPTION
# What issue is this addressing?
--

## What _type_ of issue is this addressing?
feature

## What this PR does | solves

Since `debug.IsDebug` is a constant, by putting the `strings.Cut` calls inside the check this makes the `(*commandqueue).flush` method faster when Ebitengine is compiled without the `debug` build tag.

Without the `if debug.IsDebug` check, unnecessary allocations occur (since the logger is a noop logger when debug is disabled):
![Screenshot_20241018_084146](https://github.com/user-attachments/assets/01840b2b-e7b0-46e7-a3ef-6f8f5aa18f82)

GC Details after the change:
![Screenshot_20241018_084204](https://github.com/user-attachments/assets/1216b2d2-a0b6-425a-a766-76558c0dddd2)

This happens because Go knows that IsDebug is a constant (and the compiler will optimize this away on production builds).