### PR TITLE
NewShader: allow multiple sources as arguments

### DIFF
--- a/shader.go
+++ b/shader.go
@@ -35,12 +35,31 @@ type Shader struct {
 }
 
 // NewShader compiles a shader program in the shading language Kage, and returns the result.
+// The src argument is the shader source code. The extra arguments are also shader source codes, and they are concatenated to the src argument. This is useful when you want to split a shader into multiple files.
 //
 // If the compilation fails, NewShader returns an error.
 //
 // For the details about the shader, see https://ebitengine.org/en/documents/shader.html.
-func NewShader(src []byte) (*Shader, error) {
-	return newShader(src, "")
+func NewShader(src []byte, extra... []byte) (*Shader, error) {
+	return newShader(flatten(src, extra), "")
+}
+
+func flatten(src []byte, extra [][]byte) []byte {
+    if len(extra) == 0 {
+        return src
+    }
+
+    total := len(src)
+    for _, e := range extra {
+        total += len(e)
+    }
+
+    b := make([]byte, 0, total)
+    b = append(b, src...)
+    for _, e := range extra {
+        b = append(b, e...)
+    }
+    return b
 }
 
 func newShader(src []byte, name string) (*Shader, error) {

--- a/shader.go
+++ b/shader.go
@@ -40,26 +40,26 @@ type Shader struct {
 // If the compilation fails, NewShader returns an error.
 //
 // For the details about the shader, see https://ebitengine.org/en/documents/shader.html.
-func NewShader(src []byte, extra... []byte) (*Shader, error) {
+func NewShader(src []byte, extra ...[]byte) (*Shader, error) {
 	return newShader(flatten(src, extra), "")
 }
 
 func flatten(src []byte, extra [][]byte) []byte {
-    if len(extra) == 0 {
-        return src
-    }
+	if len(extra) == 0 {
+		return src
+	}
 
-    total := len(src)
-    for _, e := range extra {
-        total += len(e)
-    }
+	total := len(src)
+	for _, e := range extra {
+		total += len(e)
+	}
 
-    b := make([]byte, 0, total)
-    b = append(b, src...)
-    for _, e := range extra {
-        b = append(b, e...)
-    }
-    return b
+	b := make([]byte, 0, total)
+	b = append(b, src...)
+	for _, e := range extra {
+		b = append(b, e...)
+	}
+	return b
 }
 
 func newShader(src []byte, name string) (*Shader, error) {

--- a/shader_test.go
+++ b/shader_test.go
@@ -279,7 +279,7 @@ func TestShaderMultipleSources(t *testing.T) {
 
 	dst := ebiten.NewImage(w, h)
 
-    extra := `
+	extra := `
 func clr(red float) (float, float, float, float) {
 	return red, 0, 0, 1
 }

--- a/shader_test.go
+++ b/shader_test.go
@@ -274,6 +274,41 @@ func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
 	}
 }
 
+func TestShaderMultipleSources(t *testing.T) {
+	const w, h = 16, 16
+
+	dst := ebiten.NewImage(w, h)
+
+    extra := `
+func clr(red float) (float, float, float, float) {
+	return red, 0, 0, 1
+}
+`
+
+	s, err := ebiten.NewShader([]byte(`//kage:unit pixels
+package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	return vec4(clr(1))
+}
+`), []byte(extra))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dst.DrawRectShader(w, h, s, nil)
+
+	for j := range h {
+		for i := range w {
+			got := dst.At(i, j).(color.RGBA)
+			want := color.RGBA{R: 0xff, A: 0xff}
+			if got != want {
+				t.Errorf("dst.At(%d, %d): got: %v, want: %v", i, j, got, want)
+			}
+		}
+	}
+}
+
 func TestShaderUninitializedUniformVariables(t *testing.T) {
 	const w, h = 16, 16
 

--- a/shader_test.go
+++ b/shader_test.go
@@ -279,8 +279,7 @@ func TestShaderMultipleSources(t *testing.T) {
 
 	dst := ebiten.NewImage(w, h)
 
-	extra := `
-func clr(red float) (float, float, float, float) {
+	extra := `func clr(red float) (float, float, float, float) {
 	return red, 0, 0, 1
 }
 `


### PR DESCRIPTION
# What issue is this addressing?
New feature discussed in #dev to allow multiple arguments to NewShader

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
NewShader(src) accepts one argument that should contain the entirety of the shader program, including all helper functions. It is useful to put helper functions into their own file, so as a convenience NewShader() can accept multiple arguments. The full shader program is the concatenation of all the arguments (order doesn't matter).

```
helpers := loadHelperFunctions()
mainShader := loadShader()
shader := ebiten.NewShader(mainShader, helpers)
```
