### PR TITLE
examples: Fixed snake game breakage when changing const gridSize

### DIFF
--- a/examples/snake/main.go
+++ b/examples/snake/main.go
@@ -85,10 +85,10 @@ func (g *Game) needsToMoveSnake() bool {
 }
 
 func (g *Game) reset() {
-	g.apple.X = 3 * gridSize
-	g.apple.Y = 3 * gridSize
+	g.apple.X = xGridCountInScreen / 3
+	g.apple.Y = yGridCountInScreen / 3
 	g.moveTime = 4
-	g.snakeBody = g.snakeBody[:1]
+	g.snakeBody = make([]Position, 1)
 	g.snakeBody[0].X = xGridCountInScreen / 2
 	g.snakeBody[0].Y = yGridCountInScreen / 2
 	g.score = 0
@@ -185,13 +185,8 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 }
 
 func newGame() *Game {
-	g := &Game{
-		apple:     Position{X: 3 * gridSize, Y: 3 * gridSize},
-		moveTime:  4,
-		snakeBody: make([]Position, 1),
-	}
-	g.snakeBody[0].X = xGridCountInScreen / 2
-	g.snakeBody[0].Y = yGridCountInScreen / 2
+	g := &Game{}
+	g.reset()
 	return g
 }
 


### PR DESCRIPTION
The apple’s starting position is incorrect if you increase the gridSize constant. I changed it to 20, and the apple is outside the screen.

Before my commit:
<img width="752" height="624" alt="image" src="https://github.com/user-attachments/assets/86d52f96-b3d8-4809-90d8-14cf982e48fa" />


After my commit:
<img width="752" height="624" alt="Screenshot 2026-03-23 at 20 47 31" src="https://github.com/user-attachments/assets/5c3adcb4-41eb-4586-b5c2-ed7721b2a126" />

