### PR TITLE
issue-#3121, monitor-switching-issue-solution

### DIFF
--- a/image.go
+++ b/image.go
@@ -1225,12 +1225,16 @@ func newImage(bounds image.Rectangle, imageType atlas.ImageType) *Image {
 	}
 
 	width, height := bounds.Dx(), bounds.Dy()
-	if width <= 0 {
-		panic(fmt.Sprintf("ebiten: width at NewImage must be positive but %d", width))
-	}
-	if height <= 0 {
-		panic(fmt.Sprintf("ebiten: height at NewImage must be positive but %d", height))
-	}
+	// if width <= 0 {
+	// 	panic(fmt.Sprintf("ebiten: width at NewImage must be positive but %d", width))
+	// }
+	// if height <= 0 {
+	// 	panic(fmt.Sprintf("ebiten: height at NewImage must be positive but %d", height))
+	// }
+	if width <= 0 || height <= 0 {
+        fmt.Printf("Warning: Received invalid dimensions (width=%d, height=%d). Setting default values.", width, height)
+        width, height = 100, 100
+    }
 
 	i := &Image{
 		image:  ui.Get().NewImage(width, height, imageType),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
Closes #3121 

## What _type_ of issue is this addressing?
bug fix

## What this PR does | solves
This PR will handle the case when the user moves the game window in the external monitor on macOS. Then while moving application crashes because the window size becomes zero while moving and the code panics. I have handled it by adding some value to width and height such that while moving code doesn't panic and the window moves smoothly to an external monitor.
