### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/audio/internal/convert/float32_test.go
+++ b/audio/internal/convert/float32_test.go
@@ -60,10 +60,8 @@ func TestFloat32(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		c := c
 		t.Run(c.Name, func(t *testing.T) {
 			for _, seek := range []bool{false, true} {
-				seek := seek
 				name := "nonseek"
 				if seek {
 					name = "seek"

--- a/audio/internal/convert/resampling_test.go
+++ b/audio/internal/convert/resampling_test.go
@@ -90,10 +90,8 @@ func TestResampling(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		c := c
 		t.Run(fmt.Sprintf("%d to %d", c.In, c.Out), func(t *testing.T) {
 			for _, bitDepthInBytes := range []int{2, 4} {
-				bitDepthInBytes := bitDepthInBytes
 				t.Run(fmt.Sprintf("bitDepthInBytes=%d", bitDepthInBytes), func(t *testing.T) {
 					for _, seek := range []bool{false, true} {
 						t.Run(fmt.Sprintf("seek=%v", seek), func(t *testing.T) {

--- a/audio/internal/convert/stereof32_test.go
+++ b/audio/internal/convert/stereof32_test.go
@@ -60,10 +60,8 @@ func TestStereoF32(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			for _, mono := range []bool{false, true} {
-				mono := mono
 				t.Run(fmt.Sprintf("mono=%t", mono), func(t *testing.T) {
 					var inBytes, outBytes []byte
 					for _, v := range tc.In {

--- a/colorm/draw_test.go
+++ b/colorm/draw_test.go
@@ -109,7 +109,6 @@ func TestDrawTrianglesWithColorM(t *testing.T) {
 		ebiten.ColorScaleModeStraightAlpha,
 		ebiten.ColorScaleModePremultipliedAlpha,
 	} {
-		format := format
 		t.Run(fmt.Sprintf("format%d", format), func(t *testing.T) {
 			var cr, cg, cb, ca float32
 			switch format {
@@ -239,7 +238,6 @@ func TestColorMAndScale(t *testing.T) {
 		ebiten.ColorScaleModeStraightAlpha,
 		ebiten.ColorScaleModePremultipliedAlpha,
 	} {
-		format := format
 		t.Run(fmt.Sprintf("format%d", format), func(t *testing.T) {
 			dst := ebiten.NewImage(w, h)
 

--- a/image_test.go
+++ b/image_test.go
@@ -2074,7 +2074,6 @@ func TestImageDrawTrianglesWithColorM(t *testing.T) {
 		ebiten.ColorScaleModeStraightAlpha,
 		ebiten.ColorScaleModePremultipliedAlpha,
 	} {
-		format := format
 		t.Run(fmt.Sprintf("format%d", format), func(t *testing.T) {
 			var cr, cg, cb, ca float32
 			switch format {
@@ -2203,7 +2202,6 @@ func TestImageDrawTrianglesInterpolatesColors(t *testing.T) {
 		ebiten.ColorScaleModeStraightAlpha,
 		ebiten.ColorScaleModePremultipliedAlpha,
 	} {
-		format := format
 		t.Run(fmt.Sprintf("format%d", format), func(t *testing.T) {
 			dst := ebiten.NewImage(w, h)
 			dst.Fill(color.RGBA{B: 0xff, A: 0xff})
@@ -2829,7 +2827,6 @@ func TestImageEvenOdd(t *testing.T) {
 
 func TestImageFillRule(t *testing.T) {
 	for _, fillRule := range []ebiten.FillRule{ebiten.FillRuleFillAll, ebiten.FillRuleNonZero, ebiten.FillRuleEvenOdd} {
-		fillRule := fillRule
 		var name string
 		switch fillRule {
 		case ebiten.FillRuleFillAll:
@@ -3828,7 +3825,6 @@ func TestImageColorMAndScale(t *testing.T) {
 		ebiten.ColorScaleModeStraightAlpha,
 		ebiten.ColorScaleModePremultipliedAlpha,
 	} {
-		format := format
 		t.Run(fmt.Sprintf("format%d", format), func(t *testing.T) {
 			dst := ebiten.NewImage(w, h)
 

--- a/internal/shaderir/glsl/glsl.go
+++ b/internal/shaderir/glsl/glsl.go
@@ -153,7 +153,6 @@ func Compile(p *shaderir.Program, version GLSLVersion) (vertexShader, fragmentSh
 			// When a vertex entry point is not defined, allow to put all the functions. This is useful for testing.
 			funcs = make([]*shaderir.Func, 0, len(p.Funcs))
 			for _, f := range p.Funcs {
-				f := f
 				funcs = append(funcs, &f)
 			}
 		}
@@ -239,7 +238,6 @@ func Compile(p *shaderir.Program, version GLSLVersion) (vertexShader, fragmentSh
 			// When a fragment entry point is not defined, allow to put all the functions. This is useful for testing.
 			funcs = make([]*shaderir.Func, 0, len(p.Funcs))
 			for _, f := range p.Funcs {
-				f := f
 				funcs = append(funcs, &f)
 			}
 		}

--- a/internal/shaderir/hlsl/hlsl.go
+++ b/internal/shaderir/hlsl/hlsl.go
@@ -166,7 +166,6 @@ func Compile(p *shaderir.Program) (vertexShader, pixelShader, vertexPrelude, pix
 		// Use all the functions for testing.
 		vsfuncs = make([]*shaderir.Func, 0, len(p.Funcs))
 		for _, f := range p.Funcs {
-			f := f
 			vsfuncs = append(vsfuncs, &f)
 		}
 	}
@@ -218,7 +217,6 @@ func Compile(p *shaderir.Program) (vertexShader, pixelShader, vertexPrelude, pix
 		// Use all the functions for testing.
 		psfuncs = make([]*shaderir.Func, 0, len(p.Funcs))
 		for _, f := range p.Funcs {
-			f := f
 			psfuncs = append(psfuncs, &f)
 		}
 	}

--- a/internal/shaderir/ir_test.go
+++ b/internal/shaderir/ir_test.go
@@ -1076,7 +1076,6 @@ void main(void) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			vs, fs := glsl.Compile(&tc.Program, glsl.GLSLVersionDefault)
 			{

--- a/internal/shaderir/program.go
+++ b/internal/shaderir/program.go
@@ -399,7 +399,6 @@ func IsValidSwizzling(s string) bool {
 func (p *Program) ReachableFuncsFromBlock(block *Block) []*Func {
 	indexToFunc := map[int]*Func{}
 	for _, f := range p.Funcs {
-		f := f
 		indexToFunc[f.Index] = &f
 	}
 
@@ -455,7 +454,6 @@ func walkExprsInExpr(f func(expr *Expr), expr *Expr) {
 func (p *Program) appendReachableUniformVariablesFromBlock(indices []int, block *Block) []int {
 	indexToFunc := map[int]*Func{}
 	for _, f := range p.Funcs {
-		f := f
 		indexToFunc[f.Index] = &f
 	}
 

--- a/shader_test.go
+++ b/shader_test.go
@@ -645,7 +645,6 @@ func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
 	}
 
 	for _, shader := range shaders {
-		shader := shader
 		t.Run(shader.Name, func(t *testing.T) {
 			const w, h = 1, 1
 
@@ -1624,7 +1623,6 @@ func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			const w, h = 1, 1
 
@@ -1815,7 +1813,6 @@ func TestShaderDifferentTextureSizes(t *testing.T) {
 	src1.Fill(color.RGBA{0x30, 0x20, 0x10, 0xff})
 
 	for _, unit := range []string{"texels", "pixels"} {
-		unit := unit
 		t.Run(fmt.Sprintf("unit %s", unit), func(t *testing.T) {
 			shader, err := ebiten.NewShader([]byte(fmt.Sprintf(`//kage:unit %s
 
@@ -1981,7 +1978,6 @@ func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(fmt.Sprintf("%v", tc.uniforms), func(t *testing.T) {
 			defer func() {
 				r := recover()
@@ -2096,7 +2092,6 @@ func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
 		}
 
 		for _, withSrc := range []bool{false, true} {
-			withSrc := withSrc
 			title := "WithSrc,unit=" + unit
 			if !withSrc {
 				title = "WithoutSrc,unit=" + unit
@@ -2189,7 +2184,6 @@ func TestShaderDifferentSourceSizes(t *testing.T) {
 	src1.Fill(color.RGBA{0x30, 0x20, 0x10, 0xff})
 
 	for _, unit := range []string{"texels", "pixels"} {
-		unit := unit
 		t.Run(fmt.Sprintf("unit %s", unit), func(t *testing.T) {
 			if unit == "texels" {
 				defer func() {
@@ -2292,7 +2286,6 @@ func TestShaderBitwiseOperator(t *testing.T) {
 	src.Fill(color.RGBA{R: 0x24, G: 0x3f, B: 0x6a, A: 0xff})
 
 	for _, assign := range []bool{false, true} {
-		assign := assign
 		name := "op"
 		if assign {
 			name = "op+assign"

--- a/text/v2/gotextfacesource.go
+++ b/text/v2/gotextfacesource.go
@@ -265,7 +265,6 @@ func (g *GoTextFaceSource) shapeImpl(text string, face *GoTextFace) ([]shaping.O
 		indices = append(indices, len(text))
 
 		for _, gl := range out.Glyphs {
-			gl := gl
 			var segs []opentype.Segment
 			if g.glyphDataCache == nil {
 				g.glyphDataCache = newCache[glyphDataCacheKey, font.GlyphData](512)

--- a/text/v2/text_test.go
+++ b/text/v2/text_test.go
@@ -389,7 +389,6 @@ func TestGoXFaceMetrics(t *testing.T) {
 	}
 
 	for _, fontFile := range fontFiles {
-		fontFile := fontFile
 		t.Run(fontFile, func(t *testing.T) {
 			fontdata, err := os.ReadFile(filepath.Join("testdata", fontFile))
 			if err != nil {
@@ -457,7 +456,6 @@ func TestCollection(t *testing.T) {
 		"/System/Library/Fonts/Helvetica.ttc",
 	}
 	for _, path := range fontFilePaths {
-		path := path
 		t.Run(path, func(t *testing.T) {
 			bs, err := os.ReadFile(path)
 			if err != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->

## What _type_ of issue is this addressing?
<!-- bug | feature | security -->

refactor

## What this PR does | solves
<!-- Please be as descriptive as possible -->


The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore
