### PR TITLE
Prefix panic messages with module names for clearer debugging

### DIFF
--- a/audio/internal/convert/resampling.go
+++ b/audio/internal/convert/resampling.go
@@ -165,7 +165,7 @@ func (r *Resampling) src(i int64) (float64, float64, error) {
 				sr[i] = float64(math.Float32frombits(uint32(buf[8*i+4]) | uint32(buf[8*i+5])<<8 | uint32(buf[8*i+6])<<16 | uint32(buf[8*i+7])<<24))
 			}
 		default:
-			panic("not reached")
+			panic("convert: not reached")
 		}
 		r.srcBlock = nextPos
 		r.srcBufL[r.srcBlock] = sl
@@ -189,7 +189,7 @@ func (r *Resampling) src(i int64) (float64, float64, error) {
 			}
 		}
 		if idx == -1 {
-			panic("not reach")
+			panic("convert: not reach")
 		}
 		r.lruSrcBlocks = append(r.lruSrcBlocks[:idx], r.lruSrcBlocks[idx+1:]...)
 		r.lruSrcBlocks = append(r.lruSrcBlocks, r.srcBlock)
@@ -297,7 +297,7 @@ func (r *Resampling) Read(b []byte) (int, error) {
 			b[8*i+7] = byte(r32b >> 24)
 		}
 	default:
