### PR TITLE
clarify the same images size rule for DrawTrianglesShaderOptions

### DIFF
--- a/image.go
+++ b/image.go
@@ -638,7 +638,8 @@ type DrawTrianglesShaderOptions struct {
 	Uniforms map[string]any
 
 	// Images is a set of the source images.
-	// All the images' sizes must be the same.
+	// In texel mode, all the image sizes must be the same.
+	// The pixels mode allows images of different sizes.
 	Images [4]*Image
 
 	// FillRule indicates the rule how an overlapped region is rendered.

--- a/image.go
+++ b/image.go
@@ -638,8 +638,8 @@ type DrawTrianglesShaderOptions struct {
 	Uniforms map[string]any
 
 	// Images is a set of the source images.
-	// In texel mode, all the image sizes must be the same.
-	// The pixels mode allows images of different sizes.
+	// In the texel mode, all the image sizes must be the same.
+	// The pixel mode allows images of different sizes.
 	Images [4]*Image
 
 	// FillRule indicates the rule how an overlapped region is rendered.


### PR DESCRIPTION
Since it's not allowed to have differently-sized images for DrawTrianglesShaderOptions in pixels mode, the comment should be updated.

# What issue is this addressing?

None

## What _type_ of issue is this addressing?

It's just a comment update.

## What this PR does | solves

Makes the engine's feature more apparent, instead of stating that doing something is impossible while it is possible.
