### PR TITLE
internal/fbdev, internal/ui: run on Linux without a window system

### DIFF
--- a/internal/fbdev/display_linux.go
+++ b/internal/fbdev/display_linux.go
@@ -1,0 +1,151 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fbdev provides rendering on a Linux framebuffer device, for systems
+// that have no window system.
+package fbdev
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const _FBIOGET_VSCREENINFO = 0x4600
+
+type fbBitfield struct {
+	offset   uint32
+	length   uint32
+	msbRight uint32
+}
+
+// fbVarScreeninfo mirrors the kernel's fb_var_screeninfo. The whole layout is
+// declared because the ioctl fills all of it.
+type fbVarScreeninfo struct {
+	xres        uint32
+	yres        uint32
+	xresVirtual uint32
+	yresVirtual uint32
+	xoffset     uint32
+	yoffset     uint32
+
+	bitsPerPixel uint32
+	grayscale    uint32
+
+	red    fbBitfield
+	green  fbBitfield
+	blue   fbBitfield
+	transp fbBitfield
+
+	nonstd   uint32
+	activate uint32
+
+	height uint32
+	width  uint32
+
+	accelFlags uint32
+
+	pixclock    uint32
+	leftMargin  uint32
+	rightMargin uint32
+	upperMargin uint32
+	lowerMargin uint32
+	hsyncLen    uint32
+	vsyncLen    uint32
+	sync        uint32
+	vmode       uint32
+	rotate      uint32
+	colorspace  uint32
+	reserved    [4]uint32
+}
+
+// Display is a framebuffer device.
+type Display struct {
+	width       int
+	height      int
+	refreshRate int
+
+	redBits   int
+	greenBits int
+	blueBits  int
+}
+
+// OpenDisplay returns the framebuffer device's current mode.
+//
+// The device is not kept open: it is the source of the mode, while the vendor
+// EGL implementation owns presentation.
+func OpenDisplay() (*Display, error) {
+	fd, err := unix.Open("/dev/fb0", unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("fbdev: failed to open /dev/fb0: %w", err)
+	}
+	defer func() {
+		_ = unix.Close(fd)
+	}()
+
+	var vi fbVarScreeninfo
+	if _, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), _FBIOGET_VSCREENINFO, uintptr(unsafe.Pointer(&vi))); e != 0 {
+		return nil, fmt.Errorf("fbdev: FBIOGET_VSCREENINFO failed: %w", unix.Errno(e))
+	}
+
+	if vi.xres == 0 || vi.yres == 0 {
+		return nil, fmt.Errorf("fbdev: /dev/fb0 reported an empty mode")
+	}
+
+	return &Display{
+		width:       int(vi.xres),
+		height:      int(vi.yres),
+		refreshRate: vi.refreshRate(),
+		redBits:     int(vi.red.length),
+		greenBits:   int(vi.green.length),
+		blueBits:    int(vi.blue.length),
+	}, nil
+}
+
+// Size returns the display's size in pixels.
+func (d *Display) Size() (width, height int) {
+	return d.width, d.height
+}
+
+// RefreshRate returns the display's refresh rate in Hz.
+func (d *Display) RefreshRate() int {
+	return d.refreshRate
+}
+
+// BitsPerColor returns the display's bit depth per color channel.
+func (d *Display) BitsPerColor() (red, green, blue int) {
+	return d.redBits, d.greenBits, d.blueBits
+}
+
+// refreshRate returns the refresh rate in Hz, or 0 when the mode does not
+// describe the timings.
+func (vi *fbVarScreeninfo) refreshRate() int {
+	if vi.pixclock == 0 {
+		return 0
+	}
+
+	hTotal := uint64(vi.xres) + uint64(vi.leftMargin) + uint64(vi.rightMargin) + uint64(vi.hsyncLen)
+	vTotal := uint64(vi.yres) + uint64(vi.upperMargin) + uint64(vi.lowerMargin) + uint64(vi.vsyncLen)
+	if hTotal == 0 || vTotal == 0 {
+		return 0
+	}
+
+	// pixclock is the duration of one pixel in picoseconds.
+	frame := uint64(vi.pixclock) * hTotal * vTotal
+	if frame == 0 {
+		return 0
+	}
+	return int(1e12 / frame)
+}

