### PR TITLE
internal/gamepad: implement VibrateGamepad on Linux (#1452) 

### DIFF
--- a/internal/gamepad/api_linux.go
+++ b/internal/gamepad/api_linux.go
@@ -39,6 +39,10 @@ const (
 	_ABS_MAX   = 0x3f
 	_ABS_CNT   = _ABS_MAX + 1
 
+	_FF_RUMBLE = 0x50
+	_FF_MAX    = 0x7f
+	_FF_CNT    = _FF_MAX + 1
+
 	_BTN_MISC       = 0x100
 	_BTN_GAMEPAD    = 0x130
 	_BTN_A          = 0x130
@@ -90,6 +94,10 @@ func _IOR(typ, nr, size uint) uint {
 	return _IOC(_IOC_READ, typ, nr, size)
 }
 
+func _IOW(typ, nr, size uint) uint {
+	return _IOC(_IOC_WRITE, typ, nr, size)
+}
+
 func _EVIOCGABS(abs uint) uint {
 	return _IOR('E', 0x40+abs, uint(unsafe.Sizeof(input_absinfo{})))
 }
@@ -104,6 +112,20 @@ func _EVIOCGID() uint {
 
 func _EVIOCGNAME(len uint) uint {
 	return _IOC(_IOC_READ, 'E', 0x06, len)
+}
+
+func _EVIOCSFF() uint {
+	return _IOW('E', 0x80, uint(unsafe.Sizeof(ffEffect{})))
+}
+
+// _EVIOCSFFLegacy is the EVIOCSFF ioctl number used by kernels before the
+// command was renumbered.
+func _EVIOCSFFLegacy() uint {
+	return _IOW('E', 0x52, uint(unsafe.Sizeof(ffEffect{})))
+}
+
+func _EVIOCRMFF() uint {
+	return _IOW('E', 0x81, 4)
 }
 
 type input_absinfo struct {
@@ -127,6 +149,54 @@ type input_id struct {
 	vendor  uint16
 	product uint16
 	version uint16
+}
+
+type ffTrigger struct {
+	button   uint16
+	interval uint16
+}
+
+type ffReplay struct {
+	length uint16
+	delay  uint16
+}
+
+type ffEnvelope struct {
+	attackLength uint16
+	attackLevel  uint16
+	fadeLength   uint16
+	fadeLevel    uint16
+}
+
+type ffPeriodicEffect struct {
+	waveform   uint16
+	period     uint16
+	magnitude  int16
+	offset     int16
+	phase      uint16
+	envelope   ffEnvelope
+	customLen  uint32
+	customData uintptr
+}
+
+type ffRumbleEffect struct {
+	strongMagnitude uint16
+	weakMagnitude   uint16
+}
+
+type ffEffectUnion struct {
+	rumble ffRumbleEffect
+	_      [unsafe.Sizeof(ffPeriodicEffect{}) - unsafe.Sizeof(ffRumbleEffect{})]byte
+}
+
+type ffEffect struct {
+	typ       uint16
+	id        int16
+	direction uint16
+	trigger   ffTrigger
+	replay    ffReplay
+	_         [2]byte
+	u         ffEffectUnion
 }
 
 func ioctl(fd int, request uint, ptr unsafe.Pointer) error {

--- a/internal/gamepad/gamepad_linux.go
+++ b/internal/gamepad/gamepad_linux.go
@@ -106,7 +106,13 @@ func (*nativeGamepadsImpl) openGamepad(gamepads *gamepads, path string) (err err
 		return nil
 	}
 
-	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_NONBLOCK, 0)
+	// Write access is required to play force-feedback effects. Fall back to read-only access,
+	// which is enough for reading the input events.
+	fd, err := unix.Open(path, unix.O_RDWR|unix.O_NONBLOCK, 0)
+	writable := err == nil
+	if !writable {
+		fd, err = unix.Open(path, unix.O_RDONLY|unix.O_NONBLOCK, 0)
+	}
 	if err != nil {
 		if err == unix.EACCES {
 			return nil
@@ -130,6 +136,7 @@ func (*nativeGamepadsImpl) openGamepad(gamepads *gamepads, path string) (err err
 	evBits := make([]byte, (unix.EV_CNT+7)/8)
 	keyBits := make([]byte, (_KEY_CNT+7)/8)
 	absBits := make([]byte, (_ABS_CNT+7)/8)
+	ffBits := make([]byte, (_FF_CNT+7)/8)
 	var id input_id
 	if err := ioctl(fd, _EVIOCGBIT(0, uint(len(evBits))), unsafe.Pointer(&evBits[0])); err != nil {
 		return fmt.Errorf("gamepad: ioctl for evBits failed: %w", err)
@@ -139,6 +146,9 @@ func (*nativeGamepadsImpl) openGamepad(gamepads *gamepads, path string) (err err
 	}
 	if err := ioctl(fd, _EVIOCGBIT(unix.EV_ABS, uint(len(absBits))), unsafe.Pointer(&absBits[0])); err != nil {
 		return fmt.Errorf("gamepad: ioctl for absBits failed: %w", err)
+	}
+	if err := ioctl(fd, _EVIOCGBIT(unix.EV_FF, uint(len(ffBits))), unsafe.Pointer(&ffBits[0])); err != nil {
+		return fmt.Errorf("gamepad: ioctl for ffBits failed: %w", err)
 	}
 	if err := ioctl(fd, _EVIOCGID(), unsafe.Pointer(&id)); err != nil {
 		return fmt.Errorf("gamepad: ioctl for an ID failed: %w", err)
@@ -177,14 +187,17 @@ func (*nativeGamepadsImpl) openGamepad(gamepads *gamepads, path string) (err err
 	}
 
 	n := &nativeGamepadImpl{
-		path: path,
-		fd:   fd,
+		path:     path,
+		fd:       fd,
+		effectID: -1,
 	}
 	gp := gamepads.add(name, sdlID)
 	gp.native = n
 	runtime.AddCleanup(gp, func(n *nativeGamepadImpl) {
 		n.close()
 	}, n)
+
+	n.hasVibration = writable && isBitSet(ffBits, _FF_RUMBLE)
 
 	var axisCount int
 	var buttonCount int
@@ -294,6 +307,9 @@ type nativeGamepadImpl struct {
 	absInfo [_ABS_CNT]input_absinfo
 	dropped bool
 
+	hasVibration bool
+	effectID     int16
+
 	axes    [_ABS_CNT]float64
 	buttons [_KEY_CNT - _BTN_MISC]bool
 	hats    [4]int
@@ -308,6 +324,11 @@ type nativeGamepadImpl struct {
 
 func (g *nativeGamepadImpl) close() {
 	if g.fd != 0 {
+		if g.effectID >= 0 {
+			id := int(g.effectID)
+			_, _, _ = unix.Syscall(unix.SYS_IOCTL, uintptr(g.fd), uintptr(_EVIOCRMFF()), uintptr(unsafe.Pointer(&id)))
+			g.effectID = -1
+		}
 		_ = unix.Close(g.fd)
 	}
 	g.fd = 0
@@ -622,5 +643,70 @@ func (g *nativeGamepadImpl) hatState(hat int) int {
 }
 
 func (g *nativeGamepadImpl) vibrate(duration time.Duration, strongMagnitude float64, weakMagnitude float64) {
-	// TODO: Implement this (#1452)
+	if g.fd == 0 || !g.hasVibration {
+		return
+	}
+
+	var length uint16
+	if ms := duration.Milliseconds(); ms > int64(0xffff) {
+		length = 0xffff
+	} else if ms > 0 {
+		length = uint16(ms)
+	}
+	if strongMagnitude <= 0 && weakMagnitude <= 0 {
+		length = 0
+	}
+
+	if length == 0 {
+		// Stop playing the current effect.
+		if g.effectID < 0 {
+			return
+		}
+		g.writeForceFeedbackEvent(g.effectID, false)
+		return
+	}
+
+	var effect ffEffect
+	effect.typ = _FF_RUMBLE
+	effect.id = g.effectID
+	effect.replay.length = length
+	effect.u.rumble.strongMagnitude = magnitudeToUint16(strongMagnitude)
+	effect.u.rumble.weakMagnitude = magnitudeToUint16(weakMagnitude)
+
+	// Kernels renumbered EVIOCSFF, so try the current number first and fall
+	// back to the legacy one.
+	err := ioctl(g.fd, _EVIOCSFF(), unsafe.Pointer(&effect))
+	if err != nil {
+		err = ioctl(g.fd, _EVIOCSFFLegacy(), unsafe.Pointer(&effect))
+	}
+	if err != nil {
+		g.effectID = -1
+		return
+	}
+	g.effectID = effect.id
+
+	g.writeForceFeedbackEvent(effect.id, true)
+}
+
+func (g *nativeGamepadImpl) writeForceFeedbackEvent(id int16, play bool) {
+	event := input_event{
+		typ:   unix.EV_FF,
+		code:  uint16(id),
+		value: 0,
+	}
+	if play {
+		event.value = 1
+	}
+	buf := (*[unsafe.Sizeof(input_event{})]byte)(unsafe.Pointer(&event))[:]
+	_, _ = unix.Write(g.fd, buf)
+}
+
+func magnitudeToUint16(magnitude float64) uint16 {
+	if magnitude <= 0 {
+		return 0
+	}
+	if magnitude >= 1 {
+		return 0xffff
+	}
+	return uint16(magnitude * 0xffff)
 }

--- a/internal/gamepad/gamepad_linux_rumble_test.go
+++ b/internal/gamepad/gamepad_linux_rumble_test.go
@@ -1,0 +1,258 @@
+//go:build !android && !nintendosdk && !playstation5
+
+package gamepad
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	_UI_SET_EVBIT   = 0x40045564
+	_UI_SET_KEYBIT  = 0x40045565
+	_UI_SET_ABSBIT  = 0x40045567
+	_UI_SET_FFBIT   = 0x4004556b
+	_UI_DEV_CREATE  = 0x5501
+	_UI_DEV_DESTROY = 0x5502
+
+	_UI_BEGIN_FF_UPLOAD = 0xc03855c8
+	_UI_END_FF_UPLOAD   = 0x403855c9
+
+	_UI_FF_UPLOAD = 1
+)
+
+type uinputUserDev struct {
+	name         [80]byte
+	id           input_id
+	ffEffectsMax uint32
+	absmax       [_ABS_CNT]int32
+	absmin       [_ABS_CNT]int32
+	absfuzz      [_ABS_CNT]int32
+	absflat      [_ABS_CNT]int32
+}
+
+type uinputFFUpload struct {
+	requestID uint32
+	retval    int32
+	effect    ffEffect
+}
+
+func TestFFEffectLayout(t *testing.T) {
+	want := uintptr(48)
+	if unsafe.Sizeof(uintptr(0)) == 4 {
+		want = 44
+	}
+	if got := unsafe.Sizeof(ffEffect{}); got != want {
+		t.Errorf("sizeof(ffEffect) = %d, want %d to match struct ff_effect", got, want)
+	}
+	if got := unsafe.Offsetof(ffEffect{}.u); got != 16 {
+		t.Errorf("offsetof(ffEffect.u) = %d, want 16", got)
+	}
+	if got := unsafe.Sizeof(uinputFFUpload{}); got != 8+want {
+		t.Errorf("sizeof(uinputFFUpload) = %d, want %d", got, 8+want)
+	}
+}
+
+func TestLinuxUinputRumble(t *testing.T) {
+	ufd, err := unix.Open("/dev/uinput", unix.O_RDWR|unix.O_NONBLOCK, 0)
+	if err != nil {
+		t.Skipf("cannot open /dev/uinput: %v", err)
+	}
+	defer func() { _ = unix.Close(ufd) }()
+
+	setBit := func(req uint, bit uint) {
+		t.Helper()
+		r, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(ufd), uintptr(req), uintptr(bit))
+		if int32(r) < 0 {
+			t.Fatalf("ioctl %#x(%#x) failed: %v", req, bit, e)
+		}
+	}
+	setBit(_UI_SET_EVBIT, unix.EV_KEY)
+	setBit(_UI_SET_EVBIT, unix.EV_ABS)
+	setBit(_UI_SET_EVBIT, unix.EV_FF)
+	setBit(_UI_SET_KEYBIT, _BTN_GAMEPAD)
+	setBit(_UI_SET_ABSBIT, _ABS_X)
+	setBit(_UI_SET_ABSBIT, _ABS_Y)
+	setBit(_UI_SET_FFBIT, _FF_RUMBLE)
+
+	setup := uinputUserDev{
+		ffEffectsMax: 4,
+		id:           input_id{bustype: 0x03 /* BUS_USB */, vendor: 0x1234, product: 0x5678, version: 1},
+	}
+	copy(setup.name[:], "Ebitengine Rumble Test Pad")
+	setup.absmin[_ABS_X] = -32767
+	setup.absmax[_ABS_X] = 32767
+	setup.absmin[_ABS_Y] = -32767
+	setup.absmax[_ABS_Y] = 32767
+	buf := (*[unsafe.Sizeof(setup)]byte)(unsafe.Pointer(&setup))[:]
+	if _, err := unix.Write(ufd, buf); err != nil {
+		t.Fatalf("writing uinput_user_dev failed: %v", err)
+	}
+	r, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(ufd), uintptr(_UI_DEV_CREATE), 0)
+	if int32(r) < 0 {
+		t.Fatalf("UI_DEV_CREATE failed: %v", e)
+	}
+	t.Cleanup(func() {
+		unix.Syscall(unix.SYS_IOCTL, uintptr(ufd), uintptr(_UI_DEV_DESTROY), 0)
+	})
+
+	// Stale device nodes can be reused by a newly created device, so compare inodes
+	// rather than directory entries.
+	type nodeInfo struct{ ino, dev uint64 }
+	before := map[string]nodeInfo{}
+	if ents, err := os.ReadDir(dirName); err == nil {
+		for _, ent := range ents {
+			if !ent.IsDir() && reEvent.MatchString(ent.Name()) {
+				if st, err := ent.Info(); err == nil {
+					s := st.Sys().(*syscall.Stat_t)
+					before[ent.Name()] = nodeInfo{ino: s.Ino, dev: s.Dev}
+				}
+			}
+		}
+	}
+	var node string
+	for i := 0; i < 50 && node == ""; i++ {
+		time.Sleep(200 * time.Millisecond)
+		ents, err := os.ReadDir(dirName)
+		if err != nil {
+			continue
+		}
+		for _, ent := range ents {
+			name := ent.Name()
+			if !reEvent.MatchString(name) || ent.IsDir() {
+				continue
+			}
+			st, err := ent.Info()
+			if err != nil {
+				continue
+			}
+			s := st.Sys().(*syscall.Stat_t)
+			b, ok := before[name]
+			if ok && b.ino == s.Ino && b.dev == s.Dev {
+				continue
+			}
+			fd, err := unix.Open(dirName+"/"+name, unix.O_RDWR|unix.O_NONBLOCK, 0)
+			if err != nil {
+				if err == unix.EACCES || err == unix.EPERM {
+					t.Skipf("no permission for the created event node %s: %v", name, err)
+				}
+				continue // A stale node: ENODEV or similar.
+			}
+			node = dirName + "/" + name
+			unix.Close(fd)
+			break
+		}
+	}
+	if node == "" {
+		t.Skip("the created input event node was not found")
+	}
+
+	probe, err := unix.Open(node, unix.O_RDWR|unix.O_NONBLOCK, 0)
+	if err != nil {
+		t.Skipf("no permission for the created event node %s: %v", node, err)
+	}
+
+	g := &gamepads{}
+	np := &nativeGamepadsImpl{}
+	if err := np.openGamepad(g, node); err != nil {
+		_ = unix.Close(probe)
+		t.Fatalf("openGamepad failed: %v", err)
+	}
+	gp := g.find(func(*Gamepad) bool { return true })
+	if gp == nil {
+		_ = unix.Close(probe)
+		t.Fatal("gamepad not found after openGamepad")
+	}
+	native := gp.native.(*nativeGamepadImpl)
+	if !native.hasVibration {
+		_ = unix.Close(probe)
+		t.Error("hasVibration is false")
+		return
+	}
+	if native.effectID != -1 {
+		_ = unix.Close(probe)
+		t.Errorf("effectID should be initialized to -1, got %d", native.effectID)
+		return
+	}
+
+	stop := make(chan struct{})
+	drained := make(chan int16, 16)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			var ev input_event
+			b := (*[unsafe.Sizeof(ev)]byte)(unsafe.Pointer(&ev))[:]
+			if _, err := unix.Read(ufd, b); err != nil {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			if ev.typ == _UI_FF_UPLOAD {
+				req := uinputFFUpload{requestID: uint32(ev.code)}
+				if err := ioctl(ufd, _UI_BEGIN_FF_UPLOAD, unsafe.Pointer(&req)); err != nil {
+					t.Errorf("UI_BEGIN_FF_UPLOAD failed: %v", err)
+					return
+				}
+				select {
+				case drained <- req.effect.id:
+				default:
+				}
+				if err := ioctl(ufd, _UI_END_FF_UPLOAD, unsafe.Pointer(&req)); err != nil {
+					t.Errorf("UI_END_FF_UPLOAD failed: %v", err)
+					return
+				}
+			}
+		}
+	}()
+
+	readEvent := func(typ uint16, value int32, timeout time.Duration) bool {
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			var ev input_event
+			b := (*[unsafe.Sizeof(ev)]byte)(unsafe.Pointer(&ev))[:]
+			n, err := unix.Read(probe, b)
+			if err != nil || n < len(b) {
+				time.Sleep(5 * time.Millisecond)
+				continue
+			}
+			if ev.typ == typ && ev.value == value {
+				return true
+			}
+		}
+		return false
+	}
+
+	gp.Vibrate(time.Second, 0.75, 0.25)
+
+	select {
+	case id := <-drained:
+		if id < 0 {
+			t.Errorf("uploaded effect ID should be non-negative, got %d", id)
+		}
+	case <-time.After(5 * time.Second):
+		close(stop)
+		_ = unix.Close(probe)
+		t.Fatal("no FF upload was requested")
+	}
+
+	if !readEvent(unix.EV_FF_STATUS, 1, 5*time.Second) {
+		t.Error("FF_STATUS ON was not observed")
+	}
+
+	gp.Vibrate(0, 0, 0)
+
+	if !readEvent(unix.EV_FF_STATUS, 0, 5*time.Second) {
+		t.Error("FF_STATUS OFF was not observed")
+	}
+
+	close(stop)
+	_ = unix.Close(probe)
+}

--- a/vibrate.go
+++ b/vibrate.go
@@ -70,13 +70,17 @@ type VibrateGamepadOptions struct {
 
 // VibrateGamepad vibrates the specified gamepad with the specified options.
 //
-// VibrateGamepad does nothing on Android and Linux so far.
+// VibrateGamepad does nothing on Android so far.
 //
 // On Windows, VibrateGamepad works only for XInput gamepads (e.g. Xbox controllers).
 // VibrateGamepad does nothing for DirectInput gamepads.
 //
 // On macOS, VibrateGamepad works only for gamepads the GameController framework supports
 // (e.g. Xbox, PlayStation, and MFi controllers). VibrateGamepad does nothing for other gamepads.
+//
+// On Linux, VibrateGamepad works only for gamepads supporting the rumble force-feedback effect
+// (e.g. Xbox, PlayStation, and Nintendo Switch Pro controllers), and requires write permission
+// for the device files under /dev/input. VibrateGamepad does nothing for other gamepads.
 //
 // VibrateGamepad does nothing before the game starts.
 //


### PR DESCRIPTION
# What issue is this addressing?
Updates #1452 

## What _type_ of issue is this addressing?
Linux support

## What this PR does | solves
At least in my environment, it works.

This implements ebiten.VibrateGamepad on Linux using the kernel's evdev force-feedback API (FF_RUMBLE), replacing the // TODO: Implement this (#1452) stub. Gamepads whose drivers expose the rumble effect (e.g. Xbox, PlayStation, Nintendo Switch Pro controllers via xpad, hid-playstation, hid-nintendo) now vibrate when the game calls VibrateGamepad.

Details
Device access (openGamepad)

Device files are now opened O_RDWR when possible, since playing force-feedback effects requires write access. If the device cannot be opened for writing (e.g. missing input group membership), it falls back to O_RDONLY so input still works — vibration is simply disabled for that device.
On open, the EV_FF capability bitmap is queried and hasVibration is set only when the device actually reports FF_RUMBLE. The bitmap buffer is sized with FF_CNT (the FF event-code space extends up to 0x7f, beyond EV_CNT, so sizing it after EV_CNT would overflow when checking bit FF_RUMBLE = 0x50).
Effect playback (vibrate)

A single FF_RUMBLE effect is uploaded through EVIOCSFF and reused across calls (effectID), played/stopped by writing an EV_FF event to the device — the same approach SDL uses.
Duration is clamped to the uint16 millisecond range of ff_replay.length; zero duration or both magnitudes being zero stops the currently playing effect.
The uploaded effect is erased with EVIOCRMFF when the gamepad is closed.
Kernel ABI compatibility

Newer kernels renumbered the EVIOCSFF ioctl command (nr 0x52 → 0x80). The code tries the current number first and falls back to the legacy number, so rumble works on both old and new kernels. (With only the legacy number, uploads fail with EINVAL on newer kernels.)
struct ff_effect is reproduced as Go structs, with a compile-time layout test asserting sizeof == 48 bytes and offsetof(u) == 16 to match the C ABI on 64-bit (44 bytes on 32-bit).
EVIOCRMFF correctly passes the effect ID as a pointer to int, as the ioctl expects.
Tests

TestFFEffectLayout: compile-time checks of the ff_effect binary layout.
TestLinuxUinputRumble: creates a virtual rumble-capable gamepad via /dev/uinput, opens it through the real openGamepad path, verifies hasVibration, and asserts that a vibration request results in an effect upload (UI_BEGIN_FF_UPLOAD), an FF_STATUS ON event, and an FF_STATUS OFF event after stop. Skips gracefully when /dev/uinput or the created event node is not accessible (e.g. without root or the input group).
Docs

Updated the VibrateGamepad doc comment: Linux is no longer listed as unsupported, with a note about FF_RUMBLE support and write-permission requirements under /dev/input.
Testing
go test ./internal/gamepad/ (layout test always runs; uinput test runs where permissions allow)
Manually verified end-to-end on Linux with a Nintendo Switch Pro Controller connected over USB (hid-nintendo): effect upload succeeds, play/stop events reach the device, and the motors physically respond to examples/gamepad button presses.