### PR TITLE
Use modern go idioms

### DIFF
--- a/audio/internal/convert/resampling.go
+++ b/audio/internal/convert/resampling.go
@@ -158,12 +158,12 @@ func (r *Resampling) src(i int64) (float64, float64, error) {
 		sr := make([]float64, resamplingBufferSize)
 		switch r.bitDepthInBytes {
 		case 2:
-			for i := 0; i < len(buf)/int(sizePerSample); i++ {
+			for i := range len(buf) / int(sizePerSample) {
 				sl[i] = float64(int16(buf[4*i])|(int16(buf[4*i+1])<<8)) / (1<<15 - 1)
 				sr[i] = float64(int16(buf[4*i+2])|(int16(buf[4*i+3])<<8)) / (1<<15 - 1)
 			}
 		case 4:
-			for i := 0; i < len(buf)/int(sizePerSample); i++ {
+			for i := range len(buf) / int(sizePerSample) {
 				sl[i] = float64(math.Float32frombits(uint32(buf[8*i]) | uint32(buf[8*i+1])<<8 | uint32(buf[8*i+2])<<16 | uint32(buf[8*i+3])<<24))
 				sr[i] = float64(math.Float32frombits(uint32(buf[8*i+4]) | uint32(buf[8*i+5])<<8 | uint32(buf[8*i+6])<<16 | uint32(buf[8*i+7])<<24))
 			}

--- a/audio/internal/convert/stereof32.go
+++ b/audio/internal/convert/stereof32.go
@@ -46,7 +46,7 @@ func (s *StereoF32) Read(b []byte) (int, error) {
 		return 0, err
 	}
 	if s.mono {
-		for i := 0; i < n/4; i++ {
+		for i := range n / 4 {
 			b[8*i] = s.buf[4*i]
 			b[8*i+1] = s.buf[4*i+1]
 			b[8*i+2] = s.buf[4*i+2]

--- a/audio/internal/convert/stereoi16.go
+++ b/audio/internal/convert/stereoi16.go
@@ -66,7 +66,7 @@ func (s *StereoI16ReadSeeker) Read(b []byte) (int, error) {
 	if s.mono {
 		switch s.format {
 		case FormatU8:
-			for i := 0; i < n; i++ {
+			for i := range n {
 				v := int16(int(s.buf[i])*0x101 - (1 << 15))
 				b[4*i] = byte(v)
 				b[4*i+1] = byte(v >> 8)
@@ -74,14 +74,14 @@ func (s *StereoI16ReadSeeker) Read(b []byte) (int, error) {
 				b[4*i+3] = byte(v >> 8)
 			}
 		case FormatS16:
-			for i := 0; i < n/2; i++ {
+			for i := range n / 2 {
 				b[4*i] = s.buf[2*i]
 				b[4*i+1] = s.buf[2*i+1]
 				b[4*i+2] = s.buf[2*i]
 				b[4*i+3] = s.buf[2*i+1]
 			}
 		case FormatS24:
-			for i := 0; i < n/3; i++ {
+			for i := range n / 3 {
 				b[4*i] = s.buf[3*i+1]
 				b[4*i+1] = s.buf[3*i+2]
 				b[4*i+2] = s.buf[3*i+1]
@@ -91,7 +91,7 @@ func (s *StereoI16ReadSeeker) Read(b []byte) (int, error) {
 	} else {
 		switch s.format {
 		case FormatU8:
-			for i := 0; i < n/2; i++ {
+			for i := range n / 2 {
 				v0 := int16(int(s.buf[2*i])*0x101 - (1 << 15))
 				v1 := int16(int(s.buf[2*i+1])*0x101 - (1 << 15))
 				b[4*i] = byte(v0)
@@ -102,7 +102,7 @@ func (s *StereoI16ReadSeeker) Read(b []byte) (int, error) {
 		case FormatS16:
 			copy(b[:n], s.buf[:n])
 		case FormatS24:
-			for i := 0; i < n/6; i++ {
+			for i := range n / 6 {
 				b[4*i] = s.buf[6*i+1]
 				b[4*i+1] = s.buf[6*i+2]
 				b[4*i+2] = s.buf[6*i+4]

--- a/cmd/ebitenmobile/gobind.go
+++ b/cmd/ebitenmobile/gobind.go
@@ -27,8 +27,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"golang.org/x/tools/go/packages"
 )
+
+var caser = cases.Title(language.Und)
 
 //go:embed _files/EbitenViewController.m
 var objcM string
@@ -104,7 +108,7 @@ func run() error {
 			return err
 		}
 		prefixLower := *prefix + pkgName
-		prefixUpper := strings.Title(*prefix) + strings.Title(pkgName)
+		prefixUpper := caser.String(*prefix) + caser.String(pkgName)
 		replacePrefixes := func(content string) string {
 			content = strings.ReplaceAll(content, "$Placeholder_PrefixUpper$", prefixUpper)
 			content = strings.ReplaceAll(content, "$Placeholder_PrefixLower$", prefixLower)

--- a/cmd/ebitenmobile/main.go
+++ b/cmd/ebitenmobile/main.go
@@ -33,8 +33,12 @@ import (
 	"text/template"
 	"unicode"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"golang.org/x/tools/go/packages"
 )
+
+var caser = cases.Title(language.Und)
 
 const (
 	ebitenmobileCommand = "ebitenmobile"
@@ -196,7 +200,7 @@ func doBind(args []string, flagset *flag.FlagSet, buildOS string) error {
 		return err
 	}
 	prefixLower := bindPrefix + pkgs[0].Name
-	prefixUpper := strings.Title(bindPrefix) + strings.Title(pkgs[0].Name)
+	prefixUpper := caser.String(bindPrefix) + caser.String(pkgs[0].Name)
 
 	args = append(args, "github.com/hajimehoshi/ebiten/v2/mobile/ebitenmobileview")
 
@@ -230,30 +234,21 @@ func doBind(args []string, flagset *flag.FlagSet, buildOS string) error {
 	}
 
 	if buildOS == "darwin" {
-		// TODO: Use os.ReadDir after Ebitengine stops supporting Go 1.15.
-		f, err := os.Open(buildO)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			_ = f.Close()
-		}()
-
-		names, err := f.Readdirnames(-1)
+		dirEntries, err := os.ReadDir(buildO)
 		if err != nil {
 			return err
 		}
 
-		for _, name := range names {
+		for _, dirEntry := range dirEntries {
+			name := dirEntry.Name()
 			if name == "Info.plist" {
 				continue
 			}
 			frameworkName := filepath.Base(buildO)
 			frameworkNameBase := frameworkName[:len(frameworkName)-len(".xcframework")]
 			// The first character must be an upper case (#2192).
-			// TODO: strings.Title is used here for the consistency with gomobile (see cmd/gomobile/bind_iosapp.go).
-			// As strings.Title is deprecated, golang.org/x/text/cases should be used.
-			frameworkNameBase = strings.Title(frameworkNameBase)
+			// For the consistency with gomobile (see cmd/gomobile/bind_iosapp.go), the name is title-cased.
+			frameworkNameBase = caser.String(frameworkNameBase)
 			dir := filepath.Join(buildO, name, frameworkNameBase+".framework")
 
 			if err := os.WriteFile(filepath.Join(dir, "Headers", prefixUpper+"EbitenViewController.h"), []byte(replacePrefixes(objcH)), 0644); err != nil {

--- a/cmd/ebitenmobile/main.go
+++ b/cmd/ebitenmobile/main.go
@@ -200,7 +200,7 @@ func doBind(args []string, flagset *flag.FlagSet, buildOS string) error {
 		return err
 	}
 	prefixLower := bindPrefix + pkgs[0].Name
-	prefixUpper := caser.String(bindPrefix) + caser.String(pkgs[0].Name)
+	prefixUpper := strings.Title(bindPrefix) + strings.Title(pkgs[0].Name)
 
 	args = append(args, "github.com/hajimehoshi/ebiten/v2/mobile/ebitenmobileview")
 

--- a/exp/textinput/textinput_ios.go
+++ b/exp/textinput/textinput_ios.go
@@ -613,7 +613,7 @@ func (t *textInputImpl) pressesOnMain(self, presses, event objc.ID, cmd objc.SEL
 
 	var kept objc.ID
 	consumed := 0
-	for i := 0; i < n; i++ {
+	for i := range n {
 		p := arr.Send(sel_objectAtIndex, uint(i))
 		if cmd == sel_pressesBegan {
 			if key, ok := t.consumableKey(self, p); ok {

--- a/genkeys.go
+++ b/genkeys.go
@@ -20,10 +20,11 @@ package main
 
 import (
 	"bufio"
+	"cmp"
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -690,38 +691,35 @@ func functionKey(name string) int {
 	return i
 }
 
-func keyNamesLess(k []string) func(i, j int) bool {
-	return func(i, j int) bool {
-		k0, k1 := k[i], k[j]
-		d0, d1 := digitKey(k0), digitKey(k1)
-		a0, a1 := alphabetKey(k0), alphabetKey(k1)
-		f0, f1 := functionKey(k0), functionKey(k1)
-		if d0 != -1 {
-			if d1 != -1 {
-				return d0 < d1
-			}
-			return true
-		}
-		if a0 != -1 {
-			if d1 != -1 {
-				return false
-			}
-			if a1 != -1 {
-				return a0 < a1
-			}
-			return true
-		}
+func keyNamesCmp(k0, k1 string) int {
+	d0, d1 := digitKey(k0), digitKey(k1)
+	a0, a1 := alphabetKey(k0), alphabetKey(k1)
+	f0, f1 := functionKey(k0), functionKey(k1)
+	if d0 != -1 {
 		if d1 != -1 {
-			return false
+			return cmp.Compare(d0, d1)
+		}
+		return -1
+	}
+	if a0 != -1 {
+		if d1 != -1 {
+			return 1
 		}
 		if a1 != -1 {
-			return false
+			return cmp.Compare(a0, a1)
 		}
-		if f0 != -1 && f1 != -1 {
-			return f0 < f1
-		}
-		return k0 < k1
+		return -1
 	}
+	if d1 != -1 {
+		return 1
+	}
+	if a1 != -1 {
+		return 1
+	}
+	if f0 != -1 && f1 != -1 {
+		return cmp.Compare(f0, f1)
+	}
+	return strings.Compare(k0, k1)
 }
 
 const license = `// Copyright 2013 The Ebitengine Authors
@@ -761,10 +759,10 @@ func main() {
 	ebitengineKeyNames = append(ebitengineKeyNames, "Alt", "Control", "Shift", "Meta")
 	ebitengineKeyNamesWithoutOld = append(ebitengineKeyNamesWithoutOld, "Alt", "Control", "Shift", "Meta")
 
-	sort.Slice(ebitengineKeyNames, keyNamesLess(ebitengineKeyNames))
-	sort.Slice(ebitengineKeyNamesWithoutOld, keyNamesLess(ebitengineKeyNamesWithoutOld))
-	sort.Slice(ebitengineKeyNamesWithoutMods, keyNamesLess(ebitengineKeyNamesWithoutMods))
-	sort.Slice(uiKeyNames, keyNamesLess(uiKeyNames))
+	slices.SortFunc(ebitengineKeyNames, keyNamesCmp)
+	slices.SortFunc(ebitengineKeyNamesWithoutOld, keyNamesCmp)
+	slices.SortFunc(ebitengineKeyNamesWithoutMods, keyNamesCmp)
+	slices.SortFunc(uiKeyNames, keyNamesCmp)
 
 	// TODO: Add this line for event package (#926).
 	//

--- a/internal/buffered/pixelcache.go
+++ b/internal/buffered/pixelcache.go
@@ -16,6 +16,7 @@ package buffered
 
 import (
 	"image"
+	"maps"
 
 	"github.com/hajimehoshi/ebiten/v2/internal/atlas"
 	"github.com/hajimehoshi/ebiten/v2/internal/graphics"
@@ -208,12 +209,9 @@ func (c *pixelCache) writePixels(img *atlas.Image, pix []byte, region image.Rect
 	// Avoid this unless ReadPixels is called.
 
 	// Remove entries in the dots buffer that are overwritten by this writePixels call.
-	for pos := range c.dots {
-		if !pos.In(region) {
-			continue
-		}
-		delete(c.dots, pos)
-	}
+	maps.DeleteFunc(c.dots, func(pos image.Point, _ [4]byte) bool {
+		return pos.In(region)
+	})
 
 	img.WritePixels(pix, region)
 }

--- a/internal/gamepad/gamepad_desktop_windows.go
+++ b/internal/gamepad/gamepad_desktop_windows.go
@@ -669,7 +669,7 @@ func (g *nativeGamepadDesktop) update(gamepads *gamepads) (err error) {
 	g.xinputState = state
 
 	// XInput vibration lasts until changed, so stop it once the requested duration has passed.
-	if g.vib && time.Now().Sub(g.vibEnd) >= 0 {
+	if g.vib && time.Since(g.vibEnd) >= 0 {
 		g.stopVibration()
 	}
 	return nil

--- a/internal/gamepad/gamepad_desktop_windows.go
+++ b/internal/gamepad/gamepad_desktop_windows.go
@@ -15,9 +15,10 @@
 package gamepad
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -332,11 +333,11 @@ func (g *nativeGamepadsDesktop) dinput8EnumDevicesCallback(lpddi *_DIDEVICEINSTA
 		return _DIENUM_STOP
 	}
 
-	sort.Slice(ctx.objects, func(i, j int) bool {
-		if ctx.objects[i].objectType != ctx.objects[j].objectType {
-			return ctx.objects[i].objectType < ctx.objects[j].objectType
-		}
-		return ctx.objects[i].index < ctx.objects[j].index
+	slices.SortFunc(ctx.objects, func(a, b dinputObject) int {
+		return cmp.Or(
+			cmp.Compare(a.objectType, b.objectType),
+			cmp.Compare(a.index, b.index),
+		)
 	})
 
 	name := windows.UTF16ToString(lpddi.tszInstanceName[:])

--- a/internal/gamepad/gamepad_iokit_darwin.go
+++ b/internal/gamepad/gamepad_iokit_darwin.go
@@ -15,9 +15,10 @@
 package gamepad
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -283,9 +284,16 @@ func (g *nativeGamepadsIOKit) addDevice(device _IOHIDDeviceRef, gamepads *gamepa
 		}
 	}
 
-	sort.Stable(n.axes)
-	sort.Stable(n.buttons)
-	sort.Stable(n.hats)
+	slices.SortStableFunc(n.axes, compareElements)
+	slices.SortStableFunc(n.buttons, compareElements)
+	slices.SortStableFunc(n.hats, compareElements)
+}
+
+func compareElements(a, b element) int {
+	return cmp.Or(
+		cmp.Compare(a.usage, b.usage),
+		cmp.Compare(a.index, b.index),
+	)
 }
 
 type element struct {
@@ -296,31 +304,11 @@ type element struct {
 	maximum int
 }
 
-type elements []element
-
-func (e elements) Len() int {
-	return len(e)
-}
-
-func (e elements) Less(i, j int) bool {
-	if e[i].usage != e[j].usage {
-		return e[i].usage < e[j].usage
-	}
-	if e[i].index != e[j].index {
-		return e[i].index < e[j].index
-	}
-	return false
-}
-
-func (e elements) Swap(i, j int) {
-	e[i], e[j] = e[j], e[i]
-}
-
 type nativeGamepadHID struct {
 	device  _IOHIDDeviceRef
-	axes    elements
-	buttons elements
-	hats    elements
+	axes    []element
+	buttons []element
+	hats    []element
 
 	axisValues   []float64
 	buttonValues []bool

--- a/internal/gamepad/gamepad_virtual.go
+++ b/internal/gamepad/gamepad_virtual.go
@@ -88,9 +88,7 @@ func (g *gamepads) appendVirtualVibrations(dst []VirtualGamepadVibration) []Virt
 func (g *gamepads) setVirtualGamepads(states []VirtualGamepadState) {
 	maxID := -1
 	for i := range states {
-		if id := int(states[i].ID); id > maxID {
-			maxID = id
-		}
+		maxID = max(maxID, int(states[i].ID))
 	}
 	for len(g.gamepads) <= maxID {
 		g.gamepads = append(g.gamepads, nil)

--- a/internal/gamepad/gamepad_xbox_windows.go
+++ b/internal/gamepad/gamepad_xbox_windows.go
@@ -140,7 +140,7 @@ func (n *nativeGamepadXbox) update(gamepads *gamepads) error {
 	}
 	n.state = state
 
-	if n.vib && time.Now().Sub(n.vibEnd) >= 0 {
+	if n.vib && time.Since(n.vibEnd) >= 0 {
 		n.gameInputDevice.SetRumbleState(&_GameInputRumbleParams{
 			lowFrequency:  0,
 			highFrequency: 0,

--- a/internal/graphicscommand/command.go
+++ b/internal/graphicscommand/command.go
@@ -216,18 +216,10 @@ func dstRegionFromVertices(vertices []float32) (minX, minY, maxX, maxY float32) 
 	for i := 0; i < len(vertices); i += graphics.VertexFloatCount {
 		x := vertices[i]
 		y := vertices[i+1]
-		if x < minX {
-			minX = x
-		}
-		if y < minY {
-			minY = y
-		}
-		if maxX < x {
-			maxX = x
-		}
-		if maxY < y {
-			maxY = y
-		}
+		minX = min(minX, x)
+		minY = min(minY, y)
+		maxX = max(maxX, x)
+		maxY = max(maxY, y)
 	}
 	return
 }

--- a/internal/graphicscommand/image.go
+++ b/internal/graphicscommand/image.go
@@ -15,10 +15,11 @@
 package graphicscommand
 
 import (
+	"cmp"
 	"fmt"
 	"image"
 	"io"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -230,8 +231,8 @@ func (i *Image) dumpTo(w io.Writer, graphicsDriver graphicsdriver.Graphics, blac
 }
 
 func LogImagesInfo(images []*Image) {
-	sort.Slice(images, func(a, b int) bool {
-		return images[a].id < images[b].id
+	slices.SortFunc(images, func(a, b *Image) int {
+		return cmp.Compare(a.id, b.id)
 	})
 	for _, i := range images {
 		w, h := i.InternalSize()

--- a/internal/graphicscommand/image.go
+++ b/internal/graphicscommand/image.go
@@ -214,7 +214,7 @@ func (i *Image) dumpTo(w io.Writer, graphicsDriver graphicsdriver.Graphics, blac
 	}
 
 	if blackbg {
-		for i := 0; i < len(pix)/4; i++ {
+		for i := range len(pix) / 4 {
 			pix[4*i+3] = 0xff
 		}
 	}

--- a/internal/graphicsdriver/directx/graphics11_windows.go
+++ b/internal/graphicsdriver/directx/graphics11_windows.go
@@ -66,7 +66,7 @@ func init() {
 	if diff%4 != 0 {
 		panic("directx: unexpected attribute layout")
 	}
-	for i := 0; i < diff/4; i++ {
+	for i := range diff / 4 {
 		inputElementDescsForDX11 = append(inputElementDescsForDX11, _D3D11_INPUT_ELEMENT_DESC{
 			SemanticName:         &([]byte("COLOR\000"))[0],
 			SemanticIndex:        uint32(i) + 1,

--- a/internal/graphicsdriver/directx/pipeline12_windows.go
+++ b/internal/graphicsdriver/directx/pipeline12_windows.go
@@ -62,7 +62,7 @@ func init() {
 	if diff%4 != 0 {
 		panic("directx: unexpected attribute layout")
 	}
-	for i := 0; i < diff/4; i++ {
+	for i := range diff / 4 {
 		inputElementDescsForDX12 = append(inputElementDescsForDX12, _D3D12_INPUT_ELEMENT_DESC{
 			SemanticName:         &([]byte("COLOR\000"))[0],
 			SemanticIndex:        uint32(i) + 1,

--- a/internal/graphicsdriver/metal/graphics_darwin.go
+++ b/internal/graphicsdriver/metal/graphics_darwin.go
@@ -15,11 +15,12 @@
 package metal
 
 import (
+	"cmp"
 	"fmt"
 	"image"
 	"math"
 	"runtime"
-	"sort"
+	"slices"
 	"unsafe"
 
 	"github.com/ebitengine/purego/objc"
@@ -209,8 +210,8 @@ loop:
 		for b := range g.unusedBuffers {
 			bufs = append(bufs, b)
 		}
-		sort.Slice(bufs, func(a, b int) bool {
-			return bufs[a].Length() > bufs[b].Length()
+		slices.SortFunc(bufs, func(a, b mtl.Buffer) int {
+			return cmp.Compare(b.Length(), a.Length())
 		})
 		for _, b := range bufs[maxUnusedBuffers:] {
 			delete(g.unusedBuffers, b)

--- a/internal/graphicsdriver/opengl/program.go
+++ b/internal/graphicsdriver/opengl/program.go
@@ -121,7 +121,7 @@ func init() {
 	if diff%4 != 0 {
 		panic("opengl: unexpected attribute layout")
 	}
-	for i := 0; i < diff/4; i++ {
+	for i := range diff / 4 {
 		theArrayBufferLayout.addPart(arrayBufferLayoutPart{
 			name: fmt.Sprintf("A%d", i+3),
 			num:  4,

--- a/internal/mipmap/mipmap.go
+++ b/internal/mipmap/mipmap.go
@@ -296,9 +296,7 @@ func mipmapLevelFromDistance(dx0, dy0, dx1, dy1, sx0, sy0, sx1, sy1 float32) int
 		}
 	}
 
-	if level > maxLevel {
-		level = maxLevel
-	}
+	level = min(level, maxLevel)
 
 	return level
 }

--- a/internal/shaderir/program.go
+++ b/internal/shaderir/program.go
@@ -22,7 +22,7 @@ import (
 	"go/constant"
 	"go/token"
 	"hash/fnv"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -433,7 +433,7 @@ func (p *Program) ReachableFuncsFromBlock(block *Block) []*Func {
 	}
 	walkExprs(f, block)
 
-	sort.Ints(indices)
+	slices.Sort(indices)
 
 	funcs := make([]*Func, 0, len(indices))
 	for _, i := range indices {

--- a/internal/ui/context.go
+++ b/internal/ui/context.go
@@ -112,7 +112,7 @@ func (c *context) forceUpdateFrame(graphicsDriver graphicsdriver.Graphics, outsi
 		// Or, the rendering result becomes unexpected when the window is resized.
 		n = 2
 	}
-	for i := 0; i < n; i++ {
+	for range n {
 		// Let the clock determine the tick count as usual, instead of forcing one tick per call.
 		// Forced frames can happen at any rate, like once per window-resizing event, and forcing
 		// a tick there would advance the game time faster than the specified TPS (#2615).
@@ -196,7 +196,7 @@ func (c *context) updateFrameImpl(graphicsDriver graphicsdriver.Graphics, update
 	debug.FrameLogf("Update count per frame: %d\n", updateCount)
 
 	// Update the game.
-	for i := 0; i < updateCount; i++ {
+	for range updateCount {
 		// Read the input state and use it for one tick to give a consistent result for one tick (#2496, #2501).
 		c.game.UpdateInputState(func(inputState *InputState) {
 			ui.readInputState(inputState)

--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -758,7 +758,7 @@ func (u *UserInterface) appendDroppedFiles(data js.Value) {
 	items := data.Get("items")
 
 	var entries []js.Value
-	for i := 0; i < items.Length(); i++ {
+	for i := range items.Length() {
 		kind := items.Index(i).Get("kind").String()
 		switch kind {
 		case "file":

--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -310,7 +310,7 @@ func (u *UserInterface) isFocused() bool {
 // > This prevents locking upon initial navigation or re-acquiring lock without user's attention.
 func (u *UserInterface) canCaptureCursor() bool {
 	// 1.5 [sec] seems enough in the real world.
-	return time.Now().Sub(u.lastCaptureExitTime) >= 1500*time.Millisecond
+	return time.Since(u.lastCaptureExitTime) >= 1500*time.Millisecond
 }
 
 func (u *UserInterface) update() error {

--- a/mobile/ebitenmobileview/input_ios.go
+++ b/mobile/ebitenmobileview/input_ios.go
@@ -62,9 +62,7 @@ func getIDFromPtr(ptr int64) int {
 	}
 	maxID := 0
 	for _, id := range ptrToID {
-		if maxID < id {
-			maxID = id
-		}
+		maxID = max(maxID, id)
 	}
 	id := maxID + 1
 	ptrToID[ptr] = id

--- a/text/v2/gotextfacesource.go
+++ b/text/v2/gotextfacesource.go
@@ -848,10 +848,7 @@ func (g *GoTextFaceSource) buildGlyphs(outputs []shaping.Output, text string, fa
 	// face.variations may be replaced by a later SetVariation, so each
 	// buildGlyphs call needs its own copy, but all glyphs within one
 	// call can safely point at the same snapshot.
-	var variationsSnapshot []font.Variation
-	if len(face.variations) > 0 {
-		variationsSnapshot = append([]font.Variation(nil), face.variations...)
-	}
+	variationsSnapshot := slices.Clone(face.variations)
 
 	var gs []goTextGlyph
 	for _, out := range outputs {

--- a/text/v2/gotextfacesource.go
+++ b/text/v2/gotextfacesource.go
@@ -789,9 +789,7 @@ func appendL2VisualOrder(dst []int, levels []bidi.Level) []int {
 	var maxLevel bidi.Level
 	minOddLevel := bidi.Level(127)
 	for _, l := range levels {
-		if l > maxLevel {
-			maxLevel = l
-		}
+		maxLevel = max(maxLevel, l)
 		if l%2 == 1 && l < minOddLevel {
 			minOddLevel = l
 		}

--- a/text/v2/internal/chunk/chunk.go
+++ b/text/v2/internal/chunk/chunk.go
@@ -332,7 +332,7 @@ func mayContainStrongRTLInFirstLine(text string) bool {
 	//   NEL  U+0085 → 0xC2 0x85
 	//   LS   U+2028 → 0xE2 0x80 0xA8
 	//   PS   U+2029 → 0xE2 0x80 0xA9
-	for i := 0; i < len(text); i++ {
+	for i := range len(text) {
 		b := text[i]
 		if b < 0x80 {
 			switch b {

--- a/text/v2/multi.go
+++ b/text/v2/multi.go
@@ -64,30 +64,14 @@ func (m *MultiFace) Metrics() Metrics {
 	var mt Metrics
 	for _, f := range m.faces {
 		mt1 := f.Metrics()
-		if mt1.HLineGap > mt.HLineGap {
-			mt.HLineGap = mt1.HLineGap
-		}
-		if mt1.HAscent > mt.HAscent {
-			mt.HAscent = mt1.HAscent
-		}
-		if mt1.HDescent > mt.HDescent {
-			mt.HDescent = mt1.HDescent
-		}
-		if mt1.VLineGap > mt.VLineGap {
-			mt.VLineGap = mt1.VLineGap
-		}
-		if mt1.VAscent > mt.VAscent {
-			mt.VAscent = mt1.VAscent
-		}
-		if mt1.VDescent > mt.VDescent {
-			mt.VDescent = mt1.VDescent
-		}
-		if mt1.XHeight > mt.XHeight {
-			mt.XHeight = mt1.XHeight
-		}
-		if mt1.CapHeight > mt.CapHeight {
-			mt.CapHeight = mt1.CapHeight
-		}
+		mt.HLineGap = max(mt.HLineGap, mt1.HLineGap)
+		mt.HAscent = max(mt.HAscent, mt1.HAscent)
+		mt.HDescent = max(mt.HDescent, mt1.HDescent)
+		mt.VLineGap = max(mt.VLineGap, mt1.VLineGap)
+		mt.VAscent = max(mt.VAscent, mt1.VAscent)
+		mt.VDescent = max(mt.VDescent, mt1.VDescent)
+		mt.XHeight = max(mt.XHeight, mt1.XHeight)
+		mt.CapHeight = max(mt.CapHeight, mt1.CapHeight)
 	}
 	return mt
 }


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
clean-up

## What this PR does | solves
Introduced modern Go idioms (Go 1.25)

Mechanical modernizations found by auditing the codebase against Go 1.25 features. No behavior changes intended.

### Changes

- **cmd/ebitenmobile**: use `os.ReadDir` instead of `os.Open` + `Readdirnames(-1)` (resolves an old TODO), and replace deprecated `strings.Title` with `golang.org/x/text/cases`. Title-casing is kept for consistency with gomobile.
- **builtin min/max** (`text/v2/multi.go`, `text/v2/gotextfacesource.go`, `internal/graphicscommand/command.go`, `internal/mipmap/mipmap.go`, `mobile/ebitenmobileview/input_ios.go`, `internal/gamepad/gamepad_virtual.go`)
- **sort → slices** (`genkeys.go`, `internal/shaderir/program.go`, `internal/graphicscommand/image.go`, `internal/gamepad/gamepad_iokit_darwin.go`, `internal/gamepad/gamepad_desktop_windows.go`, `internal/graphicsdriver/metal/graphics_darwin.go`). This also removes the now-unnecessary `sort.Interface` implementation in gamepad_iokit_darwin.go.
- **time.Since** instead of `time.Now().Sub` (3 sites)
- **range-over-int** where the counter is a simple index (11 sites)
- **maps.DeleteFunc** (`internal/buffered/pixelcache.go`) and **slices.Clone** (`text/v2/gotextfacesource.go`)

Note: gopls's modernize analyzer only reports a few of these (its minmax pass skips floats by design due to NaN semantics), so most were applied manually with NaN behavior verified per site.


### Verification

- `go build ./...` on linux/amd64, windows (CGO_ENABLED=0), js/wasm, darwin (purego packages)
- `go vet ./...` clean except pre-existing warnings (internal/glfw fork, internal/ui/api_linbsd.go)
- `gofmt -l` clean
- Tests pass: root package, text/v2, audio, internal/graphicscommand, internal/ui, internal/buffered, internal/shaderir
- Every commit builds independently on linux/amd64 (bisectable)
