### PR TITLE
audio/wav: accept more audio formats 24bit

### DIFF
--- a/audio/audio.go
+++ b/audio/audio.go
@@ -345,7 +345,7 @@ type Player struct {
 // A Player for 16bit integer must be used with 16bit integer version of audio APIs, like vorbis.DecodeWithoutResampling or audio.NewInfiniteLoop, not or vorbis.DecodeF32 or audio.NewInfiniteLoopF32.
 func (c *Context) NewPlayer(src io.Reader) (*Player, error) {
 	_, seekable := src.(io.Seeker)
-	f32Src := convert.NewFloat32BytesReadSeekerFromVariableIntBytesReader(src, 2)
+	f32Src := convert.NewFloat32BytesReadSeekerFromIntBytesReader(src, 2, true)
 	pi, err := c.playerFactory.newPlayer(c, f32Src, seekable, src, bitDepthInBytesFloat32)
 	if err != nil {
 		return nil, err

--- a/audio/audio.go
+++ b/audio/audio.go
@@ -345,7 +345,7 @@ type Player struct {
 // A Player for 16bit integer must be used with 16bit integer version of audio APIs, like vorbis.DecodeWithoutResampling or audio.NewInfiniteLoop, not or vorbis.DecodeF32 or audio.NewInfiniteLoopF32.
 func (c *Context) NewPlayer(src io.Reader) (*Player, error) {
 	_, seekable := src.(io.Seeker)
-	f32Src := convert.NewFloat32BytesReaderFromInt16BytesReader(src)
+	f32Src := convert.NewFloat32BytesReadSeekerFromVariableIntBytesReader(src, 2)
 	pi, err := c.playerFactory.newPlayer(c, f32Src, seekable, src, bitDepthInBytesFloat32)
 	if err != nil {
 		return nil, err

--- a/audio/internal/convert/float32.go
+++ b/audio/internal/convert/float32.go
@@ -50,9 +50,13 @@ func (r *float32BytesReader) asFloat32(buf []byte) float32 {
 		var iVal int32
 		for s := 0; s < r.numBytes; s++ {
 			b := buf[s]
+			// In order to line up the high bit/sign bit of the integer we are decoding
+			// with the high bit if the int32, we need to move it (4 - r.numBytes) bytes left.
+			// The high bits need to line up for the sign to work correctly.
 			iVal |= int32(b) << (8 * (s + (4 - r.numBytes)))
-
 		}
+		// After moving the decoded int left by (4 - r.numBytes) bytes, it is now too large
+		// and it needs to be divided by 2^8*(4 - r.numBytes).
 		iVal /= 1 >> (8 * (4 - r.numBytes))
 		v := float32(iVal) / float32((int32(1) << (r.numBytes*8 - 1)))
 		return v

--- a/audio/internal/convert/float32.go
+++ b/audio/internal/convert/float32.go
@@ -53,7 +53,7 @@ func (r *float32BytesReader) asFloat32(buf []byte) float32 {
 			iVal |= int32(b) << (8 * (s + (4 - r.numBytes)))
 
 		}
-		iVal = iVal / 1 >> (8 * (4 - r.numBytes))
+		iVal /= 1 >> (8 * (4 - r.numBytes))
 		v := float32(iVal) / float32((int32(1) << (r.numBytes*8 - 1)))
 		return v
 	}

--- a/audio/internal/convert/float32.go
+++ b/audio/internal/convert/float32.go
@@ -29,21 +29,19 @@ type float32BytesReaderVariable struct {
 	iBuf     []byte
 }
 
-func NewFloat32BytesReadSeekerFromVariableIntBytesReader(r io.Reader, numBytes int) io.Reader {
+func NewFloat32BytesReadSeekerFromIntBytesReader(r io.Reader, numBytes int, signed bool) io.Reader {
 	return &float32BytesReaderVariable{
 		r:        r,
 		numBytes: numBytes,
-		// The spec has 1-8 bits as unsigned integers, 9 or more as signed
-		signed: numBytes > 1,
+		signed:   signed,
 	}
 }
 
-func NewFloat32BytesReadSeekerFromVariableIntBytesReadSeeker(r io.ReadSeeker, numBytes int) io.ReadSeeker {
+func NewFloat32BytesReadSeekerFromIntBytesReadSeeker(r io.ReadSeeker, numBytes int, signed bool) io.ReadSeeker {
 	return &float32BytesReaderVariable{
 		r:        r,
 		numBytes: numBytes,
-		// The spec has 1-8 bits as unsigned integers, 9 or more as signed
-		signed: numBytes > 1,
+		signed:   signed,
 	}
 }
 

--- a/audio/internal/convert/float32.go
+++ b/audio/internal/convert/float32.go
@@ -48,33 +48,33 @@ func NewFloat32BytesReadSeekerFromIntBytesReadSeeker(r io.ReadSeeker, numBytes i
 func (r *float32BytesReader) asFloat32(buf []byte) float32 {
 	if r.signed {
 
-		var rBig int32
+		var iVal int32
 		for s := 0; s < r.numBytes; s++ {
 			b := buf[s]
-			rBig |= int32(b) << (8 * (s + (4 - r.numBytes)))
+			iVal |= int32(b) << (8 * (s + (4 - r.numBytes)))
 
 		}
-		rBig = rBig / 1 >> (8 * (4 - r.numBytes))
-		v := float32(rBig) / float32((int32(1) << (r.numBytes*8 - 1)))
+		iVal = iVal / 1 >> (8 * (4 - r.numBytes))
+		v := float32(iVal) / float32((int32(1) << (r.numBytes*8 - 1)))
 		return v
 	}
 	if r.numBytes == 1 {
 		// This converts the byte into a int16, and then into a float32
 		// This gives slightly different floats than converting from byte to float32 directly
 		// but is kept this way as that is what the package used to do
-		rBig := int16(int(buf[0])*0x101 - (1 << 15))
-		v := float32(rBig) / float32((int32(1) << (2*8 - 1)))
+		iVal := int16(int(buf[0])*0x101 - (1 << 15))
+		v := float32(iVal) / float32((int32(1) << (2*8 - 1)))
 		return v
 	}
 
-	var rBig int32
+	var iVal int32
 	for s := 0; s < r.numBytes; s++ {
 		b := buf[s]
-		rBig |= int32(b) << (8 * s)
+		iVal |= int32(b) << (8 * s)
 
 	}
-	rBig = rBig - 1<<(8*r.numBytes-1)
-	v := float32(rBig) / float32((int32(1) << (r.numBytes*8 - 1)))
+	iVal = iVal - 1<<(8*r.numBytes-1)
+	v := float32(iVal) / float32((int32(1) << (r.numBytes*8 - 1)))
 	return v
 }
 

--- a/audio/internal/convert/float32.go
+++ b/audio/internal/convert/float32.go
@@ -21,86 +21,21 @@ import (
 	"math"
 )
 
-func NewFloat32BytesReaderFromInt16BytesReader(r io.Reader) io.Reader {
-	return &float32BytesReader{r: r}
-}
-
-func NewFloat32BytesReadSeekerFromInt16BytesReadSeeker(r io.ReadSeeker) io.ReadSeeker {
-	return &float32BytesReader{r: r}
-}
-
-type float32BytesReader struct {
-	r      io.Reader
-	eof    bool
-	i16Buf []byte
-}
-
-func (r *float32BytesReader) Read(buf []byte) (int, error) {
-	if r.eof && len(r.i16Buf) == 0 {
-		return 0, io.EOF
-	}
-
-	if i16LenToFill := len(buf) / 4 * 2; len(r.i16Buf) < i16LenToFill && !r.eof {
-		origLen := len(r.i16Buf)
-		if cap(r.i16Buf) < i16LenToFill {
-			r.i16Buf = append(r.i16Buf, make([]byte, i16LenToFill-origLen)...)
-		}
-
-		// Read int16 bytes.
-		n, err := r.r.Read(r.i16Buf[origLen:i16LenToFill])
-		if err != nil && err != io.EOF {
-			return 0, err
-		}
-		if err == io.EOF {
-			r.eof = true
-		}
-		r.i16Buf = r.i16Buf[:origLen+n]
-	}
-
-	// Convert int16 bytes to float32 bytes and fill buf.
-	samplesToFill := min(len(r.i16Buf)/2, len(buf)/4)
-	for i := 0; i < samplesToFill; i++ {
-		vi16l := r.i16Buf[2*i]
-		vi16h := r.i16Buf[2*i+1]
-		v := float32(int16(vi16l)|int16(vi16h)<<8) / (1 << 15)
-		vf32 := math.Float32bits(v)
-		buf[4*i] = byte(vf32)
-		buf[4*i+1] = byte(vf32 >> 8)
-		buf[4*i+2] = byte(vf32 >> 16)
-		buf[4*i+3] = byte(vf32 >> 24)
-	}
-
-	// Copy the remaining part for the next read.
-	copy(r.i16Buf, r.i16Buf[samplesToFill*2:])
-	r.i16Buf = r.i16Buf[:len(r.i16Buf)-samplesToFill*2]
-
-	n := samplesToFill * 4
-	if r.eof {
-		return n, io.EOF
-	}
-	return n, nil
-}
-
-func (r *float32BytesReader) Seek(offset int64, whence int) (int64, error) {
-	s, ok := r.r.(io.Seeker)
-	if !ok {
-		return 0, fmt.Errorf("float32: the source must be io.Seeker when seeking but not: %w", errors.ErrUnsupported)
-	}
-	r.i16Buf = r.i16Buf[:0]
-	r.eof = false
-	n, err := s.Seek(offset/4*2, whence)
-	if err != nil {
-		return 0, err
-	}
-	return n / 2 * 4, nil
-}
-
 type float32BytesReaderVariable struct {
 	r        io.Reader
 	numBytes int
 	signed   bool
 	eof      bool
 	iBuf     []byte
+}
+
+func NewFloat32BytesReadSeekerFromVariableIntBytesReader(r io.Reader, numBytes int) io.Reader {
+	return &float32BytesReaderVariable{
+		r:        r,
+		numBytes: numBytes,
+		// The spec has 1-8 bits as unsigned integers, 9 or more as signed
+		signed: numBytes > 1,
+	}
 }
 
 func NewFloat32BytesReadSeekerFromVariableIntBytesReadSeeker(r io.ReadSeeker, numBytes int) io.ReadSeeker {

--- a/audio/internal/convert/float32.go
+++ b/audio/internal/convert/float32.go
@@ -57,7 +57,7 @@ func (r *float32BytesReader) asFloat32(buf []byte) float32 {
 		}
 		// After moving the decoded int left by (4 - r.numBytes) bytes, it is now too large
 		// and it needs to be divided by 2^8*(4 - r.numBytes).
-		iVal /= 1 >> (8 * (4 - r.numBytes))
+		iVal /= 1 << (8 * (4 - r.numBytes))
 		v := float32(iVal) / float32((int32(1) << (r.numBytes*8 - 1)))
 		return v
 	}

--- a/audio/internal/convert/float32.go
+++ b/audio/internal/convert/float32.go
@@ -47,7 +47,6 @@ func NewFloat32BytesReadSeekerFromIntBytesReadSeeker(r io.ReadSeeker, numBytes i
 
 func (r *float32BytesReader) asFloat32(buf []byte) float32 {
 	if r.signed {
-
 		var iVal int32
 		for s := 0; s < r.numBytes; s++ {
 			b := buf[s]

--- a/audio/internal/convert/float32.go
+++ b/audio/internal/convert/float32.go
@@ -21,7 +21,7 @@ import (
 	"math"
 )
 
-type float32BytesReaderVariable struct {
+type float32BytesReader struct {
 	r        io.Reader
 	numBytes int
 	signed   bool
@@ -30,7 +30,7 @@ type float32BytesReaderVariable struct {
 }
 
 func NewFloat32BytesReadSeekerFromIntBytesReader(r io.Reader, numBytes int, signed bool) io.Reader {
-	return &float32BytesReaderVariable{
+	return &float32BytesReader{
 		r:        r,
 		numBytes: numBytes,
 		signed:   signed,
@@ -38,14 +38,14 @@ func NewFloat32BytesReadSeekerFromIntBytesReader(r io.Reader, numBytes int, sign
 }
 
 func NewFloat32BytesReadSeekerFromIntBytesReadSeeker(r io.ReadSeeker, numBytes int, signed bool) io.ReadSeeker {
-	return &float32BytesReaderVariable{
+	return &float32BytesReader{
 		r:        r,
 		numBytes: numBytes,
 		signed:   signed,
 	}
 }
 
-func (r *float32BytesReaderVariable) asFloat32(buf []byte) float32 {
+func (r *float32BytesReader) asFloat32(buf []byte) float32 {
 	if r.signed {
 
 		var rBig int32
@@ -78,7 +78,7 @@ func (r *float32BytesReaderVariable) asFloat32(buf []byte) float32 {
 	return v
 }
 
-func (r *float32BytesReaderVariable) Read(buf []byte) (int, error) {
+func (r *float32BytesReader) Read(buf []byte) (int, error) {
 	if r.eof && len(r.iBuf) == 0 {
 		return 0, io.EOF
 	}
@@ -123,7 +123,7 @@ func (r *float32BytesReaderVariable) Read(buf []byte) (int, error) {
 	return n, nil
 }
 
-func (r *float32BytesReaderVariable) Seek(offset int64, whence int) (int64, error) {
+func (r *float32BytesReader) Seek(offset int64, whence int) (int64, error) {
 	s, ok := r.r.(io.Seeker)
 	if !ok {
 		return 0, fmt.Errorf("float32: the source must be io.Seeker when seeking but not: %w", errors.ErrUnsupported)

--- a/audio/internal/convert/float32.go
+++ b/audio/internal/convert/float32.go
@@ -94,3 +94,112 @@ func (r *float32BytesReader) Seek(offset int64, whence int) (int64, error) {
 	}
 	return n / 2 * 4, nil
 }
+
+type float32BytesReaderVariable struct {
+	r        io.Reader
+	numBytes int
+	signed   bool
+	eof      bool
+	iBuf     []byte
+}
+
+func NewFloat32BytesReadSeekerFromVariableIntBytesReadSeeker(r io.ReadSeeker, numBytes int) io.ReadSeeker {
+	return &float32BytesReaderVariable{
+		r:        r,
+		numBytes: numBytes,
+		// The spec has 1-8 bits as unsigned integers, 9 or more as signed
+		signed: numBytes > 1,
+	}
+}
+
+func (r *float32BytesReaderVariable) asFloat32(buf []byte) float32 {
+	if r.signed {
+
+		var rBig int32
+		for s := 0; s < r.numBytes; s++ {
+			b := buf[s]
+			rBig |= int32(b) << (8 * (s + (4 - r.numBytes)))
+
+		}
+		rBig = rBig / 1 >> (8 * (4 - r.numBytes))
+		v := float32(rBig) / float32((int32(1) << (r.numBytes*8 - 1)))
+		return v
+	}
+	if r.numBytes == 1 {
+		// This converts the byte into a int16, and then into a float32
+		// This gives slightly different floats than converting from byte to float32 directly
+		// but is kept this way as that is what the package used to do
+		rBig := int16(int(buf[0])*0x101 - (1 << 15))
+		v := float32(rBig) / float32((int32(1) << (2*8 - 1)))
+		return v
+	}
+
+	var rBig int32
+	for s := 0; s < r.numBytes; s++ {
+		b := buf[s]
+		rBig |= int32(b) << (8 * s)
+
+	}
+	rBig = rBig - 1<<(8*r.numBytes-1)
+	v := float32(rBig) / float32((int32(1) << (r.numBytes*8 - 1)))
+	return v
+}
+
+func (r *float32BytesReaderVariable) Read(buf []byte) (int, error) {
+	if r.eof && len(r.iBuf) == 0 {
+		return 0, io.EOF
+	}
+
+	if lenToFill := len(buf) / 4 * r.numBytes; len(r.iBuf) < lenToFill && !r.eof {
+		origLen := len(r.iBuf)
+		if cap(r.iBuf) < lenToFill {
+			r.iBuf = append(r.iBuf, make([]byte, lenToFill-origLen)...)
+		}
+
+		// Read bytes.
+		n, err := r.r.Read(r.iBuf[origLen:lenToFill])
+		if err != nil && err != io.EOF {
+			return 0, err
+		}
+		if err == io.EOF {
+			r.eof = true
+		}
+		r.iBuf = r.iBuf[:origLen+n]
+	}
+
+	// Convert bytes to float32 bytes and fill buf.
+	samplesToFill := min(len(r.iBuf)/r.numBytes, len(buf)/4)
+	for i := 0; i < samplesToFill; i++ {
+		v := r.asFloat32(r.iBuf[r.numBytes*i : r.numBytes*i+r.numBytes])
+
+		vf32 := math.Float32bits(v)
+		buf[4*i] = byte(vf32)
+		buf[4*i+1] = byte(vf32 >> 8)
+		buf[4*i+2] = byte(vf32 >> 16)
+		buf[4*i+3] = byte(vf32 >> 24)
+	}
+
+	// Copy the remaining part for the next read.
+	copy(r.iBuf, r.iBuf[samplesToFill*r.numBytes:])
+	r.iBuf = r.iBuf[:len(r.iBuf)-samplesToFill*r.numBytes]
+
+	n := samplesToFill * 4
+	if r.eof {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *float32BytesReaderVariable) Seek(offset int64, whence int) (int64, error) {
+	s, ok := r.r.(io.Seeker)
+	if !ok {
+		return 0, fmt.Errorf("float32: the source must be io.Seeker when seeking but not: %w", errors.ErrUnsupported)
+	}
+	r.iBuf = r.iBuf[:0]
+	r.eof = false
+	n, err := s.Seek(offset/4*int64(r.numBytes), whence)
+	if err != nil {
+		return 0, err
+	}
+	return n / int64(r.numBytes) * 4, nil
+}

--- a/audio/internal/convert/float32_test.go
+++ b/audio/internal/convert/float32_test.go
@@ -86,7 +86,7 @@ func TestFloat32(t *testing.T) {
 						in = unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(c.In))), len(c.In)*2)
 						out = unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(outF32))), len(outF32)*4)
 					}
-					r := convert.NewFloat32BytesReadSeekerFromVariableIntBytesReadSeeker((bytes.NewReader(in)), 2).(io.ReadSeeker)
+					r := convert.NewFloat32BytesReadSeekerFromIntBytesReadSeeker((bytes.NewReader(in)), 2, true).(io.ReadSeeker)
 					var got []byte
 					for {
 						var buf [97]byte
@@ -169,7 +169,7 @@ func TestVariableIntFloat32(t *testing.T) {
 						}
 						out = unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(outF32))), len(outF32)*4)
 					}
-					r := convert.NewFloat32BytesReadSeekerFromVariableIntBytesReadSeeker((bytes.NewReader(in)), 3).(io.ReadSeeker)
+					r := convert.NewFloat32BytesReadSeekerFromIntBytesReadSeeker((bytes.NewReader(in)), 3, true).(io.ReadSeeker)
 					var got []byte
 					for {
 						var buf [97]byte

--- a/audio/internal/convert/float32_test.go
+++ b/audio/internal/convert/float32_test.go
@@ -16,7 +16,6 @@ package convert_test
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"math/rand/v2"
 	"testing"
@@ -68,69 +67,57 @@ func TestFloat32(t *testing.T) {
 			In:   randInt16s(65536),
 		},
 	}
-	functions := []func(*bytes.Reader) io.ReadSeeker{
-		func(r *bytes.Reader) io.ReadSeeker {
-			return convert.NewFloat32BytesReaderFromInt16BytesReader(r).(io.ReadSeeker)
-		},
-		func(r *bytes.Reader) io.ReadSeeker {
-			return convert.NewFloat32BytesReadSeekerFromVariableIntBytesReadSeeker(r, 2).(io.ReadSeeker)
-		},
-	}
-	for factoryNum, factory := range functions {
-		for _, c := range cases {
-			c := c
-			t.Run(c.Name, func(t *testing.T) {
-				for _, seek := range []bool{false, true} {
-					seek := seek
-					name := "nonseek"
-					if seek {
-						name = "seek"
-					}
-					name += fmt.Sprint(factoryNum)
-					t.Run(name, func(t *testing.T) {
-						var in, out []byte
-						if len(c.In) > 0 {
-							outF32 := make([]float32, len(c.In))
-							for i := range c.In {
-								outF32[i] = float32(c.In[i]) / (1 << 15)
-							}
-							in = unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(c.In))), len(c.In)*2)
-							out = unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(outF32))), len(outF32)*4)
-						}
-						r := factory(bytes.NewReader(in))
-						var got []byte
-						for {
-							var buf [97]byte
-							n, err := r.Read(buf[:])
-							got = append(got, buf[:n]...)
-							if err != nil {
-								if err != io.EOF {
-									t.Fatal(err)
-								}
-								break
-							}
-							if seek {
-								// Shifting by incomplete bytes should not affect the result.
-								for i := 0; i < 4; i++ {
-									if _, err := r.Seek(int64(i), io.SeekCurrent); err != nil {
-										if err != io.EOF {
-											t.Fatal(err)
-										}
-										break
-									}
-								}
-							}
-						}
-						want := out
-						if !bytes.Equal(got, want) {
-							t.Errorf("got: %v, want: %v", got, want)
-						}
-					})
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			for _, seek := range []bool{false, true} {
+				seek := seek
+				name := "nonseek"
+				if seek {
+					name = "seek"
 				}
-			})
-		}
+				t.Run(name, func(t *testing.T) {
+					var in, out []byte
+					if len(c.In) > 0 {
+						outF32 := make([]float32, len(c.In))
+						for i := range c.In {
+							outF32[i] = float32(c.In[i]) / (1 << 15)
+						}
+						in = unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(c.In))), len(c.In)*2)
+						out = unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(outF32))), len(outF32)*4)
+					}
+					r := convert.NewFloat32BytesReadSeekerFromVariableIntBytesReadSeeker((bytes.NewReader(in)), 2).(io.ReadSeeker)
+					var got []byte
+					for {
+						var buf [97]byte
+						n, err := r.Read(buf[:])
+						got = append(got, buf[:n]...)
+						if err != nil {
+							if err != io.EOF {
+								t.Fatal(err)
+							}
+							break
+						}
+						if seek {
+							// Shifting by incomplete bytes should not affect the result.
+							for i := 0; i < 4; i++ {
+								if _, err := r.Seek(int64(i), io.SeekCurrent); err != nil {
+									if err != io.EOF {
+										t.Fatal(err)
+									}
+									break
+								}
+							}
+						}
+					}
+					want := out
+					if !bytes.Equal(got, want) {
+						t.Errorf("got: %v, want: %v", got, want)
+					}
+				})
+			}
+		})
 	}
-
 }
 
 func TestVariableIntFloat32(t *testing.T) {
@@ -160,67 +147,60 @@ func TestVariableIntFloat32(t *testing.T) {
 			In:   randInt24s(65536),
 		},
 	}
-	functions := []func(*bytes.Reader) io.ReadSeeker{
-		func(r *bytes.Reader) io.ReadSeeker {
-			return convert.NewFloat32BytesReadSeekerFromVariableIntBytesReadSeeker(r, 3).(io.ReadSeeker)
-		},
-	}
-	for factoryNum, factory := range functions {
-		for _, c := range cases {
-			c := c
-			t.Run(c.Name, func(t *testing.T) {
-				for _, seek := range []bool{false, true} {
-					seek := seek
-					name := "nonseek"
-					if seek {
-						name = "seek"
-					}
-					name += fmt.Sprint(factoryNum)
-					t.Run(name, func(t *testing.T) {
-						var in, out []byte
-						if len(c.In) > 0 {
-							outF32 := make([]float32, len(c.In))
-							for i := range c.In {
-								outF32[i] = float32(c.In[i]) / (1 << 23)
-								v := c.In[i] * 1 << 8
-								in = append(in, byte(v>>8))
-								in = append(in, byte(v>>16))
-								in = append(in, byte(v>>24))
-							}
-							out = unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(outF32))), len(outF32)*4)
-						}
-						r := factory(bytes.NewReader(in))
-						var got []byte
-						for {
-							var buf [97]byte
-							n, err := r.Read(buf[:])
-							got = append(got, buf[:n]...)
-							if err != nil {
-								if err != io.EOF {
-									t.Fatal(err)
-								}
-								break
-							}
-							if seek {
-								// Shifting by incomplete bytes should not affect the result.
-								for i := 0; i < 4; i++ {
-									if _, err := r.Seek(int64(i), io.SeekCurrent); err != nil {
-										if err != io.EOF {
-											t.Fatal(err)
-										}
-										break
-									}
-								}
-							}
-						}
-						want := out
-						if !bytes.Equal(got, want) {
-							t.Errorf("got: %v, want: %v", got, want)
-						}
-					})
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			for _, seek := range []bool{false, true} {
+				seek := seek
+				name := "nonseek"
+				if seek {
+					name = "seek"
 				}
+				t.Run(name, func(t *testing.T) {
+					var in, out []byte
+					if len(c.In) > 0 {
+						outF32 := make([]float32, len(c.In))
+						for i := range c.In {
+							outF32[i] = float32(c.In[i]) / (1 << 23)
+							v := c.In[i] * 1 << 8
+							in = append(in, byte(v>>8))
+							in = append(in, byte(v>>16))
+							in = append(in, byte(v>>24))
+						}
+						out = unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(outF32))), len(outF32)*4)
+					}
+					r := convert.NewFloat32BytesReadSeekerFromVariableIntBytesReadSeeker((bytes.NewReader(in)), 3).(io.ReadSeeker)
+					var got []byte
+					for {
+						var buf [97]byte
+						n, err := r.Read(buf[:])
+						got = append(got, buf[:n]...)
+						if err != nil {
+							if err != io.EOF {
+								t.Fatal(err)
+							}
+							break
+						}
+						if seek {
+							// Shifting by incomplete bytes should not affect the result.
+							for i := 0; i < 4; i++ {
+								if _, err := r.Seek(int64(i), io.SeekCurrent); err != nil {
+									if err != io.EOF {
+										t.Fatal(err)
+									}
+									break
+								}
+							}
+						}
+					}
+					want := out
+					if !bytes.Equal(got, want) {
+						t.Errorf("got: %v, want: %v", got, want)
+					}
+				})
+			}
 
-			})
-		}
+		})
 	}
