### PR TITLE
Fixes godoc error for GraphicsLibraryPlayStation5

### DIFF
--- a/graphics.go
+++ b/graphics.go
@@ -55,7 +55,7 @@ const (
 	// GraphicsLibraryMetal represents the graphics library Apple's Metal.
 	GraphicsLibraryMetal GraphicsLibrary = GraphicsLibrary(ui.GraphicsLibraryMetal)
 
-	// GraphicsLibraryMetal represents the graphics library PlayStation 5.
+	// GraphicsLibraryPlayStation5 represents the graphics library PlayStation 5.
 	GraphicsLibraryPlayStation5 GraphicsLibrary = GraphicsLibrary(ui.GraphicsLibraryPlayStation5)
 )
 


### PR DESCRIPTION
This very unnecessary nitpick PR that I can only apologise for fixes the godoc for the GraphicsLibraryPlayStation5 variable. (found when reading through the godoc).