### PR TITLE
inpututil: add function to get current gamepad ids

### DIFF
--- a/inpututil/inpututil.go
+++ b/inpututil/inpututil.go
@@ -226,6 +226,25 @@ func MouseButtonPressDuration(button ebiten.MouseButton) int {
 	return int(inputstate.Get().MouseButtonPressDuration(ui.MouseButton(button)))
 }
 
+
+// AppendGamepadIDs appends currently connected gamepad IDs to gamepadIDs,
+// and returns the extended buffer.
+// Giving a slice that already has enough capacity works efficiently.
+//
+// AppendGamepadIDs is concurrent safe.
+func AppendGamepadIDs(gamepadIDs []ebiten.GamepadID) []ebiten.GamepadID {
+    theInputState.m.RLock()
+	defer theInputState.m.RUnlock()
+
+	origLen := len(gamepadIDs)
+	for id := range theInputState.gamepadStates {
+        gamepadIDs = append(gamepadIDs, id)
+	}
+
+	slices.Sort(gamepadIDs[origLen:])
+	return gamepadIDs
+}
+
 // AppendJustConnectedGamepadIDs appends gamepad IDs that are connected just in the current tick to gamepadIDs,
 // and returns the extended buffer.
 // Giving a slice that already has enough capacity works efficiently.


### PR DESCRIPTION
# What issue is this addressing?
It would be convenient to have an API that returns the current set of connected gamepad ids. Otherwise an application must keep track on its own via
```
var gamepadIDs map[ebiten.GamepadID]struct{}
func Update(){
  ids = AppendJustConnectedGamepadIDs(nil)
  // set new ids in map ...
  // remove old ones no longer connected
  for id := range gamepadIDs {
    if IsGamepadJustDisconnected(id) {
     delete(gamepadIDs, di)
   }
  }
```

## What _type_ of issue is this addressing?
Feature, add an API for gamepad in inpututil

## What this PR does | solves
This PR adds a function called AppendGamepadIDs that accepts a slice of GamepadID, and appends to it all the current gamepad ids (from `theInputState.gamepadStates`). This function is almost identical to AppendJustConnectedGamepadIDs but does not compare the ids in the current gamepad state to the previous state.

Note that this is similar to the APIs `AppendTouchIDs` and `AppendPressedKeys`, but those APIs are not public.