--- a/internal/fbdev/egl_linux.go
+++ b/internal/fbdev/egl_linux.go
@@ -1,0 +1,344 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fbdev
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	_EGL_NONE                   = 0x3038
+	_EGL_SURFACE_TYPE           = 0x3033
+	_EGL_WINDOW_BIT             = 0x0004
+	_EGL_RENDERABLE_TYPE        = 0x3040
+	_EGL_OPENGL_ES2_BIT         = 0x0004
+	_EGL_RED_SIZE               = 0x3024
+	_EGL_GREEN_SIZE             = 0x3023
+	_EGL_BLUE_SIZE              = 0x3022
+	_EGL_OPENGL_ES_API          = 0x30a0
+	_EGL_CONTEXT_CLIENT_VERSION = 0x3098
+
+	_EGL_HEIGHT = 0x3056
+	_EGL_WIDTH  = 0x3057
+
+	_EGL_SUCCESS = 0x3000
+)
+
+// nativeWindow is the native window type the framebuffer drivers that want one
+// expect a pointer to.
+type nativeWindow struct {
+	width  uint16
+	height uint16
+}
+
+type eglAPI struct {
+	GetDisplay          func(displayID uintptr) uintptr
+	Initialize          func(display uintptr, major, minor *int32) bool
+	Terminate           func(display uintptr) bool
+	BindAPI             func(api int32) bool
+	ChooseConfig        func(display uintptr, attribList *int32, configs *uintptr, configSize int32, numConfig *int32) bool
+	CreateWindowSurface func(display uintptr, config uintptr, win uintptr, attribList *int32) uintptr
+	CreateContext       func(display uintptr, config uintptr, shareContext uintptr, attribList *int32) uintptr
+	DestroySurface      func(display uintptr, surface uintptr) bool
+	DestroyContext      func(display uintptr, ctx uintptr) bool
+	MakeCurrent         func(display uintptr, draw, read, ctx uintptr) bool
+	SwapBuffers         func(display uintptr, surface uintptr) bool
+	SwapInterval        func(display uintptr, interval int32) bool
+	QuerySurface        func(display uintptr, surface uintptr, attribute int32, value *int32) bool
+	GetError            func() int32
+}
+
+// Context is an EGL context presenting to a framebuffer device.
+type Context struct {
+	egl eglAPI
+
+	lib     uintptr
+	display uintptr
+	surface uintptr
+	context uintptr
+
+	// window is the memory a driver that wants a native window receives a
+	// pointer to. It is mapped outside the Go heap since such a driver keeps
+	// the pointer for as long as the surface exists.
+	window []byte
+
+	width  int
+	height int
+
+	swapInterval int
+}
+
+// NewContext creates an OpenGL ES context covering the display.
+func NewContext(d *Display) (*Context, error) {
+	c := &Context{
+		swapInterval: -1,
+	}
+
+	if err := c.loadEGL(); err != nil {
+		return nil, err
+	}
+
+	// EGL_DEFAULT_DISPLAY: there is no display server to name.
+	c.display = c.egl.GetDisplay(0)
+	if c.display == 0 {
+		return nil, fmt.Errorf("fbdev: eglGetDisplay failed: %w", c.lastError())
+	}
+
+	var major, minor int32
+	if !c.egl.Initialize(c.display, &major, &minor) {
+		return nil, fmt.Errorf("fbdev: eglInitialize failed: %w", c.lastError())
+	}
+
+	if !c.egl.BindAPI(_EGL_OPENGL_ES_API) {
+		err := fmt.Errorf("fbdev: eglBindAPI failed: %w", c.lastError())
+		return nil, errors.Join(err, c.Close())
+	}
+
+	config, err := c.chooseConfig(d)
+	if err != nil {
+		return nil, errors.Join(err, c.Close())
+	}
+
+	if err := c.createWindow(d); err != nil {
+		return nil, errors.Join(err, c.Close())
+	}
+
+	// The native window type is what the drivers here disagree on: some read
+	// the dimensions through a pointer, while a null window system has no
+	// window to describe and takes the display instead. Ask for a window
+	// first, as a driver that wants one dereferences what it is given, and a
+	// driver that wants none reports an error rather than crashing.
+	attribs := []int32{_EGL_NONE}
+	for _, win := range []uintptr{c.nativeWindowPointer(), 0} {
+		c.surface = c.egl.CreateWindowSurface(c.display, config, win, &attribs[0])
+		if c.surface != 0 {
+			break
+		}
+	}
+	if c.surface == 0 {
+		err := fmt.Errorf("fbdev: eglCreateWindowSurface failed: %w", c.lastError())
+		return nil, errors.Join(err, c.Close())
+	}
+
+	// The surface's own size is the one to render at: it is created without a
+	// size wherever the driver takes no window.
+	var width, height int32
+	if !c.egl.QuerySurface(c.display, c.surface, _EGL_WIDTH, &width) || !c.egl.QuerySurface(c.display, c.surface, _EGL_HEIGHT, &height) {
+		err := fmt.Errorf("fbdev: eglQuerySurface failed: %w", c.lastError())
+		return nil, errors.Join(err, c.Close())
+	}
+	if width <= 0 || height <= 0 {
+		err := fmt.Errorf("fbdev: the EGL surface reported an empty size %dx%d", width, height)
+		return nil, errors.Join(err, c.Close())
+	}
+	c.width = int(width)
+	c.height = int(height)
+
+	// OpenGL ES 3 comes first as the graphics driver uses ES 3 features where
+	// they are available.
+	for _, version := range []int32{3, 2} {
+		attribs := []int32{_EGL_CONTEXT_CLIENT_VERSION, version, _EGL_NONE}
+		c.context = c.egl.CreateContext(c.display, config, 0, &attribs[0])
+		if c.context != 0 {
+			break
+		}
+	}
+	if c.context == 0 {
+		err := fmt.Errorf("fbdev: eglCreateContext failed: %w", c.lastError())
+		return nil, errors.Join(err, c.Close())
+	}
+
+	return c, nil
+}
+
+func (c *Context) loadEGL() error {
+	var errs []error
+	for _, name := range []string{"libEGL.so.1", "libEGL.so"} {
+		lib, err := purego.Dlopen(name, purego.RTLD_LAZY|purego.RTLD_GLOBAL)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		c.lib = lib
+		break
+	}
+	if c.lib == 0 {
+		return fmt.Errorf("fbdev: failed to load libEGL: %w", errors.Join(errs...))
+	}
+
+	for _, f := range []struct {
+		ptr  any
+		name string
+	}{
+		{&c.egl.GetDisplay, "eglGetDisplay"},
+		{&c.egl.Initialize, "eglInitialize"},
+		{&c.egl.Terminate, "eglTerminate"},
+		{&c.egl.BindAPI, "eglBindAPI"},
+		{&c.egl.ChooseConfig, "eglChooseConfig"},
+		{&c.egl.CreateWindowSurface, "eglCreateWindowSurface"},
+		{&c.egl.CreateContext, "eglCreateContext"},
+		{&c.egl.DestroySurface, "eglDestroySurface"},
+		{&c.egl.DestroyContext, "eglDestroyContext"},
+		{&c.egl.MakeCurrent, "eglMakeCurrent"},
+		{&c.egl.SwapBuffers, "eglSwapBuffers"},
+		{&c.egl.SwapInterval, "eglSwapInterval"},
+		{&c.egl.QuerySurface, "eglQuerySurface"},
+		{&c.egl.GetError, "eglGetError"},
+	} {
+		sym, err := purego.Dlsym(c.lib, f.name)
+		if err != nil || sym == 0 {
+			return fmt.Errorf("fbdev: %s not found in libEGL: %w", f.name, err)
+		}
+		purego.RegisterFunc(f.ptr, sym)
+	}
+
+	return nil
+}
+
+// chooseConfig asks the implementation for a config, taking the color depths
+// from the display: a framebuffer device is often 16-bit, where a request for
+// 8 bits per channel matches nothing.
+func (c *Context) chooseConfig(d *Display) (uintptr, error) {
+	red, green, blue := d.BitsPerColor()
+	attribs := []int32{
+		_EGL_SURFACE_TYPE, _EGL_WINDOW_BIT,
+		_EGL_RENDERABLE_TYPE, _EGL_OPENGL_ES2_BIT,
+		_EGL_RED_SIZE, int32(red),
+		_EGL_GREEN_SIZE, int32(green),
+		_EGL_BLUE_SIZE, int32(blue),
+		_EGL_NONE,
+	}
+
+	var config uintptr
+	var num int32
+	if !c.egl.ChooseConfig(c.display, &attribs[0], &config, 1, &num) {
+		return 0, fmt.Errorf("fbdev: eglChooseConfig failed: %w", c.lastError())
+	}
+	if num == 0 {
+		return 0, fmt.Errorf("fbdev: no EGL config matches the display's %d/%d/%d bit color", red, green, blue)
+	}
+	return config, nil
+}
+
+func (c *Context) createWindow(d *Display) error {
+	// The native window's fields are 16-bit, so a larger mode cannot be
+	// expressed to a driver that reads them.
+	width, height := d.Size()
+	if width > math.MaxUint16 || height > math.MaxUint16 {
+		return fmt.Errorf("fbdev: a display of %dx%d does not fit in a native window", width, height)
+	}
+
+	buf, err := unix.Mmap(-1, 0, int(unsafe.Sizeof(nativeWindow{})), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_ANON|unix.MAP_PRIVATE)
+	if err != nil {
+		return fmt.Errorf("fbdev: failed to allocate a native window: %w", err)
+	}
+
+	w := (*nativeWindow)(unsafe.Pointer(&buf[0]))
+	w.width = uint16(width)
+	w.height = uint16(height)
+
+	c.window = buf
+	return nil
+}
+
+func (c *Context) nativeWindowPointer() uintptr {
+	return uintptr(unsafe.Pointer(&c.window[0]))
+}
+
+// Size returns the size of the surface in pixels.
+func (c *Context) Size() (width, height int) {
+	return c.width, c.height
+}
+
+// MakeContextCurrent binds the context to the calling thread.
+func (c *Context) MakeContextCurrent() error {
+	if !c.egl.MakeCurrent(c.display, c.surface, c.surface, c.context) {
+		return fmt.Errorf("fbdev: eglMakeCurrent failed: %w", c.lastError())
+	}
+	return nil
+}
+
+// SwapInterval sets how many display refreshes a frame is shown for.
+func (c *Context) SwapInterval(interval int) error {
+	if c.swapInterval == interval {
+		return nil
+	}
+	if !c.egl.SwapInterval(c.display, int32(interval)) {
+		return fmt.Errorf("fbdev: eglSwapInterval failed: %w", c.lastError())
+	}
+	c.swapInterval = interval
+	return nil
+}
+
+// SwapBuffers presents the rendered frame.
+func (c *Context) SwapBuffers() error {
+	if !c.egl.SwapBuffers(c.display, c.surface) {
+		return fmt.Errorf("fbdev: eglSwapBuffers failed: %w", c.lastError())
+	}
+	return nil
+}
+
+// Close releases the context and its surface.
+func (c *Context) Close() error {
+	if c.display != 0 {
+		if c.context != 0 || c.surface != 0 {
+			c.egl.MakeCurrent(c.display, 0, 0, 0)
+		}
+		if c.context != 0 {
+			c.egl.DestroyContext(c.display, c.context)
+			c.context = 0
+		}
+		if c.surface != 0 {
+			c.egl.DestroySurface(c.display, c.surface)
+			c.surface = 0
+		}
+		c.egl.Terminate(c.display)
+		c.display = 0
+	}
+
+	if c.window != nil {
+		if err := unix.Munmap(c.window); err != nil {
+			c.window = nil
+			return fmt.Errorf("fbdev: failed to release the native window: %w", err)
+		}
+		c.window = nil
+	}
+
+	return nil
+}
+
+// eglError is an error reported by the EGL implementation.
+type eglError int32
+
+func (e eglError) Error() string {
+	return fmt.Sprintf("EGL error 0x%x", int32(e))
+}
+
+func (c *Context) lastError() error {
+	if c.egl.GetError == nil {
+		return nil
+	}
+	code := c.egl.GetError()
+	if code == _EGL_SUCCESS {
+		return nil
+	}
+	return eglError(code)
+}