-		panic("not reached")
+		panic("convert: not reached")
 	}
 	r.pos += int64(n)
 	if r.eof {

--- a/cmd/ebitenmobile/gobind.go
+++ b/cmd/ebitenmobile/gobind.go
@@ -137,7 +137,7 @@ import "C"`); err != nil {
 		case "go":
 			// Do nothing.
 		default:
-			panic(fmt.Sprintf("unsupported language: %s", lang))
+			panic(fmt.Sprintf("ebitenmobile: unsupported language: %s", lang))
 		}
 	}
 

--- a/internal/graphicsdriver/directx/api_notmicrosoftgdk_windows.go
+++ b/internal/graphicsdriver/directx/api_notmicrosoftgdk_windows.go
@@ -25,101 +25,101 @@ func _D3D12_RESOURCE_STATE_PRESENT() _D3D12_RESOURCE_STATES {
 }
 
 func _ID3D12CommandQueue_ExecuteCommandLists(i *_ID3D12CommandQueue, ppCommandLists []*_ID3D12GraphicsCommandList) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12CommandQueue_PresentX(i *_ID3D12CommandQueue, planeCount uint32, pPlaneParameters *_D3D12XBOX_PRESENT_PLANE_PARAMETERS, pPresentParameters *_D3D12XBOX_PRESENT_PARAMETERS) uintptr {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12CommandQueue_Release(i *_ID3D12CommandQueue) uint32 {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12CommandQueue_ResumeX(i *_ID3D12CommandQueue) uintptr {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12CommandQueue_Signal(i *_ID3D12CommandQueue, pFence *_ID3D12Fence, value uint64) uintptr {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12CommandQueue_SuspendX(i *_ID3D12CommandQueue, flags uint32) uintptr {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_ClearDepthStencilView(i *_ID3D12GraphicsCommandList, depthStencilView _D3D12_CPU_DESCRIPTOR_HANDLE, clearFlags _D3D12_CLEAR_FLAGS, depth float32, stencil uint8, rects []_D3D12_RECT) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_ClearRenderTargetView(i *_ID3D12GraphicsCommandList, pRenderTargetView _D3D12_CPU_DESCRIPTOR_HANDLE, colorRGBA [4]float32, rects []_D3D12_RECT) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_Close(i *_ID3D12GraphicsCommandList) uintptr {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_CopyTextureRegion(i *_ID3D12GraphicsCommandList, pDst unsafe.Pointer, dstX uint32, dstY uint32, dstZ uint32, pSrc unsafe.Pointer, pSrcBox *_D3D12_BOX) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_DrawIndexedInstanced(i *_ID3D12GraphicsCommandList, indexCountPerInstance uint32, instanceCount uint32, startIndexLocation uint32, baseVertexLocation int32, startInstanceLocation uint32) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_IASetIndexBuffer(i *_ID3D12GraphicsCommandList, pView *_D3D12_INDEX_BUFFER_VIEW) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_IASetPrimitiveTopology(i *_ID3D12GraphicsCommandList, primitiveTopology _D3D_PRIMITIVE_TOPOLOGY) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_IASetVertexBuffers(i *_ID3D12GraphicsCommandList, startSlot uint32, pViews []_D3D12_VERTEX_BUFFER_VIEW) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_OMSetRenderTargets(i *_ID3D12GraphicsCommandList, renderTargetDescriptors []_D3D12_CPU_DESCRIPTOR_HANDLE, rtsSingleHandleToDescriptorRange bool, pDepthStencilDescriptor *_D3D12_CPU_DESCRIPTOR_HANDLE) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_OMSetStencilRef(i *_ID3D12GraphicsCommandList, stencilRef uint32) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_Release(i *_ID3D12GraphicsCommandList) uint32 {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_Reset(i *_ID3D12GraphicsCommandList, pAllocator *_ID3D12CommandAllocator, pInitialState *_ID3D12PipelineState) uintptr {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_ResourceBarrier(i *_ID3D12GraphicsCommandList, barriers []_D3D12_RESOURCE_BARRIER_Transition) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_RSSetViewports(i *_ID3D12GraphicsCommandList, viewports []_D3D12_VIEWPORT) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_RSSetScissorRects(i *_ID3D12GraphicsCommandList, rects []_D3D12_RECT) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_SetDescriptorHeaps(i *_ID3D12GraphicsCommandList, descriptorHeaps []*_ID3D12DescriptorHeap) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(i *_ID3D12GraphicsCommandList, rootParameterIndex uint32, baseDescriptor _D3D12_GPU_DESCRIPTOR_HANDLE) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_SetGraphicsRootSignature(i *_ID3D12GraphicsCommandList, pRootSignature *_ID3D12RootSignature) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }
 
 func _ID3D12GraphicsCommandList_SetPipelineState(i *_ID3D12GraphicsCommandList, pPipelineState *_ID3D12PipelineState) {
-	panic("not implemented")
+	panic("directx: not implemented")
 }

--- a/vector/path.go
+++ b/vector/path.go
@@ -158,7 +158,7 @@ func (s *subPath) endAtOp(index int) point {
 	case opTypeQuadTo:
 		return op.p2
 	}
-	panic("not reached")
+	panic("vector: not reached")
 }
 
 func (s *subPath) startDir(index int) vec2 {
@@ -174,7 +174,7 @@ func (s *subPath) endDir(index int) vec2 {
 	case opTypeQuadTo:
 		return vec2{x: op.p2.x - op.p1.x, y: op.p2.y - op.p1.y}
 	}
-	panic("not reached")
+	panic("vector: not reached")
 }
 
 // flatPath is a flattened sub-path of a path.

--- a/vector/stroke.go
+++ b/vector/stroke.go
@@ -168,7 +168,7 @@ func strokeEndControlPositions(subPath *subPath, dist float32) (point, point, po
 
 func appendParalleledPathFromSubPath(strokePath *Path, subPath *subPath, options *StrokeOptions) {
 	if len(subPath.ops) == 0 {
-		panic("not reached")
+		panic("vector: not reached")
 	}
 
 	// As the source path is normalized, every operation is guaranteed to be valid.
@@ -192,7 +192,7 @@ func appendParalleledPathFromSubPath(strokePath *Path, subPath *subPath, options
 
 func appendParalleledPathFromSubPathReversed(strokePath *Path, subPath *subPath, options *StrokeOptions) {
 	if len(subPath.ops) == 0 {
-		panic("not reached")
+		panic("vector: not reached")
 	}
 
 	// As the source path is normalized, every operation is guaranteed to be valid.
@@ -214,7 +214,7 @@ func appendParalleledPathFromSubPathReversed(strokePath *Path, subPath *subPath,
 
 func appendParalleledLine(path *Path, p0, p1 point, dist float32) {
 	if p0 == p1 {
-		panic("not reached")
+		panic("vector: not reached")
 	}
 
 	dir := vec2{x: p1.x - p0.x, y: p1.y - p0.y}
@@ -226,7 +226,7 @@ func appendParalleledLine(path *Path, p0, p1 point, dist float32) {
 // appendParalleledLineForQuadIfNeeded appends a paralleled line for a quadratic curve if the quadratic curve is just a line.
 func appendParalleledLineForQuadIfNeeded(path *Path, p0, p1, p2 point, dist float32) bool {
 	if p0 == p1 && p0 == p2 {
-		panic("not reached")
+		panic("vector: not reached")
 	}
 	// This curve is empty as the start and the end points are the same.
 	if p0 == p2 {


### PR DESCRIPTION
This pull request updates panic messages across several modules to include their respective prefixes (e.g., ‎`vector:`, ‎`convert:`, ‎`directx:`, ‎`ebitenmobile:`). This change improves error identification and debugging by making it easier to locate the source of panics.
 • In ‎`audio/internal/convert/resampling.go`, panic messages now use the ‎`convert:` prefix.
 • In ‎`cmd/ebitenmobile/gobind.go`, unsupported language panics are prefixed with ‎`ebitenmobile:`.
 • In ‎`internal/graphicsdriver/directx/api_notmicrosoftgdk_windows.go`, all DirectX stub panics use the ‎`directx:` prefix.
 • In ‎`vector/path.go` and ‎`vector/stroke.go`, panic messages are prefixed with ‎`vector:`.

No functional changes are introduced; this is a developer experience improvement for debugging and maintenance.