### PR TITLE
Windows: Add support for setting light/dark mode and window backdrop

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -173,16 +173,18 @@ func (u *UserInterface) dumpImages(dir string) (string, error) {
 }
 
 type RunOptions struct {
-	GraphicsLibrary          GraphicsLibrary
-	InitUnfocused            bool
-	ScreenTransparent        bool
-	SkipTaskbar              bool
-	SingleThread             bool
-	DisableHiDPI             bool
-	ColorSpace               color.ColorSpace
-	ApplePressAndHoldEnabled bool
-	X11ClassName             string
-	X11InstanceName          string
+	GraphicsLibrary           GraphicsLibrary
+	InitUnfocused             bool
+	ScreenTransparent         bool
+	SkipTaskbar               bool
+	SingleThread              bool
+	DisableHiDPI              bool
+	ColorSpace                color.ColorSpace
+	ApplePressAndHoldEnabled  bool
+	X11ClassName              string
+	X11InstanceName           string
+	WindowsUseDarkMode        bool
+	WindowsSystemBackdropType int
 }
 
 // InitialWindowPosition returns the position for centering the given second width/height pair within the first width/height pair.

--- a/internal/ui/ui_darwin.go
+++ b/internal/ui/ui_darwin.go
@@ -450,6 +450,10 @@ func (u *UserInterface) skipTaskbar() error {
 	return nil
 }
 