--- a/internal/fbdev/export_linux_test.go
+++ b/internal/fbdev/export_linux_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fbdev
+
+import (
+	"unsafe"
+)
+
+// NativeWindowSize is the size of the native window type.
+const NativeWindowSize = unsafe.Sizeof(nativeWindow{})
+
+// VarScreeninfoSize is the size of the struct FBIOGET_VSCREENINFO fills.
+const VarScreeninfoSize = unsafe.Sizeof(fbVarScreeninfo{})
+
+// RefreshRateForTiming returns the refresh rate derived from a mode's timings.
+func RefreshRateForTiming(pixclock, xres, leftMargin, rightMargin, hsyncLen, yres, upperMargin, lowerMargin, vsyncLen uint32) int {
+	vi := fbVarScreeninfo{
+		xres:        xres,
+		yres:        yres,
+		pixclock:    pixclock,
+		leftMargin:  leftMargin,
+		rightMargin: rightMargin,
+		upperMargin: upperMargin,
+		lowerMargin: lowerMargin,
+		hsyncLen:    hsyncLen,
+		vsyncLen:    vsyncLen,
+	}
+	return vi.refreshRate()
+}

--- a/internal/fbdev/fbdev_linux_test.go
+++ b/internal/fbdev/fbdev_linux_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fbdev_test
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2/internal/fbdev"
+)
+
+// TestVarScreeninfoSize checks the layout FBIOGET_VSCREENINFO writes into. The
+// kernel writes the whole struct, so a short one would be a buffer overflow.
+func TestVarScreeninfoSize(t *testing.T) {
+	if got, want := fbdev.VarScreeninfoSize, uintptr(160); got != want {
+		t.Errorf("size of fb_var_screeninfo: got %d, want %d", got, want)
+	}
+}
+
+// TestNativeWindowSize checks the native window type the drivers that want one
+// expect: two 16-bit dimensions.
+func TestNativeWindowSize(t *testing.T) {
+	if got, want := fbdev.NativeWindowSize, uintptr(4); got != want {
+		t.Errorf("size of the native window: got %d, want %d", got, want)
+	}
+}
+
+func TestRefreshRateForTiming(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pixclock uint32
+		xres     uint32
+		left     uint32
+		right    uint32
+		hsync    uint32
+		yres     uint32
+		upper    uint32
+		lower    uint32
+		vsync    uint32
+		want     int
+	}{
+		{
+			// 1280x720p60: 74.25 MHz over 1650x750.
+			name:     "720p60",
+			pixclock: 13468,
+			xres:     1280,
+			left:     220,
+			right:    110,
+			hsync:    40,
+			yres:     720,
+			upper:    20,
+			lower:    5,
+			vsync:    5,
+			want:     60,
+		},
+		{
+			// 1024x768@60: 65 MHz over 1344x806.
+			name:     "XGA60",
+			pixclock: 15384,
+			xres:     1024,
+			left:     160,
+			right:    24,
+			hsync:    136,
+			yres:     768,
+			upper:    29,
+			lower:    3,
+			vsync:    6,
+			want:     60,
+		},
+		{
+			name:     "unset pixclock",
+			pixclock: 0,
+			xres:     1280,
+			yres:     720,
+			want:     0,
+		},
+		{
+			name:     "no timings",
+			pixclock: 13468,
+			want:     0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fbdev.RefreshRateForTiming(tc.pixclock, tc.xres, tc.left, tc.right, tc.hsync, tc.yres, tc.upper, tc.lower, tc.vsync)
+			if got != tc.want {
+				t.Errorf("refresh rate: got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/graphicsdriver/opengl/gl/procaddr_linbsd.go
+++ b/internal/graphicsdriver/opengl/gl/procaddr_linbsd.go
@@ -22,6 +22,8 @@ import (
 	"os"
 
 	"github.com/ebitengine/purego"
+
+	"github.com/hajimehoshi/ebiten/v2/internal/windowsystem"
 )
 
 var (
@@ -35,8 +37,9 @@ func (c *defaultContext) init() error {
 	// Try OpenGL ES first. Some machines like Android and Raspberry Pi might work only with OpenGL ES.
 	//
 	// Do not use OpenGL ES for Steam, as overlays might not work properly (#3338).
-	// With Steam, OpenGL (not ES) should be available anyway.
-	if os.Getenv("SteamEnv") != "1" {
+	// With Steam, OpenGL (not ES) should be available anyway. Where there is no
+	// window system there is no overlay, and OpenGL ES is the only option.
+	if !windowsystem.Available() || os.Getenv("SteamEnv") != "1" {
 		for _, name := range []string{"libGLESv2.so", "libGLESv2.so.2", "libGLESv2.so.1", "libGLESv2.so.0"} {
 			lib, err := purego.Dlopen(name, purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 			if err == nil {
@@ -48,18 +51,21 @@ func (c *defaultContext) init() error {
 		}
 	}
 
-	// Try OpenGL next.
+	// Try OpenGL next. It needs a window system, so it is not an alternative
+	// where there is none.
 	// Usually libGL.so or libGL.so.1 is used. libGL.so.2 might exist only on NetBSD.
 	// TODO: Should "libOpenGL.so.0" [1] and "libGLX.so.0" [2] be added? These were added as of GLFW 3.3.9.
 	// [1] https://github.com/glfw/glfw/commit/55aad3c37b67f17279378db52da0a3ab81bbf26d
 	// [2] https://github.com/glfw/glfw/commit/c18851f52ec9704eb06464058a600845ec1eada1
-	for _, name := range []string{"libGL.so", "libGL.so.2", "libGL.so.1", "libGL.so.0"} {
-		lib, err := purego.Dlopen(name, purego.RTLD_LAZY|purego.RTLD_GLOBAL)
-		if err == nil {
-			libGL = lib
-			return nil
+	if windowsystem.Available() {
+		for _, name := range []string{"libGL.so", "libGL.so.2", "libGL.so.1", "libGL.so.0"} {
+			lib, err := purego.Dlopen(name, purego.RTLD_LAZY|purego.RTLD_GLOBAL)
+			if err == nil {
+				libGL = lib
+				return nil
+			}
+			errs = append(errs, fmt.Errorf("gl: Dlopen failed: name: %s: %w", name, err))
 		}
-		errs = append(errs, fmt.Errorf("gl: Dlopen failed: name: %s: %w", name, err))
 	}
 
 	errs = append([]error{fmt.Errorf("gl: failed to load libGL.so and libGLESv2.so: ")}, errs...)

--- a/internal/graphicsdriver/opengl/graphics_linbsd.go
+++ b/internal/graphicsdriver/opengl/graphics_linbsd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/internal/glfw"
 	"github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver"
 	"github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver/opengl/gl"
+	"github.com/hajimehoshi/ebiten/v2/internal/windowsystem"
 )
 
 func isGLXExtensionForGL2Available() bool {
@@ -75,8 +76,12 @@ func NewGraphics() (graphicsdriver.Graphics, error) {
 		return nil, err
 	}
 
-	if err := setGLFWClientAPI(ctx.IsES()); err != nil {
-		return nil, err
+	// The hints configure the window glfw creates, so they are meaningless
+	// where there is no window system.
+	if windowsystem.Available() {
+		if err := setGLFWClientAPI(ctx.IsES()); err != nil {
+			return nil, err
+		}
 	}
 
 	return newGraphics(ctx, color.ColorSpaceSRGB), nil

--- a/internal/ui/ui_desktop.go
+++ b/internal/ui/ui_desktop.go
@@ -17,6 +17,7 @@
 package ui
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -133,7 +134,15 @@ func (u *UserInterface) Run(game Game, options *RunOptions) error {
 	if b != nil {
 		return b.run(game, options)
 	}
-	return newGLFWBackend(u).run(game, options)
+	if b := maybeNewGLFWBackend(u); b != nil {
+		return b.run(game, options)
+	}
+	// Fall back to a framebuffer device where there is no window system.
+	fb, err := maybeNewFbdevBackend(u)
+	if err != nil {
+		return fmt.Errorf("ui: no window system is available: %w", err)
+	}
+	return fb.run(game, options)
 }
 
 // maybeNewVMGuestBackend returns a remote (guest) backend when a host endpoint is configured, or nil

--- a/internal/ui/ui_fbdev.go
+++ b/internal/ui/ui_fbdev.go
@@ -1,0 +1,279 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux && !android && !nintendosdk && !playstation5
+
+package ui
+
+import (
+	stdcontext "context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/hajimehoshi/ebiten/v2/internal/fbdev"
+	"github.com/hajimehoshi/ebiten/v2/internal/gamepad"
+	"github.com/hajimehoshi/ebiten/v2/internal/graphicscommand"
+	"github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver/opengl"
+	"github.com/hajimehoshi/ebiten/v2/internal/thread"
+)
+
+var _ uiBackend = (*fbdevBackend)(nil)
+
+// fbdevBackend runs the game on a system that has no window system, presenting
+// through the vendor EGL implementation of a framebuffer device.
+type fbdevBackend struct {
+	*UserInterface
+
+	display    *fbdev.Display
+	eglContext *fbdev.Context
+
+	// frameCh wakes the game loop in FPSModeVsyncOffMinimum, where a frame runs
+	// only when something asks for one.
+	frameCh chan struct{}
+
+	// monitor is the single monitor exposed to the game: the display itself.
+	monitor *Monitor
+
+	inputState InputState
+
+	m sync.Mutex
+}
+
+// maybeNewFbdevBackend returns a backend presenting on a framebuffer device, or
+// the reason the device cannot be used.
+func maybeNewFbdevBackend(u *UserInterface) (*fbdevBackend, error) {
+	display, err := fbdev.OpenDisplay()
+	if err != nil {
+		return nil, err
+	}
+
+	b := &fbdevBackend{
+		UserInterface: u,
+		display:       display,
+		frameCh:       make(chan struct{}, 1),
+	}
+	b.monitor = &Monitor{virtual: b}
+	return b, nil
+}
+
+func (b *fbdevBackend) run(game Game, options *RunOptions) error {
+	if options == nil {
+		options = &RunOptions{}
+	}
+
+	b.mainThread = thread.NewOSThread()
+	graphicscommand.SetOSThreadAsRenderThread()
+
+	b.context = newContext(game)
+
+	ctx, cancel := stdcontext.WithCancel(stdcontext.Background())
+	defer cancel()
+
+	var wg errgroup.Group
+
+	// Run the render thread.
+	wg.Go(func() error {
+		defer cancel()
+
+		graphicscommand.LoopRenderThread(ctx)
+		return nil
+	})
+
+	// Run the game thread.
+	wg.Go(func() error {
+		defer cancel()
+
+		var initErr error
+		b.mainThread.Call(func() {
+			initErr = b.initOnMainThread(options)
+		})
+		if initErr != nil {
+			return initErr
+		}
+
+		defer b.setRunningBackend(nil)
+
+		return b.loopGame()
+	})
+
+	// Run the main thread.
+	_ = b.mainThread.Loop(ctx)
+	return wg.Wait()
+}
+
+func (b *fbdevBackend) initOnMainThread(options *RunOptions) error {
+	c, err := fbdev.NewContext(b.display)
+	if err != nil {
+		return err
+	}
+	b.eglContext = c
+
+	g, lib, err := newGraphicsDriver(&graphicsDriverCreatorImpl{}, options.GraphicsLibrary)
+	if err != nil {
+		return err
+	}
+	// The driver has nothing to present through until the EGL context is handed
+	// over, so a driver that cannot take one is unusable here.
+	p, ok := g.(interface{ SetPresenter(opengl.Presenter) })
+	if !ok {
+		return fmt.Errorf("ui: the graphics driver cannot present without a window system")
+	}
+	p.SetPresenter(c)
+
+	b.graphicsDriver = g
+	b.setGraphicsLibrary(lib)
+	graphicscommand.SetVsyncEnabled(FPSModeType(b.fpsMode.Load()) == FPSModeVsyncOn, g)
+
+	b.setRunningBackend(b)
+
+	// Ask for the first frame. In FPSModeVsyncOffMinimum the game loop waits
+	// for a request, and a framebuffer device raises no event that would stand
+	// in for one, so nothing else would ever ask.
+	b.ScheduleFrame()
+
+	return nil
+}
+
+func (b *fbdevBackend) loopGame() (err error) {
+	defer func() {
+		graphicscommand.Terminate()
+		b.mainThread.Call(func() {
+			if b.eglContext != nil {
+				err = errors.Join(err, b.eglContext.Close())
+				b.eglContext = nil
+			}
+			b.setTerminated()
+		})
+	}()
+
+	for {
+		if err := b.updateGame(); err != nil {
+			return err
+		}
+	}
+}
+
+func (b *fbdevBackend) updateGame() error {
+	// In this mode a frame runs only when something asks for one, as there is
+	// nothing to throttle the loop: the buffer swap does not block while vsync
+	// is off. Only ScheduleFrame asks, as there is no window system to raise
+	// events.
+	if FPSModeType(b.fpsMode.Load()) == FPSModeVsyncOffMinimum {
+		<-b.frameCh
+	}
+
+	if err := gamepad.Update(0, nil); err != nil {
+		return err
+	}
+
+	w, h := b.outsideSize()
+	return b.context.updateFrame(b.graphicsDriver, w, h, b.deviceScaleFactor(), b.UserInterface, true)
+}
+
+// deviceScaleFactor implements virtualMonitorSource.
+//
+// A framebuffer device reports no physical size, so a logical pixel is a
+// device pixel.
+func (b *fbdevBackend) deviceScaleFactor() float64 {
+	return 1
+}
+
+// outsideSize implements virtualMonitorSource.
+//
+// The surface covers the display, and nothing can resize it.
+func (b *fbdevBackend) outsideSize() (width, height float64) {
+	// The surface is created without a size, so the implementation chooses one.
+	// Before it exists, the display's mode is the best answer available.
+	if b.eglContext != nil {
+		w, h := b.eglContext.Size()
+		return float64(w), float64(h)
+	}
+	w, h := b.display.Size()
+	return float64(w), float64(h)
+}
+
+func (b *fbdevBackend) readInputState(inputState *InputState) {
+	b.m.Lock()
+	defer b.m.Unlock()
+	b.inputState.copyAndReset(inputState)
+}
+
+func (b *fbdevBackend) updateInputStateForFrame(deviceScaleFactor float64) error {
+	return nil
+}
+
+func (b *fbdevBackend) KeyName(key Key) string {
+	return ""
+}
+
+func (b *fbdevBackend) updateIconIfNeeded() error {
+	return nil
+}
+
+func (b *fbdevBackend) IsFocused() bool {
+	return true
+}
+
+func (b *fbdevBackend) IsFullscreen() bool {
+	// The surface always covers the display, which is not the same as the
+	// fullscreen a window system offers.
+	return false
+}
+
+func (b *fbdevBackend) SetFullscreen(fullscreen bool) {
+}
+
+func (b *fbdevBackend) CursorMode() CursorMode {
+	return CursorModeHidden
+}
+
+func (b *fbdevBackend) SetCursorMode(mode CursorMode) {
+}
+
+func (b *fbdevBackend) applyCursorShape() {
+}
+
+func (b *fbdevBackend) applyFPSMode() {
+	b.RunOnMainThread(func() {
+		graphicscommand.SetVsyncEnabled(FPSModeType(b.fpsMode.Load()) == FPSModeVsyncOn, b.graphicsDriver)
+	})
+}
+
+func (b *fbdevBackend) ScheduleFrame() {
+	// The game loop can be waiting for this, so never block on a wakeup that is
+	// already pending.
+	select {
+	case b.frameCh <- struct{}{}:
+	default:
+	}
+}
+
+func (b *fbdevBackend) Window() backendWindow {
+	return &nullWindow{}
+}
+
+func (b *fbdevBackend) Monitor() *Monitor {
+	return b.monitor
+}
+
+func (b *fbdevBackend) appendMonitors(monitors []*Monitor) []*Monitor {
+	return append(monitors, b.monitor)
+}
+
+func (b *fbdevBackend) RunOnMainThread(f func()) {
+	b.mainThread.Call(f)
+}

--- a/internal/ui/ui_glfw.go
+++ b/internal/ui/ui_glfw.go
@@ -39,6 +39,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/internal/hook"
 	"github.com/hajimehoshi/ebiten/v2/internal/microsoftgdk"
 	"github.com/hajimehoshi/ebiten/v2/internal/thread"
+	"github.com/hajimehoshi/ebiten/v2/internal/windowsystem"
 )
 
 func driverCursorModeToGLFWCursorMode(mode CursorMode) int {
@@ -119,6 +120,15 @@ const (
 func init() {
 	// Lock the main thread.
 	runtime.LockOSThread()
+}
+
+// maybeNewGLFWBackend returns a glfw backend, or nil where there is no window
+// system for it to use.
+func maybeNewGLFWBackend(u *UserInterface) *glfwBackend {
+	if !windowsystem.Available() {
+		return nil
+	}
+	return newGLFWBackend(u)
 }
 
 func newGLFWBackend(u *UserInterface) *glfwBackend {

--- a/internal/ui/ui_notfbdev.go
+++ b/internal/ui/ui_notfbdev.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux || android || nintendosdk || playstation5
+
+package ui
+
+import (
+	"errors"
+)
+
+// fbdevBackend is never instantiated here. It exists so that Run can name the
+// same type on every system.
+type fbdevBackend struct{}
+
+// maybeNewFbdevBackend never returns a backend: a framebuffer device is a Linux
+// concept.
+func maybeNewFbdevBackend(u *UserInterface) (*fbdevBackend, error) {
+	return nil, errors.New("a framebuffer device is a Linux feature")
+}
+
+func (b *fbdevBackend) run(game Game, options *RunOptions) error {
+	return errors.New("ui: a framebuffer device is not available in this environment")
+}

--- a/internal/windowsystem/windowsystem_desktop.go
+++ b/internal/windowsystem/windowsystem_desktop.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build ((darwin && !ios) || freebsd || (linux && !android) || netbsd || windows) && !nintendosdk && !playstation5
+
+// Package windowsystem reports whether the system has a window system.
+package windowsystem
+
+import (
+	"os"
+	"runtime"
+)
+
+// Available reports whether a window system is available.
+func Available() bool {
+	switch runtime.GOOS {
+	case "freebsd", "linux", "netbsd":
+		// A device without a display server, like a handheld running its
+		// applications on a framebuffer device, sets neither variable.
+		return os.Getenv("DISPLAY") != "" || os.Getenv("WAYLAND_DISPLAY") != ""
+	}
+	return true
+}

--- a/internal/windowsystem/windowsystem_other.go
+++ b/internal/windowsystem/windowsystem_other.go
@@ -1,0 +1,23 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build android || ios || js || nintendosdk || playstation5
+
+// Package windowsystem reports whether the system has a window system.
+package windowsystem
+
+// Available reports whether a window system is available.
+func Available() bool {
+	return false
+}


### PR DESCRIPTION
# What issue is this addressing?

Updates #3491

## What _type_ of issue is this addressing?

feature

## What this PR does | solves

A handheld or an embedded device runs its applications on a framebuffer device, with a vendor EGL implementation and no display server. The glfw backend cannot serve one: it fails to load libX11 and the application never starts, which is what #3491 reports on a TrimUI Smart Pro.

This adds a backend that presents through such a device.

- **`internal/fbdev` (new)** reads the display mode from `/dev/fb0` (`FBIOGET_VSCREENINFO`) and creates an EGL context whose native window is the `{width, height uint16}` struct those implementations expect a pointer to. EGL is loaded with purego, so no cgo is involved.
- **`internal/windowsystem` (new)** reports whether a window system is available, from `DISPLAY` / `WAYLAND_DISPLAY` on the systems where one can be missing.
- **`internal/ui`** runs the glfw backend wherever a window system is available and falls back to the framebuffer backend otherwise, reporting an error where neither can serve the game.
- **`internal/graphicsdriver/opengl`** uses the same answer to skip the hints that configure a glfw window, and to treat OpenGL as no alternative to OpenGL ES when loading entry points.

The device investigation is recorded in #3491. In short: the only WSEGL module on the reporter's device is `libpvrNULL_WSEGL.so`, and presentation goes through PowerVR kernel services rather than fbdev or DRM, so the backend sets no mode and flips no page — `eglSwapBuffers` does that, and `/dev/fb0` is only the source of the mode. The surface covers the display, as there is nothing to scale or position it against. `DISPLAY` and `WAYLAND_DISPLAY` are both empty on that device, which is what selects the backend.

Gamepads (evdev) and audio (ALSA) already need no display server and work as they are. Keyboard and mouse input is not implemented yet; it needs evdev.

## What a reviewer should know

- **This has not run on hardware.** Everything through EGL config selection is derived from the driver on the reporter's device; whether the surface actually presents can only be confirmed there, and CI can only typecheck it. Hence `Updates #3491` rather than `Closes`.
- The tests in `internal/fbdev` cover what is verifiable off-device: the `fb_var_screeninfo` layout (a short struct would make the ioctl overflow its buffer), the native window size, and the refresh-rate derivation.
- Builds verified for linux/{amd64,arm64,arm}, darwin, windows, netbsd, js/wasm, freebsd (with the purego `fakecgo=-std` flag) and a cgo android/arm64 build. `-tags=microsoftgdk`, `-tags=nintendosdk` and `-tags=playstation5` typecheck with no new errors.
- Two behaviour changes outside the new backend: on Linux, FreeBSD and NetBSD with neither `DISPLAY` nor `WAYLAND_DISPLAY` set, the error is now "no window system is available" instead of glfw's "failed to load libX11"; and on Android the entry point loader goes straight to OpenGL ES, which it already preferred and where libGL does not exist.

---

Authored by Claude (Claude Code) on behalf of @hajimehoshi.
