### PR TITLE
internal/glfw: listen to XkbMapNotify events to rebuild key tables

### DIFF
--- a/internal/glfw/x11_consts_linbsd.go
+++ b/internal/glfw/x11_consts_linbsd.go
@@ -73,7 +73,9 @@ const (
 	_XkbKeyNameLength  = 4
 	_XkbEventCode      = 0
 	_XkbStateNotify    = 2
+	_XkbMapNotify      = 1
 	_XkbGroupStateMask = 1 << 4
+	_XkbKeySymsMask    = 1 << 1
 )
 
 // X.h (continued)

--- a/internal/glfw/x11_init_linbsd.go
+++ b/internal/glfw/x11_init_linbsd.go
@@ -758,6 +758,7 @@ func initExtensions() error {
 		}
 
 		xkbSelectEventDetails(display, _XkbUseCoreKbd, _XkbStateNotify, _XkbGroupStateMask, _XkbGroupStateMask)
+		xkbSelectEventDetails(display, _XkbUseCoreKbd, _XkbMapNotify, _XkbKeySymsMask, _XkbKeySymsMask)
 	}
 
 	if handle, err := openX11Library("libXrender.so.1", "libXrender.so"); err == nil {

--- a/internal/glfw/x11_init_linbsd.go
+++ b/internal/glfw/x11_init_linbsd.go
@@ -791,8 +791,6 @@ func initExtensions() error {
 	}
 
 	// Update the key code LUT
-	// FIXME: We should listen to XkbMapNotify events to track changes to
-	// the keyboard mapping.
 	createKeyTables()
 
 	// String format atoms

--- a/internal/glfw/x11_window_linbsd.go
+++ b/internal/glfw/x11_window_linbsd.go
@@ -1157,19 +1157,17 @@ func processEvent(event *_XEvent) error {
 		}
 	}
 
-	if _glfw.platformWindow.xkb.available {
-		if event.EventType() == _glfw.platformWindow.xkb.eventBase+_XkbEventCode {
-			xkbType := event.xkbAny().XkbType
-			if xkbType == _XkbStateNotify &&
-				event.xkbState().Changed&_XkbGroupStateMask != 0 {
+	if _glfw.platformWindow.xkb.available && event.EventType() == _glfw.platformWindow.xkb.eventBase+_XkbEventCode {
+		switch event.xkbAny().XkbType {
+		case _XkbStateNotify:
+			if event.xkbState().Changed&_XkbGroupStateMask != 0 {
 				_glfw.platformWindow.xkb.group = uint32(event.xkbState().Group)
 			}
-			if xkbType == _XkbMapNotify {
-				createKeyTables()
-			}
-
-			return nil
+		case _XkbMapNotify:
+			createKeyTables()
 		}
+
+		return nil
 	}
 
 	if event.EventType() == _GenericEvent {

--- a/internal/glfw/x11_window_linbsd.go
+++ b/internal/glfw/x11_window_linbsd.go
@@ -1159,9 +1159,13 @@ func processEvent(event *_XEvent) error {
 
 	if _glfw.platformWindow.xkb.available {
 		if event.EventType() == _glfw.platformWindow.xkb.eventBase+_XkbEventCode {
-			if event.xkbAny().XkbType == _XkbStateNotify &&
+			xkbType := event.xkbAny().XkbType
+			if xkbType == _XkbStateNotify &&
 				event.xkbState().Changed&_XkbGroupStateMask != 0 {
 				_glfw.platformWindow.xkb.group = uint32(event.xkbState().Group)
+			}
+			if xkbType == _XkbMapNotify {
+				createKeyTables()
 			}
 
 			return nil


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/hajimehoshi/ebiten/blob/main/CONTRIBUTING.md

Also please adhere to our Code of Conduct:
https://github.com/hajimehoshi/ebiten/blob/main/CODE_OF_CONDUCT.md
-->

# What issue is this addressing?
This addresses a FIXME comment in the code.

## What _type_ of issue is this addressing?
feature

## What this PR does | solves

Addresses a FIXME at `internal/glfw/x11_init_linbsd.go:793`:

    // FIXME: We should listen to XkbMapNotify events to track changes to
    // the keyboard mapping.

When a user changes the keyboard layout on X11 (e.g. via `setxkbmap`),
the X server sends a `XkbMapNotify` event. The key code lookup tables
were only built once during init and never refreshed, so keys that
rely on the keysym-based fallback path would map to wrong GLFW key
constants after a layout change.

This PR subscribes to `XkbMapNotify` events and calls
`createKeyTables()` to rebuild the key tables when the keyboard
mapping changes.