+func (u *UserInterface) setDWMWindowAttributes(options *RunOptions) error {
+	return nil
+}
+
 // setDocumentEdited must be called from the main thread.
 func (u *UserInterface) setDocumentEdited(edited bool) error {
 	w, err := u.window.GetCocoaWindow()

--- a/internal/ui/ui_glfw.go
+++ b/internal/ui/ui_glfw.go
@@ -1171,6 +1171,10 @@ func (u *UserInterface) initOnMainThread(options *RunOptions) error {
 		_ = u.skipTaskbar()
 	}
 
+	if err := u.setDWMWindowAttributes(options); err != nil {
+		return err
+	}
+
 	switch g := u.graphicsDriver.(type) {
 	case interface{ SetGLFWWindow(window *glfw.Window) }:
 		g.SetGLFWWindow(u.window)

--- a/internal/ui/ui_linbsd.go
+++ b/internal/ui/ui_linbsd.go
@@ -207,6 +207,10 @@ func (u *UserInterface) skipTaskbar() error {
 	return nil
 }
 
+func (u *UserInterface) setDWMWindowAttributes(options *RunOptions) error {
+	return nil
+}
+
 func (u *UserInterface) setDocumentEdited(edited bool) error {
 	return nil
 }

--- a/internal/winver/winver_windows.go
+++ b/internal/winver/winver_windows.go
@@ -85,3 +85,11 @@ func IsWindows10AnniversaryUpdateOrGreater() bool {
 func IsWindows10CreatorsUpdateOrGreater() bool {
 	return isWindows10BuildOrGreater(15063)
 }
+
+func IsWindows11Build22000OrGreater() bool {
+	return isWindows10BuildOrGreater(22000)
+}
+
+func IsWindows11Build22621OrGreater() bool {
+	return isWindows10BuildOrGreater(22621)
+}

--- a/run.go
+++ b/run.go
@@ -312,6 +312,18 @@ type RunGameOptions struct {
 
 	// X11InstanceName is an instance name in the ICCCM WM_CLASS window property.
 	X11InstanceName string
+
+	// WindowsUseDarkMode indicates whether the window uses dark mode on Windows.
+	// WindowsUseDarkMode requires Windows 11 or later. On older Windows, this option is ignored.
+	//
+	// The default (zero) value is false.
+	WindowsUseDarkMode bool
+
+	// WindowsSystemBackdropType specifies the system backdrop type on Windows.
+	// WindowsSystemBackdropType requires Windows 11 22H2 or later. On older Windows, this option is ignored.
+	//
+	// The default (zero) value is WindowsSystemBackdropTypeNone.
+	WindowsSystemBackdropType WindowsSystemBackdropType
 }
 
 // RunGameWithOptions starts the main loop and runs the game with the specified options.
@@ -725,16 +737,18 @@ func toUIRunOptions(options *RunGameOptions) *ui.RunOptions {
 	}
 
 	return &ui.RunOptions{
-		GraphicsLibrary:          ui.GraphicsLibrary(options.GraphicsLibrary),
-		InitUnfocused:            options.InitUnfocused,
-		ScreenTransparent:        options.ScreenTransparent,
-		SkipTaskbar:              options.SkipTaskbar,
-		SingleThread:             options.SingleThread,
-		DisableHiDPI:             options.DisableHiDPI,
-		ColorSpace:               colorSpace,
-		ApplePressAndHoldEnabled: options.ApplePressAndHoldEnabled,
-		X11ClassName:             options.X11ClassName,
-		X11InstanceName:          options.X11InstanceName,
+		GraphicsLibrary:           ui.GraphicsLibrary(options.GraphicsLibrary),
+		InitUnfocused:             options.InitUnfocused,
+		ScreenTransparent:         options.ScreenTransparent,
+		SkipTaskbar:               options.SkipTaskbar,
+		SingleThread:              options.SingleThread,
+		DisableHiDPI:              options.DisableHiDPI,
+		ColorSpace:                colorSpace,
+		ApplePressAndHoldEnabled:  options.ApplePressAndHoldEnabled,
+		X11ClassName:              options.X11ClassName,
+		X11InstanceName:           options.X11InstanceName,
+		WindowsUseDarkMode:        options.WindowsUseDarkMode,
+		WindowsSystemBackdropType: int(options.WindowsSystemBackdropType),
 	}
 }
 

--- a/windowsbackdrop.go
+++ b/windowsbackdrop.go
@@ -1,0 +1,36 @@
+// Copyright 2025 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebiten
+
+// WindowsSystemBackdropType specifies the system backdrop type on Windows.
+// See https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type
+type WindowsSystemBackdropType int
+
+const (
+	// WindowsSystemBackdropTypeNone indicates no system backdrop (DWMSBT_NONE).
+	WindowsSystemBackdropTypeNone WindowsSystemBackdropType = iota
+
+	// WindowsSystemBackdropTypeAuto lets the system decide the backdrop (DWMSBT_AUTO).
+	WindowsSystemBackdropTypeAuto
+
+	// WindowsSystemBackdropTypeMica uses the Mica backdrop (DWMSBT_MAINWINDOW).
+	WindowsSystemBackdropTypeMica
+
+	// WindowsSystemBackdropTypeAcrylic uses the Acrylic backdrop (DWMSBT_TRANSIENTWINDOW).
+	WindowsSystemBackdropTypeAcrylic
+
+	// WindowsSystemBackdropTypeTabbed uses the Tabbed backdrop (DWMSBT_TABBEDWINDOW).
+	WindowsSystemBackdropTypeTabbed
+)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md
Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->
Closes #3381 

## What _type_ of issue is this addressing?
<!-- bug | feature | security -->
Feature

## What this PR does | solves
<!-- Please be as descriptive as possible -->
This PR adds two new fields to `RunGameOptions` that allows a user to specify dark mode and backdrop [attributes](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute)) for Windows 11. It is a no-op on platforms other than Windows 11. The attributes are applied at window creation time in `ui_glfw.go`, invoking new DWM attribute setting methods in `ui_windows.go`.

<img width="785" height="185" alt="dark" src="https://github.com/user-attachments/assets/a1618a86-fc79-47c6-a517-a476b40621b8" />
<img width="783" height="167" alt="light" src="https://github.com/user-attachments/assets/350f2115-5db9-4e8f-a038-4be789678123" />

