### PR TITLE
.github/workflows: test with Go 1.27

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.25.x', '1.26.x']
+        go: ['1.25.x', '1.26.x', '1.27.x']
     name: Test with Go ${{ matrix.go }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
@@ -144,7 +144,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.25.x', '1.26.x']
+        go: ['1.25.x', '1.26.x', '1.27.x']
     name: Test Cgo with Go ${{ matrix.go }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
@@ -224,7 +224,7 @@ jobs:
   wasm:
     strategy:
       matrix:
-        go: ['1.25.x', '1.26.x']
+        go: ['1.25.x', '1.26.x', '1.27.x']
     name: Test WebAssembly with Go ${{ matrix.go }}
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/test_freebsd.yml
+++ b/.github/workflows/test_freebsd.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.25', '1.26']
+        go: ['1.25', '1.26', '1.27']
     name: Test with Go ${{ matrix.go }} on FreeBSD
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->
None.

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
Go 1.27 has been released, so add it to the CI matrices:

* `test.yml`: the `test`, `cgo`, and `wasm` jobs now run with `1.25.x`, `1.26.x`, and `1.27.x`.
* `test_freebsd.yml`: the FreeBSD job now runs with `1.25`, `1.26`, and `1.27`.

Notes for reviewers:

* Go 1.25 is kept for now. Dropping the oldest version has historically been a separate change (see 1cc1e6e54 followed by a61219607), and `go.mod` still declares `go 1.25.0`.
* `vuln.yml` and `steam.yml` need no change: they resolve the version from `https://go.dev/VERSION?m=text` and therefore already follow the latest release.
* No Go-version-gated `if:` conditions remain. The last one, which skipped the Android `ebitenmobile bind` on Windows with Go 1.26, was removed in 9a399f2d6.
* `test_freebsd.yml` resolves a concrete patch version from `https://go.dev/dl/`, and 4145bb65b already added `&include=all` so that Go 1.25 keeps resolving now that it is no longer one of the two most recent major versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)