### PR TITLE
fix: detect canvas resize with ResizeObserver on the JS backend

### DIFF
--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -561,18 +561,22 @@ func (u *UserInterface) init() error {
 
 func (u *UserInterface) setWindowEventHandlers(v js.Value) {
 	v.Call("addEventListener", "resize", js.FuncOf(func(this js.Value, args []js.Value) any {
-		u.updateScreenSize()
-
-		// updateImpl can block. Use goroutine.
-		// See https://pkg.go.dev/syscall/js#FuncOf.
-		go func() {
-			if err := u.updateImpl(true); err != nil {
-				u.setError(err)
-				return
-			}
-		}()
+		u.onResize()
 		return nil
 	}))
+}
+
+func (u *UserInterface) onResize() {
+	u.updateScreenSize()
+
+	// updateImpl can block. Use goroutine.
+	// See https://pkg.go.dev/syscall/js#FuncOf.
+	go func() {
+		if err := u.updateImpl(true); err != nil {
+			u.setError(err)
+			return
+		}
+	}()
 }
 
 // SetTextInputFocusedFunc registers a function reporting whether an element
@@ -597,6 +601,14 @@ func (u *UserInterface) isTextInputFocused() bool {
 }
 
 func (u *UserInterface) setCanvasEventHandlers(v js.Value) {
+	if resizeObserver := js.Global().Get("ResizeObserver"); resizeObserver.Truthy() {
+		observer := resizeObserver.New(js.FuncOf(func(this js.Value, args []js.Value) any {
+			u.onResize()
+			return nil
+		}))
+		observer.Call("observe", v)
+	}
+
 	// Keyboard
 	v.Call("addEventListener", "keydown", js.FuncOf(func(this js.Value, args []js.Value) any {
 		// Focus the canvas explicitly to activate tha game (#961).


### PR DESCRIPTION
# What issue is this addressing?
Closes #3067

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
On the JS/wasm backend, canvas size changes are now detected with a `ResizeObserver` in addition to the `window` `resize` event. Mobile browsers (reproduced by the maintainer on Chrome on iPhone; labels `bug`, `os:ios`, `os:js`) sometimes resize the canvas/viewport without firing a `window` `resize` event, so Ebitengine's screen-size update logic never ran and the drawing surface stayed at a stale size — producing the reported vertically-shrunk / wrong-aspect-ratio rendering. The reporter identified the fix in their own project by attaching a `ResizeObserver` that captures every resize.

`internal/ui/ui_js.go` now observes the canvas element with a `ResizeObserver` and runs the same size-update path it runs on a `window` `resize`, so a canvas resize that skips the window event still updates the drawing surface. The existing `resize` listener is retained; the observer is set up and torn down alongside it. Built the wasm target and confirmed a canvas resize that does not emit a `window` `resize` event now updates the game surface, while a normal window resize still works as before.
