### PR TITLE
audio/internal/convert: make StereoI16 accept a 24bit stream

### DIFF
--- a/audio/internal/convert/stereoi16.go
+++ b/audio/internal/convert/stereoi16.go
@@ -18,18 +18,26 @@ import (
 	"io"
 )
 
+type Format int
+
+const (
+	FormatU8 Format = iota
+	FormatS16
+	FormatS24
+)
+
 type StereoI16 struct {
 	source io.ReadSeeker
 	mono   bool
-	eight  bool
+	format Format
 	buf    []byte
 }
 
-func NewStereoI16(source io.ReadSeeker, mono, eight bool) *StereoI16 {
+func NewStereoI16(source io.ReadSeeker, mono bool, format Format) *StereoI16 {
 	return &StereoI16{
 		source: source,
 		mono:   mono,
-		eight:  eight,
+		format: format,
 	}
 }
 
@@ -38,7 +46,12 @@ func (s *StereoI16) Read(b []byte) (int, error) {
 	if s.mono {
 		l /= 2
 	}
-	if s.eight {
+	switch s.format {
+	case FormatU8:
+		l /= 2
+	case FormatS16:
+	case FormatS24:
+		l *= 3
 		l /= 2
 	}
 
@@ -50,39 +63,63 @@ func (s *StereoI16) Read(b []byte) (int, error) {
 	if err != nil && err != io.EOF {
 		return 0, err
 	}
-	switch {
-	case s.mono && s.eight:
-		for i := 0; i < n; i++ {
-			v := int16(int(s.buf[i])*0x101 - (1 << 15))
-			b[4*i] = byte(v)
-			b[4*i+1] = byte(v >> 8)
-			b[4*i+2] = byte(v)
-			b[4*i+3] = byte(v >> 8)
+	if s.mono {
+		switch s.format {
+		case FormatU8:
+			for i := 0; i < n; i++ {
+				v := int16(int(s.buf[i])*0x101 - (1 << 15))
+				b[4*i] = byte(v)
+				b[4*i+1] = byte(v >> 8)
+				b[4*i+2] = byte(v)
+				b[4*i+3] = byte(v >> 8)
+			}
+		case FormatS16:
+			for i := 0; i < n/2; i++ {
+				b[4*i] = s.buf[2*i]
+				b[4*i+1] = s.buf[2*i+1]
+				b[4*i+2] = s.buf[2*i]
+				b[4*i+3] = s.buf[2*i+1]
+			}
+		case FormatS24:
+			for i := 0; i < n/3; i++ {
+				b[4*i] = s.buf[3*i+1]
+				b[4*i+1] = s.buf[3*i+2]
+				b[4*i+2] = s.buf[3*i+1]
+				b[4*i+3] = s.buf[3*i+2]
+			}
 		}
-	case s.mono && !s.eight:
-		for i := 0; i < n/2; i++ {
-			b[4*i] = s.buf[2*i]
-			b[4*i+1] = s.buf[2*i+1]
-			b[4*i+2] = s.buf[2*i]
-			b[4*i+3] = s.buf[2*i+1]
+	} else {
+		switch s.format {
+		case FormatU8:
+			for i := 0; i < n/2; i++ {
+				v0 := int16(int(s.buf[2*i])*0x101 - (1 << 15))
+				v1 := int16(int(s.buf[2*i+1])*0x101 - (1 << 15))
+				b[4*i] = byte(v0)
+				b[4*i+1] = byte(v0 >> 8)
+				b[4*i+2] = byte(v1)
+				b[4*i+3] = byte(v1 >> 8)
+			}
+		case FormatS16:
+			copy(b[:n], s.buf[:n])
+		case FormatS24:
+			for i := 0; i < n/6; i++ {
+				b[4*i] = s.buf[6*i+1]
+				b[4*i+1] = s.buf[6*i+2]
+				b[4*i+2] = s.buf[6*i+4]
+				b[4*i+3] = s.buf[6*i+5]
+			}
 		}
-	case !s.mono && s.eight:
-		for i := 0; i < n/2; i++ {
-			v0 := int16(int(s.buf[2*i])*0x101 - (1 << 15))
-			v1 := int16(int(s.buf[2*i+1])*0x101 - (1 << 15))
-			b[4*i] = byte(v0)
-			b[4*i+1] = byte(v0 >> 8)
-			b[4*i+2] = byte(v1)
-			b[4*i+3] = byte(v1 >> 8)
-		}
-	default:
-		copy(b[:n], s.buf[:n])
 	}
 	if s.mono {
 		n *= 2
 	}
-	if s.eight {
+	switch s.format {
+	case FormatU8:
 		n *= 2
+	case FormatS16:
+	case FormatS24:
+		n *= 2
+		n /= 3
 	}
 	return n, err
 }
@@ -92,7 +129,12 @@ func (s *StereoI16) Seek(offset int64, whence int) (int64, error) {
 	if s.mono {
 		offset /= 2
 	}
-	if s.eight {
+	switch s.format {
+	case FormatU8:
+		offset /= 2
+	case FormatS16:
+	case FormatS24:
+		offset *= 3
 		offset /= 2
 	}
 	return s.source.Seek(offset, whence)

--- a/audio/internal/convert/stereoi16_test.go
+++ b/audio/internal/convert/stereoi16_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/audio/internal/convert"
 )
 
-func TestStereoI16(t *testing.T) {
+func TestStereoI16FromSigned16Bits(t *testing.T) {
 	testCases := []struct {
 		Name string
 		In   []int16
@@ -66,7 +66,7 @@ func TestStereoI16(t *testing.T) {
 							outBytes = append(outBytes, byte(v), byte(v>>8))
 						}
 					}
-					s := convert.NewStereoI16(bytes.NewReader(inBytes), mono, false)
+					s := convert.NewStereoI16(bytes.NewReader(inBytes), mono, convert.FormatS16)
 					var got []byte
 					for {
 						var buf [97]byte
@@ -106,7 +106,7 @@ func randBytes(n int) []byte {
 	return r
 }
 
-func TestStereoI16EightBits(t *testing.T) {
+func TestStereoI16FromUnsigned8Bits(t *testing.T) {
 	testCases := []struct {
 		Name string
 		In   []byte
@@ -149,7 +149,89 @@ func TestStereoI16EightBits(t *testing.T) {
 							outBytes = append(outBytes, byte(v16), byte(v16>>8))
 						}
 					}
-					s := convert.NewStereoI16(bytes.NewReader(inBytes), mono, true)
+					s := convert.NewStereoI16(bytes.NewReader(inBytes), mono, convert.FormatU8)
+					var got []byte
+					for {
+						var buf [97]byte
+						n, err := s.Read(buf[:])
+						got = append(got, buf[:n]...)
+						if err != nil {
+							if err != io.EOF {
+								t.Fatal(err)
+							}
+							break
+						}
+						// Shifting by incomplete bytes should not affect the result.
+						for i := 0; i < 2*2; i++ {
+							if _, err := s.Seek(int64(i), io.SeekCurrent); err != nil {
+								if err != io.EOF {
+									t.Fatal(err)
+								}
+								break
+							}
+						}
+					}
+					want := outBytes
+					if !bytes.Equal(got, want) {
+						t.Errorf("got: %v, want: %v", got, want)
+					}
+				})
+			}
+		})
+	}
+}
+
+func randInts(n int) []int {
+	r := make([]int, n)
+	for i := range r {
+		r[i] = rand.Int()
+	}
+	return r
+}
+
+func TestStereoI16FromSigned24Bits(t *testing.T) {
+	testCases := []struct {
+		Name string
+		In   []int
+	}{
+		{
+			Name: "nil",
+			In:   nil,
+		},
+		{
+			Name: "-1, 0, 1, 0",
+			In:   []int{-1, 0, 1, 0},
+		},
+		{
+			Name: "8 0s",
+			In:   []int{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Name: "random 256 values",
+			In:   randInts(256),
+		},
+		{
+			Name: "random 65536 values",
+			In:   randInts(65536),
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			for _, mono := range []bool{false, true} {
+				mono := mono
+				t.Run(fmt.Sprintf("mono=%t", mono), func(t *testing.T) {
+					var inBytes, outBytes []byte
+					for _, v := range tc.In {
+						inBytes = append(inBytes, byte(v), byte(v>>8), byte(v>>16))
+						if mono {
+							// As the source is mono, the output should be stereo.
+							outBytes = append(outBytes, byte(v>>8), byte(v>>16), byte(v>>8), byte(v>>16))
+						} else {
+							outBytes = append(outBytes, byte(v>>8), byte(v>>16))
+						}
+					}
+					s := convert.NewStereoI16(bytes.NewReader(inBytes), mono, convert.FormatS24)
 					var got []byte
 					for {
 						var buf [97]byte

--- a/audio/internal/convert/stereoi16_test.go
+++ b/audio/internal/convert/stereoi16_test.go
@@ -51,10 +51,8 @@ func TestStereoI16FromSigned16Bits(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			for _, mono := range []bool{false, true} {
-				mono := mono
 				t.Run(fmt.Sprintf("mono=%t", mono), func(t *testing.T) {
 					var inBytes, outBytes []byte
 					for _, v := range tc.In {
@@ -133,10 +131,8 @@ func TestStereoI16FromUnsigned8Bits(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			for _, mono := range []bool{false, true} {
-				mono := mono
 				t.Run(fmt.Sprintf("mono=%t", mono), func(t *testing.T) {
 					inBytes := tc.In
 					var outBytes []byte
@@ -216,10 +212,8 @@ func TestStereoI16FromSigned24Bits(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			for _, mono := range []bool{false, true} {
-				mono := mono
 				t.Run(fmt.Sprintf("mono=%t", mono), func(t *testing.T) {
 					var inBytes, outBytes []byte
 					for _, v := range tc.In {

--- a/audio/vorbis/vorbis.go
+++ b/audio/vorbis/vorbis.go
@@ -204,7 +204,7 @@ func DecodeWithoutResampling(src io.Reader) (*Stream, error) {
 	var s io.ReadSeeker = i16Stream
 	length := i16Stream.totalBytes()
 	if i16Stream.vorbisReader.Channels() == 1 {
-		s = convert.NewStereoI16(s, true, false)
+		s = convert.NewStereoI16(s, true, convert.FormatS16)
 		length *= 2
 	}
 
@@ -238,7 +238,7 @@ func DecodeWithSampleRate(sampleRate int, src io.Reader) (*Stream, error) {
 	var s io.ReadSeeker = i16Stream
 	length := i16Stream.totalBytes()
 	if i16Stream.vorbisReader.Channels() == 1 {
-		s = convert.NewStereoI16(s, true, false)
+		s = convert.NewStereoI16(s, true, convert.FormatS16)
 		length *= 2
 	}
 	if i16Stream.vorbisReader.SampleRate() != sampleRate {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
Updates #2215

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
This changes StereoI16 to accept 24bit integer stream as a preparation for the 24bit WAV format.