### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/internal/shaderir/reachable_test.go
+++ b/internal/shaderir/reachable_test.go
@@ -15,6 +15,7 @@
 package shaderir_test
 
 import (
+	"slices"
 	"sort"
 	"testing"
 
@@ -24,18 +25,6 @@ import (
 
 func compileToIR(src []byte) (*shaderir.Program, error) {
 	return shader.Compile(src, "Vertex", "Fragment", 0)
-}
-
-func areIntSlicesEqual(a, b []int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func TestReachableUniformVariablesFromBlock(t *testing.T) {
@@ -109,7 +98,7 @@ func neverCalled() float {
 		got := ir.AppendReachableUniformVariablesFromBlock(nil, ir.Funcs[c.index].Block)
 		sort.Ints(got)
 		want := c.expected
-		if !areIntSlicesEqual(got, want) {
+		if !slices.Equal(got, want) {
 			t.Errorf("test: %v, got: %v, want: %v", c, got, want)
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->

In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).

## What _type_ of issue is this addressing?
<!-- bug | feature | security -->

refactor

## What this PR does | solves
<!-- Please be as descriptive as possible -->