+
 }

--- a/audio/mp3/decode.go
+++ b/audio/mp3/decode.go
@@ -72,7 +72,7 @@ func DecodeF32(src io.Reader) (*Stream, error) {
 	if err != nil {
 		return nil, err
 	}
-	r := convert.NewFloat32BytesReadSeekerFromInt16BytesReadSeeker(d)
+	r := convert.NewFloat32BytesReadSeekerFromIntBytesReadSeeker(d, 2, true)
 	s := &Stream{
 		readSeeker: r,
 		length:     d.Length() / bitDepthInBytesInt16 * bitDepthInBytesFloat32,

--- a/audio/wav/decode.go
+++ b/audio/wav/decode.go
@@ -230,8 +230,10 @@ chunks:
 			format = convert.FormatU8
 		case 16:
 			format = convert.FormatS16
-		default:
+		case 24:
 			format = convert.FormatS24
+		default:
+			return nil, fmt.Errorf("wav: unsupported bits per sample: %d", bitsPerSample)
 		}
 		s = convert.NewStereoI16ReadSeeker(s, mono, format)
 		if mono {

--- a/audio/wav/decode.go
+++ b/audio/wav/decode.go
@@ -221,7 +221,7 @@ chunks:
 
 	var s io.ReadSeeker = newSectionReader(src, headerSize, dataSize)
 
-	if mono || bitsPerSample != 16 {
+	if bitDepthInBytes == bitDepthInBytesInt16 {
 		var format convert.Format
 		switch bitsPerSample {
 		case 8:

--- a/audio/wav/decode.go
+++ b/audio/wav/decode.go
@@ -245,7 +245,10 @@ chunks:
 		}, nil
 	}
 
-	s = convert.NewFloat32BytesReadSeekerFromVariableIntBytesReadSeeker(s, bitsPerSample/8)
+	// The spec has 1-8 bits as unsigned integers, 9 or more as signed
+	numBytes := bitsPerSample / 8
+	signed := numBytes > 1
+	s = convert.NewFloat32BytesReadSeekerFromIntBytesReadSeeker(s, numBytes, signed)
 
 	dataSize *= int64(bitsPerSample) / 8
 	if mono {

--- a/audio/wav/decode_test.go
+++ b/audio/wav/decode_test.go
@@ -188,7 +188,6 @@ func TestDecodeF32(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		c := c
 		t.Run(c.Name, func(t *testing.T) {
 			var out []byte
 			if len(c.Data) > 0 {

--- a/audio/wav/decode_test.go
+++ b/audio/wav/decode_test.go
@@ -1,3 +1,16 @@
+// Copyright 2025 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package wav_test
 
 import (
@@ -12,7 +25,7 @@ import (
 func makeWav(channelCount int, bitsPerSample int, sampleRate int, data []byte) []byte {
 	var sb bytes.Buffer
 	sb.WriteString("RIFF")
-	sb.Write([]byte{0, 0, 0, 0}) // We don't care about file size, so we leave it blank
+	sb.Write([]byte{0, 0, 0, 0}) // `decode` does not use file size
 	sb.WriteString("WAVE")
 
 	sb.WriteString("fmt ")
@@ -27,7 +40,8 @@ func makeWav(channelCount int, bitsPerSample int, sampleRate int, data []byte) [
 		byte(sampleRate >> 8),
 		byte(sampleRate >> 16),
 		byte(sampleRate >> 24),
-		0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, // `decode` does not use dwAvgBytesPerSec
+		0, 0, // `decdode` does not use wBlockAlign
 		byte(bitsPerSample),
 		byte(bitsPerSample >> 8),
 	}

--- a/audio/wav/decode_test.go
+++ b/audio/wav/decode_test.go
@@ -1,0 +1,200 @@
+package wav_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"unsafe"
+
+	"github.com/hajimehoshi/ebiten/v2/audio/wav"
+)
+
+func makeWav(channelCount int, bitsPerSample int, sampleRate int, data []byte) []byte {
+	var sb bytes.Buffer
+	sb.WriteString("RIFF")
+	sb.Write([]byte{0, 0, 0, 0}) // We don't care about file size, so we leave it blank
+	sb.WriteString("WAVE")
+
+	sb.WriteString("fmt ")
+
+	format := 1
+	fmtData := []byte{
+		byte(format),
+		byte(format >> 8),
+		byte(channelCount),
+		byte(channelCount >> 8),
+		byte(sampleRate),
+		byte(sampleRate >> 8),
+		byte(sampleRate >> 16),
+		byte(sampleRate >> 24),
+		0, 0, 0, 0, 0, 0,
+		byte(bitsPerSample),
+		byte(bitsPerSample >> 8),
+	}
+	lenFmtData := len(fmtData)
+	sb.Write([]byte{
+		byte(lenFmtData),
+		byte(lenFmtData >> 8),
+		byte(lenFmtData >> 16),
+		byte(lenFmtData >> 24),
+	})
+	sb.Write(fmtData)
+
+	sb.WriteString("data")
+	lenData := len(data)
+	sb.Write([]byte{
+		byte(lenData),
+		byte(lenData >> 8),
+		byte(lenData >> 16),
+		byte(lenData >> 24),
+	})
+	sb.Write(data)
+	return sb.Bytes()
+}
+
+func int16ToBytes(a []int16) []byte {
+	return unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(a))), len(a)*2)
+}
+
+func int16ToFloat32(a []byte) []float32 {
+	outF32 := make([]float32, len(a)/2)
+	for i := 0; i < len(a); i += 2 {
+		vi16l := a[i]
+		vi16h := a[i+1]
+		outF32[i/2] = float32(int16(vi16l)|int16(vi16h)<<8) / (1 << 15)
+	}
+	return outF32
+}
+
+func byteToFloat32(a []byte) []float32 {
+	outF32 := make([]float32, len(a))
+	for i := 0; i < len(a); i += 1 {
+		// This converts the byte into a int16, and then into a float32
+		// This gives slightly different floats than converting from byte to float32 directly
+		// but is kept this way as that is what the package used to do
+		v := int16(int(a[i])*0x101 - (1 << 15))
+		outF32[i] = float32(int32(v)) / (1 << 15)
+	}
+	return outF32
+}
+
+func int24ToBytes(a []int32) []byte {
+	out := make([]byte, len(a)*3)
+	for i := range a {
+		v := a[i] * 1 << 8
+		out[i*3] = byte(v >> 8)
+		out[i*3+1] = byte(v >> 16)
+		out[i*3+2] = byte(v >> 24)
+	}
+	return out
+}
+
+func int24ToFloat32(a []byte) []float32 {
+	outF32 := make([]float32, len(a)/3)
+	for i := 0; i < len(a); i += 3 {
+		var r int32
+		r |= int32(a[i]) << 8
+		r |= int32(a[i+1]) << 16
+		r |= int32(a[i+2]) << 24
+		r = r / 1 >> 8
+		outF32[i/3] = float32(r) / (1 << 23)
+	}
+	return outF32
+}
+
+func toStereo(conv func(a []byte) []float32) func(a []byte) []float32 {
+	return func(a []byte) []float32 {
+		mono := conv(a)
+		out := make([]float32, len(mono)*2)
+		for i := range mono {
+			out[i*2] = mono[i]
+			out[i*2+1] = mono[i]
+		}
+		return out
+	}
+}
+func TestDecodeF32(t *testing.T) {
+	type testCase struct {
+		Name          string
+		Data          []byte
+		ChannelCount  int
+		BitsPerSample int
+		SampleRate    int
+		Converter     func([]byte) []float32
+	}
+	cases := []testCase{
+		{
+			Name:          "Stereo, 24 Bit",
+			Data:          int24ToBytes([]int32{-8388608, -8388608, 0, 0, 8388607, 8388607}),
+			ChannelCount:  2,
+			BitsPerSample: 24,
+			SampleRate:    44100,
+			Converter:     int24ToFloat32,
+		},
+		{
+			Name:          "Mono, 24 Bit",
+			Data:          int24ToBytes([]int32{-8388608, 0, 8388607}),
+			ChannelCount:  1,
+			BitsPerSample: 24,
+			SampleRate:    44100,
+			Converter:     toStereo(int24ToFloat32),
+		},
+		{
+			Name:          "Stereo, 16 Bit",
+			Data:          int16ToBytes([]int16{-32768, -32768, 0, 0, 32767, 32767}),
+			ChannelCount:  2,
+			BitsPerSample: 16,
+			SampleRate:    44100,
+			Converter:     int16ToFloat32,
+		},
+		{
+			Name:          "Mono, 16 Bit",
+			Data:          int16ToBytes([]int16{-32768, 0, 32767}),
+			ChannelCount:  1,
+			BitsPerSample: 16,
+			SampleRate:    44100,
+			Converter:     toStereo(int16ToFloat32),
+		},
+		{
+			Name:          "Stereo, 8 Bit",
+			Data:          []byte{0, 0, 128, 128, 255, 255},
+			ChannelCount:  2,
+			BitsPerSample: 8,
+			SampleRate:    44100,
+			Converter:     byteToFloat32,
+		},
+		{
+			Name:          "Mono, 8 Bit",
+			Data:          []byte{0, 128, 255},
+			ChannelCount:  1,
+			BitsPerSample: 8,
+			SampleRate:    44100,
+			Converter:     toStereo(byteToFloat32),
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			var out []byte
+			if len(c.Data) > 0 {
+				outF32 := c.Converter(c.Data)
+				out = unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(outF32))), len(outF32)*4)
+			}
+
+			in := makeWav(c.ChannelCount, c.BitsPerSample, c.SampleRate, c.Data)
+
+			stream, err := wav.DecodeF32(bytes.NewReader(in))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := io.ReadAll(stream)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := out
+			if !bytes.Equal(got, want) {
+				t.Errorf("got: %v, want: %v", got, want)
+			}
+		})
+	}
+}

--- a/audio/wav/decode_test.go
+++ b/audio/wav/decode_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package wav_test
 
 import (


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
Closes #2215

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
The first commit adds as test to DecodeF32, which tests for <8,16,24> bit and <mono,stereo>. The current implementation fails the 24bit cases.
The second commit introduces a reader that returns float32s from a stream of either signed/unsigned integers of specified length. The `decode` method now uses this reader to read float32s and `NewStereoF32` to handle the mono->stereo conversion.

I considered refactoring `decode` and making it purely about decoding the WAV format, and moving the data conversions into `DecodeF32`/`DecodeWithoutResampling`/`DecodeWithSampleRate`  in order to remove some of the branching that is purely dependent on which caller is calling the function, but thought I would get feedback on this feature before introducing another change. 


