### PR TITLE
examples/audiopanning: add lerp, more specific small buffer reason

### DIFF
--- a/examples/audiopanning/main.go
+++ b/examples/audiopanning/main.go
@@ -205,8 +205,6 @@ func (s *StereoPanStream) Read(p []byte) (int, error) {
 		p[i+6] = byte(rcBits >> 16)
 		p[i+7] = byte(rcBits >> 24)
 	}
-	// Only update the prevPan value if some frames of audio were actually processed. If none were
-	// processed, interpolation should continue from the old value during the next Read.
 	if alignedN > 0 {
 		s.prevPan = pan
 	}

--- a/examples/audiopanning/main.go
+++ b/examples/audiopanning/main.go
@@ -145,13 +145,10 @@ func main() {
 // based on the Panning.
 type StereoPanStream struct {
 	io.ReadSeeker
-	// m protects pan. Read is called by the audio system, which might be running in a different
+	// mu protects pan. Read is called by the audio system, which might be running in a different
 	// goroutine than the Update loop that calls SetPan.
-	m   sync.Mutex
-	pan float64 // -1: left; 0: center; 1: right
-	// prevPan is the final pan value during the previous Read call. Used to interpolate the pan
-	// effect smoothly regardless of quick pan changes or large buffer sizes. The interpolation
-	// helps avoid a discontinuous signal that sometimes causes audible clicks or pops.
+	mu      sync.Mutex
+	pan     float64 // -1: left; 0: center; 1: right
 	prevPan float64
 	buf     []byte
 }
@@ -177,9 +174,9 @@ func (s *StereoPanStream) Read(p []byte) (int, error) {
 	alignedN := totalN - extra
 
 	prevPan := s.prevPan
-	s.m.Lock()
+	s.mu.Lock()
 	pan := s.pan
-	s.m.Unlock()
+	s.mu.Unlock()
 
 	// This implementation uses a linear scale, ranging from -1 to 1, for stereo or mono sounds.
 	// If pan = 0.0, the balance for the sound in each speaker is at 100% left and 100% right.
@@ -208,8 +205,8 @@ func (s *StereoPanStream) Read(p []byte) (int, error) {
 		p[i+6] = byte(rcBits >> 16)
 		p[i+7] = byte(rcBits >> 24)
 	}
-	// Only update the prevPan value if we actually processed some frames of audio. If we didn't
-	// process any, we still want to interpolate from the old value during the next Read.
+	// Only update the prevPan value if some frames of audio were actually processed. If none were
+	// processed, interpolation should continue from the old value during the next Read.
 	if alignedN > 0 {
 		s.prevPan = pan
 	}
@@ -218,14 +215,14 @@ func (s *StereoPanStream) Read(p []byte) (int, error) {
 
 func (s *StereoPanStream) SetPan(pan float64) {
 	pan = min(max(-1, pan), 1)
-	s.m.Lock()
-	defer s.m.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.pan = pan
 }
 
 func (s *StereoPanStream) Pan() float64 {
-	s.m.Lock()
-	defer s.m.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.pan
 }
 

--- a/examples/audiopanning/main.go
+++ b/examples/audiopanning/main.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -79,8 +80,9 @@ func (g *Game) initAudioIfNeeded() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	// Set a small buffer size to avoid discontinuities in audio playback (#3396).
-	// 1/20[s] should work in most cases, but this might cause glitches in some environments.
+	// Set a small buffer size to reduce the latency between calling SetPan and the new pan value
+	// applying to what is heard. 1/20[s] should work in most cases, but this might cause glitches
+	// in some environments.
 	g.player.SetBufferSize(time.Second / 20)
 
 	// Play the infinite-length stream. This never ends.
@@ -143,8 +145,15 @@ func main() {
 // based on the Panning.
 type StereoPanStream struct {
 	io.ReadSeeker
+	// m protects pan. Read is called by the audio system, which might be running in a different
+	// goroutine than the Update loop that calls SetPan.
+	m   sync.Mutex
 	pan float64 // -1: left; 0: center; 1: right
-	buf []byte
+	// prevPan is the final pan value during the previous Read call. Used to interpolate the pan
+	// effect smoothly regardless of quick pan changes or large buffer sizes. The interpolation
+	// helps avoid a discontinuous signal that sometimes causes audible clicks or pops.
+	prevPan float64
+	buf     []byte
 }
 
 func (s *StereoPanStream) Read(p []byte) (int, error) {
@@ -167,14 +176,24 @@ func (s *StereoPanStream) Read(p []byte) (int, error) {
 	s.buf = append(s.buf, p[totalN-extra:totalN]...)
 	alignedN := totalN - extra
 
+	prevPan := s.prevPan
+	s.m.Lock()
+	pan := s.pan
+	s.m.Unlock()
+
 	// This implementation uses a linear scale, ranging from -1 to 1, for stereo or mono sounds.
 	// If pan = 0.0, the balance for the sound in each speaker is at 100% left and 100% right.
 	// When pan is -1.0, only the left channel of the stereo sound is audible, when pan is 1.0,
 	// only the right channel of the stereo sound is audible.
 	// https://docs.unity3d.com/ScriptReference/AudioSource-panStereo.html
-	ls := float32(min(s.pan*-1+1, 1))
-	rs := float32(min(s.pan+1, 1))
+	frameCount := alignedN / 8
 	for i := 0; i < alignedN; i += 8 {
+		panForFrame := pan
+		if frameCount > 1 {
+			panForFrame = lerp(prevPan, pan, float64(i/8)/float64(frameCount-1))
+		}
+		ls := float32(min(panForFrame*-1+1, 1))
+		rs := float32(min(panForFrame+1, 1))
 		lc := math.Float32frombits(uint32(p[i])|(uint32(p[i+1])<<8)|(uint32(p[i+2])<<16)|(uint32(p[i+3])<<24)) * ls
 		rc := math.Float32frombits(uint32(p[i+4])|(uint32(p[i+5])<<8)|(uint32(p[i+6])<<16)|(uint32(p[i+7])<<24)) * rs
 		lcBits := math.Float32bits(lc)
@@ -189,14 +208,24 @@ func (s *StereoPanStream) Read(p []byte) (int, error) {
 		p[i+6] = byte(rcBits >> 16)
 		p[i+7] = byte(rcBits >> 24)
 	}
+	// Only update the prevPan value if we actually processed some frames of audio. If we didn't
+	// process any, we still want to interpolate from the old value during the next Read.
+	if alignedN > 0 {
+		s.prevPan = pan
+	}
 	return alignedN, err
 }
 
 func (s *StereoPanStream) SetPan(pan float64) {
-	s.pan = min(max(-1, pan), 1)
+	pan = min(max(-1, pan), 1)
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.pan = pan
 }
 
 func (s *StereoPanStream) Pan() float64 {
+	s.m.Lock()
+	defer s.m.Unlock()
 	return s.pan
 }
 


### PR DESCRIPTION
# What issue is this addressing?
Closes #3396

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Adds linear interpolation to the pan effect so it doesn't pop no matter how large the buffer is. Changes the comment describing the small buffer size to be more specific about what it solves.

Includes a pan value mutex for thread safety between the game and sound processing loop.