### PR TITLE
fix doc comments that don't match implementations

### DIFF
--- a/input.go
+++ b/input.go
@@ -396,8 +396,6 @@ func IsStandardGamepadButtonAvailable(id GamepadID, button StandardGamepadButton
 //	"iOS":      GOOS=ios
 //	"":         Any GOOS
 //
-// On platforms where gamepad mappings are not managed by Ebitengine, this always returns false and nil.
-//
 // UpdateStandardGamepadLayoutMappings is concurrent-safe.
 //
 // UpdateStandardGamepadLayoutMappings mappings take effect immediately even for already connected gamepads.

--- a/run.go
+++ b/run.go
@@ -171,7 +171,7 @@ func SetScreenClearedEveryFrame(cleared bool) {
 	ui.Get().SetScreenClearedEveryFrame(cleared)
 }
 
-// IsScreenClearedEveryFrame returns true if the frame isn't cleared at the beginning.
+// IsScreenClearedEveryFrame returns true if the screen is cleared at the beginning of each frame.
 //
 // IsScreenClearedEveryFrame is concurrent-safe.
 func IsScreenClearedEveryFrame() bool {

--- a/text/v2/gox.go
+++ b/text/v2/gox.go
@@ -369,6 +369,6 @@ func (g *GoXFace) direction() Direction {
 func (g *GoXFace) appendVectorPathForLine(path *vector.Path, line string, originX, originY float64) {
 }
 
-// Metrics implements Face.
+// private implements Face.
 func (g *GoXFace) private() {
 }

--- a/text/v2/text.go
+++ b/text/v2/text.go
@@ -72,7 +72,8 @@ type Metrics struct {
 	// If the face is GoXFace or the font doesn't support a vertical direction, VAscent is 0.
 	VAscent float64
 
-	// VDescent is the distance in pixels from the top of a line to its baseline for vertical lines.
+	// VDescent is the distance in pixels from the bottom of a line to its baseline for vertical lines.
+	// The value is typically positive, even though a descender goes below the baseline.
 	// If the face is GoXFace or the font doesn't support a vertical direction, VDescent is 0.
 	VDescent float64
 

--- a/vector/path.go
+++ b/vector/path.go
@@ -214,7 +214,8 @@ func (p *Path) addSubPaths(n int) {
 	p.subPaths = slices.Grow(p.subPaths, n)[:len(p.subPaths)+n]
 }
 
-// MoveTo starts a new sub-path with the given position (x, y) without adding a sub-path,
+// MoveTo starts a new sub-path with the given position (x, y), without adding any line segments.
+// If the last sub-path is still empty, MoveTo updates its start position instead of adding a new one.
 func (p *Path) MoveTo(x, y float32) {
 	p.resetFlatPaths()
 
@@ -229,7 +230,8 @@ func (p *Path) MoveTo(x, y float32) {
 
 // LineTo adds a line segment to the path, which starts from the last position of the current sub-path
 // and ends to the given position (x, y).
-// If p doesn't have any sub-paths or the last sub-path is closed, LineTo sets (x, y) as the start position of a new sub-path.
+// If p doesn't have any sub-paths, LineTo sets (x, y) as the start position of a new sub-path.
+// If the last sub-path is closed, LineTo creates a new sub-path whose start position is the same as the closed sub-path's.
 func (p *Path) LineTo(x, y float32) {
 	p.resetFlatPaths()
 

--- a/vector/util.go
+++ b/vector/util.go
@@ -188,7 +188,7 @@ func StrokeRect(dst *ebiten.Image, x, y, width, height float32, strokeWidth floa
 	}
 }
 
-// FillCircle fills a circle with the specified center position (cx, cy), the radius (r), width and color.
+// FillCircle fills a circle with the specified center position (cx, cy), the radius (r) and color.
 func FillCircle(dst *ebiten.Image, cx, cy, r float32, clr color.Color, antialias bool) {
 	if antialias {
 		path := thePathPool.Get().(*Path)
@@ -239,7 +239,7 @@ func FillCircle(dst *ebiten.Image, cx, cy, r float32, clr color.Color, antialias
 	})
 }
 
-// DrawFilledCircle fills a circle with the specified center position (cx, cy), the radius (r), width and color.
+// DrawFilledCircle fills a circle with the specified center position (cx, cy), the radius (r) and color.
 //
 // Deprecated: as of v2.9. Use [FillCircle] instead.
 func DrawFilledCircle(dst *ebiten.Image, cx, cy, r float32, clr color.Color, antialias bool) {


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
clean up

## What this PR does | solves

- IsScreenClearedEveryFrame returns true when the screen IS cleared, not the other way around
- UpdateStandardGamepadLayoutMappings never returns (false, nil); remove the paragraph describing a non-existent behavior
- Path.MoveTo does add a sub-path; it adds no line segments instead. Also document the case where the last sub-path is reused
- Path.LineTo after Close starts the new sub-path at the closed sub-path's start position, not at (x, y)
- Metrics.VDescent is measured from the baseline downward, like HDescent (the previous text was copied from VAscent)
- GoXFace.private had a wrong 'Metrics implements Face.' comment
- FillCircle/DrawFilledCircle don't take any width parameter

