### PR TITLE
all: Replace deprecated strings.Title with cases.Title

### DIFF
--- a/cmd/ebitenmobile/gobind.go
+++ b/cmd/ebitenmobile/gobind.go
@@ -27,6 +27,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -98,13 +100,14 @@ func run() error {
 
 	// Add additional files.
 	langs := strings.Split(*lang, ",")
+	caser := cases.Title(language.Und)
 	for _, lang := range langs {
 		pkgName, err := invokeOriginalGobind(lang)
 		if err != nil {
 			return err
 		}
 		prefixLower := *prefix + pkgName
-		prefixUpper := strings.Title(*prefix) + strings.Title(pkgName)
+		prefixUpper := caser.String(*prefix) + caser.String(pkgName)
 		replacePrefixes := func(content string) string {
 			content = strings.ReplaceAll(content, "{{.PrefixUpper}}", prefixUpper)
 			content = strings.ReplaceAll(content, "{{.PrefixLower}}", prefixLower)

--- a/cmd/ebitenmobile/main.go
+++ b/cmd/ebitenmobile/main.go
@@ -33,6 +33,8 @@ import (
 	"text/template"
 	"unicode"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -195,8 +197,9 @@ func doBind(args []string, flagset *flag.FlagSet, buildOS string) error {
 	if err != nil {
 		return err
 	}
+	caser := cases.Title(language.Und)
 	prefixLower := bindPrefix + pkgs[0].Name
-	prefixUpper := strings.Title(bindPrefix) + strings.Title(pkgs[0].Name)
+	prefixUpper := caser.String(bindPrefix) + caser.String(pkgs[0].Name)
 
 	args = append(args, "github.com/hajimehoshi/ebiten/v2/mobile/ebitenmobileview")
 
@@ -251,9 +254,7 @@ func doBind(args []string, flagset *flag.FlagSet, buildOS string) error {
 			frameworkName := filepath.Base(buildO)
 			frameworkNameBase := frameworkName[:len(frameworkName)-len(".xcframework")]
 			// The first character must be an upper case (#2192).
-			// TODO: strings.Title is used here for the consistency with gomobile (see cmd/gomobile/bind_iosapp.go).
-			// As strings.Title is deprecated, golang.org/x/text/cases should be used.
-			frameworkNameBase = strings.Title(frameworkNameBase)
+			frameworkNameBase = caser.String(frameworkNameBase)
 			dir := filepath.Join(buildO, name, frameworkNameBase+".framework")
 
 			if err := os.WriteFile(filepath.Join(dir, "Headers", prefixUpper+"EbitenViewController.h"), []byte(replacePrefixes(objcH)), 0644); err != nil {


### PR DESCRIPTION
Updated usage of the deprecated strings.Title function to golang.org/x/text/cases.Title in gobind.go and main.go for proper title casing. This improves future compatibility and aligns with Go best practices.

