### PR TITLE
ebitenutil: check HTTP status in NewImageFromURL

### DIFF
--- a/ebitenutil/loadimage.go
+++ b/ebitenutil/loadimage.go
@@ -15,6 +15,7 @@
 package ebitenutil
 
 import (
+	"fmt"
 	"image"
 	"io"
 	"net/http"
@@ -47,6 +48,9 @@ func NewImageFromURL(url string) (*ebiten.Image, error) {
 	defer func() {
 		_ = res.Body.Close()
 	}()
+	if res.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("GET %s: %s", url, res.Status)
+	}
 
 	img, _, err := image.Decode(res.Body)
 	if err != nil {

--- a/ebitenutil/loadimage.go
+++ b/ebitenutil/loadimage.go
@@ -49,7 +49,7 @@ func NewImageFromURL(url string) (*ebiten.Image, error) {
 		_ = res.Body.Close()
 	}()
 	if res.StatusCode/100 != 2 {
-		return nil, fmt.Errorf("GET %s: %s", url, res.Status)
+		return nil, fmt.Errorf("ebitenutil: request to %s failed: %s", url, res.Status)
 	}
 
 	img, _, err := image.Decode(res.Body)

--- a/ebitenutil/loadimage.go
+++ b/ebitenutil/loadimage.go
@@ -48,7 +48,7 @@ func NewImageFromURL(url string) (*ebiten.Image, error) {
 	defer func() {
 		_ = res.Body.Close()
 	}()
-	if res.StatusCode/100 != 2 {
+	if res.StatusCode < http.StatusOK || 300 <= res.StatusCode {
 		return nil, fmt.Errorf("ebitenutil: request to %s failed: %s", url, res.Status)
 	}
 

--- a/ebitenutil/loadimage_test.go
+++ b/ebitenutil/loadimage_test.go
@@ -15,9 +15,10 @@
 package ebitenutil_test
 
 import (
+	"image"
+	"image/png"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
@@ -25,15 +26,15 @@ import (
 
 func TestNewImageFromURLHTTPError(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "not found", http.StatusNotFound)
+		w.WriteHeader(http.StatusNotFound)
+		if err := png.Encode(w, image.NewRGBA(image.Rect(0, 0, 1, 1))); err != nil {
+			t.Errorf("png.Encode failed: %v", err)
+		}
 	}))
 	defer s.Close()
 
 	_, err := ebitenutil.NewImageFromURL(s.URL)
 	if err == nil {
 		t.Fatal("NewImageFromURL returned nil error for HTTP 404")
-	}
-	if got, want := err.Error(), "404 Not Found"; !strings.Contains(got, want) {
-		t.Fatalf("NewImageFromURL error = %q, want to contain %q", got, want)
 	}
 }

--- a/ebitenutil/loadimage_test.go
+++ b/ebitenutil/loadimage_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebitenutil_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+)
+
+func TestNewImageFromURLHTTPError(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer s.Close()
+
+	_, err := ebitenutil.NewImageFromURL(s.URL)
+	if err == nil {
+		t.Fatal("NewImageFromURL returned nil error for HTTP 404")
+	}
+	if got, want := err.Error(), "404 Not Found"; !strings.Contains(got, want) {
+		t.Fatalf("NewImageFromURL error = %q, want to contain %q", got, want)
+	}
+}

--- a/ebitenutil/loadimage_test.go
+++ b/ebitenutil/loadimage_test.go
@@ -33,8 +33,7 @@ func TestNewImageFromURLHTTPError(t *testing.T) {
 	}))
 	defer s.Close()
 
-	_, err := ebitenutil.NewImageFromURL(s.URL)
-	if err == nil {
+	if _, err := ebitenutil.NewImageFromURL(s.URL); err == nil {
 		t.Fatal("NewImageFromURL returned nil error for HTTP 404")
 	}
 }


### PR DESCRIPTION
NewImageFromURL previously decoded every successful http.Get response body regardless of HTTP status. For responses like 404 or 500, callers got an image decode error instead of the HTTP failure.

This change checks for non-2xx responses before decoding and returns an error containing the URL and HTTP status.

Tested with:
- go test ./ebitenutil