### PR TITLE
examples: Refactor loops to use range in example files

### DIFF
--- a/examples/contextlost/main.go
+++ b/examples/contextlost/main.go
@@ -94,7 +94,7 @@ func main() {
 	gophersImage = ebiten.NewImageFromImage(img)
 
 	// Extend the shared backend GL texture on purpose.
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		eimg := ebiten.NewImageFromImage(img)
 		extraImages = append(extraImages, eimg)
 	}

--- a/examples/keyboard/keyboard/gen.go
+++ b/examples/keyboard/keyboard/gen.go
@@ -120,8 +120,8 @@ func drawKey(dst *ebiten.Image, name string, x, y, width int) {
 	const height = 16
 	width--
 	p := make([]byte, width*height*4)
-	for j := 0; j < height; j++ {
-		for i := 0; i < width; i++ {
+	for j := range height {
+		for i := range width {
 			x := (i + j*width) * 4
 			switch j {
 			case 0, height - 1:

--- a/examples/mandelbrot/main.go
+++ b/examples/mandelbrot/main.go
@@ -61,8 +61,8 @@ func NewGame() *Game {
 }
 
 func (gm *Game) updateOffscreen(centerX, centerY, size float64) {
-	for j := 0; j < screenHeight; j++ {
-		for i := 0; i < screenHeight; i++ {
+	for j := range screenHeight {
+		for i := range screenHeight {
 			x := float64(i)*size/screenWidth - size/2 + centerX
 			y := (screenHeight-float64(j))*size/screenHeight - size/2 + centerY
 			c := complex(x, y)

--- a/examples/masking/main.go
+++ b/examples/masking/main.go
@@ -56,8 +56,8 @@ func init() {
 	const r = 64
 	alphas := image.Point{r * 2, r * 2}
 	a := image.NewAlpha(image.Rectangle{image.Point{}, alphas})
-	for j := 0; j < alphas.Y; j++ {
-		for i := 0; i < alphas.X; i++ {
+	for j := range alphas.Y {
+		for i := range alphas.X {
 			// d is the distance between (i, j) and the (circle) center.
 			d := math.Sqrt(float64((i-r)*(i-r) + (j-r)*(j-r)))
 			// Alphas around the center are 0 and values outside of the circle are 0xff.

--- a/examples/moire/main.go
+++ b/examples/moire/main.go
@@ -43,8 +43,8 @@ func getDots(width, height int) []byte {
 	dotsWidth = width
 	dotsHeight = height
 	dots = make([]byte, width*height*4)
-	for j := 0; j < height; j++ {
-		for i := 0; i < width; i++ {
+	for j := range height {
+		for i := range width {
 			if (i+j)%2 == 0 {
 				dots[(i+j*width)*4+0] = 0xff
 				dots[(i+j*width)*4+1] = 0xff

--- a/examples/noise/main.go
+++ b/examples/noise/main.go
@@ -50,7 +50,7 @@ type Game struct {
 func (g *Game) Update() error {
 	// Generate the noise with random RGB values.
 	const l = screenWidth * screenHeight
-	for i := 0; i < l; i++ {
+	for i := range l {
 		x := theRand.next()
 		g.noiseImage.Pix[4*i] = uint8(x >> 24)
 		g.noiseImage.Pix[4*i+1] = uint8(x >> 16)


### PR DESCRIPTION
Replaces traditional for-loop constructs with 'for range' syntax in several example files for improved readability and idiomatic Go style. Affects contextlost, keyboard, mandelbrot, masking, moire, and noise examples.
