### PR TITLE
Fixed typo in comment

### DIFF
--- a/window.go
+++ b/window.go
@@ -174,7 +174,7 @@ func initializeWindowPositionIfNeeded(width, height int) {
 // WindowSize returns the window size on desktops.
 // WindowSize returns (0, 0) on other environments.
 //
-// Even if the application is in fullscreen mode, WindowSize returns the original window size
+// Even if the application is in fullscreen mode, WindowSize returns the original window size.
 // If you need the fullscreen dimensions, see Monitor().Size() instead.
 //
 // WindowSize is concurrent-safe.


### PR DESCRIPTION
Added a period to the function description, making it easier to read in the IDE hover tooptip.

# What issue is this addressing?
Trivial fix, no issue

## What _type_ of issue is this addressing?
Clarity of code comments

## What this PR does | solves
On hover tooltip, the added period makes it more clear
`WindowSize returns the original window size If you need the fullscreen dimensions, see Monitor().Size() instead.`

`WindowSize returns the original window size.  If you need the fullscreen dimensions, see Monitor().Size() instead.`
