### PR TITLE
cmd/ebitenmobile: replace for loop with strings.Join

### DIFF
--- a/cmd/ebitenmobile/main.go
+++ b/cmd/ebitenmobile/main.go
@@ -207,11 +207,7 @@ func doBind(args []string, flagset *flag.FlagSet, buildOS string) error {
 	}
 
 	if buildN {
-		fmt.Print("gomobile")
-		for _, arg := range args {
-			fmt.Print(" ", arg)
-		}
-		fmt.Println()
+		fmt.Println("gomobile " + strings.Join(args, " "))
 		return nil
 	}
 


### PR DESCRIPTION
# What issue is this addressing?
Partially addresses https://github.com/hajimehoshi/ebiten/issues/2436 by replacing a `for` loop with `strings.Join`.

## What _type_ of issue is this addressing?
Code clean up.

## What this PR does | solves
Replace `for` loop in `buildN` `if` with `strings.Join`.
