### PR TITLE
fallback to init monitor if primary is off

### DIFF
--- a/internal/ui/ui_glfw.go
+++ b/internal/ui/ui_glfw.go
@@ -1904,7 +1904,11 @@ func (u *UserInterface) currentMonitor() (*Monitor, error) {
 		return m, nil
 	}
 
-	return theMonitors.primaryMonitor(), nil
+	if m := theMonitors.primaryMonitor(); m != nil {
+		return m, nil
+	}
+
+	return u.getInitMonitor(), nil
 }
 
 func (u *UserInterface) readInputState(inputState *InputState) {


### PR DESCRIPTION
# What issue is this addressing?
Workaround for #3241.
While this fixes the issue, I am not sure this should be the definitive fix.
A better alternative could be to turn off rendering entirely when all monitors are offline?
With that being said, this workaround prevents a crash and the engine continues working after one monitor goes back online.

## What _type_ of issue is this addressing?
Resolves a panic

## What this PR does | solves
Fallback to init monitor data when primary monitor goes offline
