### PR TITLE
internal/glfw: listen to XkbMapNotify events to rebuild key tables

### DIFF
--- a/internal/glfw/x11_consts_linbsd.go
+++ b/internal/glfw/x11_consts_linbsd.go
@@ -73,7 +73,9 @@ const (
 	_XkbKeyNameLength  = 4
 	_XkbEventCode      = 0
 	_XkbStateNotify    = 2
+	_XkbMapNotify      = 1
 	_XkbGroupStateMask = 1 << 4
+	_XkbKeySymsMask    = 1 << 1
 )
 
 // X.h (continued)

--- a/internal/glfw/x11_init_linbsd.go
+++ b/internal/glfw/x11_init_linbsd.go
@@ -758,6 +758,7 @@ func initExtensions() error {
 		}
 
 		xkbSelectEventDetails(display, _XkbUseCoreKbd, _XkbStateNotify, _XkbGroupStateMask, _XkbGroupStateMask)
+		xkbSelectEventDetails(display, _XkbUseCoreKbd, _XkbMapNotify, _XkbKeySymsMask, _XkbKeySymsMask)
 	}
 
 	if handle, err := openX11Library("libXrender.so.1", "libXrender.so"); err == nil {

--- a/internal/glfw/x11_window_linbsd.go
+++ b/internal/glfw/x11_window_linbsd.go
@@ -1159,9 +1159,13 @@ func processEvent(event *_XEvent) error {
 
 	if _glfw.platformWindow.xkb.available {
 		if event.EventType() == _glfw.platformWindow.xkb.eventBase+_XkbEventCode {
-			if event.xkbAny().XkbType == _XkbStateNotify &&
+			xkbType := event.xkbAny().XkbType
+			if xkbType == _XkbStateNotify &&
 				event.xkbState().Changed&_XkbGroupStateMask != 0 {
 				_glfw.platformWindow.xkb.group = uint32(event.xkbState().Group)
+			}
+			if xkbType == _XkbMapNotify {
+				createKeyTables()
 			}
 
 			return nil


### PR DESCRIPTION
Listen to XkbMapNotify events from the X server and call createKeyTables() when the keyboard mapping changes, so the keysym-based fallback correctly reflects the new layout.