### PR TITLE
internal/shader: end a loop variable's scope with the loop

### DIFF
--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -30,6 +30,12 @@ type variable struct {
 	name           string
 	typ            shaderir.Type
 	forLoopCounter bool
+
+	// outOfScope indicates that the variable's scope has ended but the variable is still kept to
+	// keep the local variable indices. An out-of-scope variable is never found nor checked by its
+	// name. This is the case for a for-loop's iteration variables, which are shared with the
+	// enclosing block but whose scopes end with the for-loop.
+	outOfScope bool
 }
 
 type constant struct {
@@ -126,6 +132,9 @@ func (b *block) findLocalVariable(name string, markLocalVariableUsed bool) (int,
 		idx += len(outer.vars)
 	}
 	for i, v := range b.vars {
+		if v.outOfScope {
+			continue
+		}
 		if v.name == name {
 			if markLocalVariableUsed {
 				delete(b.unusedVars, i)
@@ -621,6 +630,9 @@ func (s *compileState) parseVariable(block *block, fname string, vs *ast.ValueSp
 
 		name := n.Name
 		for _, v := range append(block.vars, vars...) {
+			if v.outOfScope {
+				continue
+			}
 			if v.name == name {
 				s.addError(vs.Pos(), fmt.Sprintf("duplicated local variable name: %s", name))
 				return nil, nil, nil, false
@@ -661,6 +673,9 @@ func (s *compileState) parseConstant(block *block, fname string, vs *ast.ValueSp
 			}
 		}
 		for _, v := range block.vars {
+			if v.outOfScope {
+				continue
+			}
 			if v.name == name {
 				s.addError(vs.Pos(), fmt.Sprintf("duplicated local constant/variable name: %s", name))
 				return nil, false

--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -30,12 +30,6 @@ type variable struct {
 	name           string
 	typ            shaderir.Type
 	forLoopCounter bool
-
-	// outOfScope indicates that the variable's scope has ended but the variable is still kept to
-	// keep the local variable indices. An out-of-scope variable is never found nor checked by its
-	// name. This is the case for a for-loop's iteration variables, which are shared with the
-	// enclosing block but whose scopes end with the for-loop.
-	outOfScope bool
 }
 
 type constant struct {
@@ -132,9 +126,6 @@ func (b *block) findLocalVariable(name string, markLocalVariableUsed bool) (int,
 		idx += len(outer.vars)
 	}
 	for i, v := range b.vars {
-		if v.outOfScope {
-			continue
-		}
 		if v.name == name {
 			if markLocalVariableUsed {
 				delete(b.unusedVars, i)
@@ -630,9 +621,6 @@ func (s *compileState) parseVariable(block *block, fname string, vs *ast.ValueSp
 
 		name := n.Name
 		for _, v := range append(block.vars, vars...) {
-			if v.outOfScope {
-				continue
-			}
 			if v.name == name {
 				s.addError(vs.Pos(), fmt.Sprintf("duplicated local variable name: %s", name))
 				return nil, nil, nil, false
@@ -673,9 +661,6 @@ func (s *compileState) parseConstant(block *block, fname string, vs *ast.ValueSp
 			}
 		}
 		for _, v := range block.vars {
-			if v.outOfScope {
-				continue
-			}
 			if v.name == name {
 				s.addError(vs.Pos(), fmt.Sprintf("duplicated local constant/variable name: %s", name))
 				return nil, false

--- a/internal/shader/stmt.go
+++ b/internal/shader/stmt.go
@@ -525,9 +525,6 @@ func (cs *compileState) assign(block *block, fname string, pos token.Pos, lhs, r
 				name := e.(*ast.Ident).Name
 				if name != "_" {
 					for _, v := range block.vars {
-						if v.outOfScope {
-							continue
-						}
 						if v.name == name {
 							cs.addError(pos, fmt.Sprintf("duplicated local variable name: %s", name))
 							return nil, false
@@ -673,9 +670,6 @@ func (cs *compileState) assign(block *block, fname string, pos token.Pos, lhs, r
 				name := e.(*ast.Ident).Name
 				if name != "_" {
 					for _, v := range block.vars {
-						if v.outOfScope {
-							continue
-						}
 						if v.name == name {
 							cs.addError(pos, fmt.Sprintf("duplicated local variable name: %s", name))
 							return nil, false
@@ -916,11 +910,12 @@ func (cs *compileState) parseFor(block *block, fname string, stmt *ast.ForStmt, 
 	// As the pseudo block is not actually used, copy the variable part to the actual block.
 	// This must be done after parsing the for-loop is done, or the duplicated variables confuses the
 	// parsing.
-	// The scope of the counter variable ends with this for-loop, so the variable is marked as
-	// out-of-scope. The variable itself is still kept for the local-variable indices.
+	// The scope of the counter variable ends with this for-loop. Clear its name so that the
+	// variable is neither found nor checked by its name anymore. The variable itself is still kept
+	// for the local-variable indices.
 	v := pseudoBlock.vars[0]
 	v.forLoopCounter = true
-	v.outOfScope = true
+	v.name = ""
 	block.vars = append(block.vars, v)
 
 	return []shaderir.Stmt{
@@ -1078,15 +1073,16 @@ func (cs *compileState) parseForRange(block *block, fname string, stmt *ast.Rang
 	// As the pseudo block is not actually used, copy the variable part to the actual block.
 	// This must be done after parsing the for-loop is done, or the duplicated variables confuses the
 	// parsing.
-	// The scopes of the iteration variables end with this for-loop, so the variables are marked as
-	// out-of-scope. The variables themselves are still kept for the local-variable indices.
+	// The scopes of the iteration variables end with this for-loop. Clear their names so that the
+	// variables are neither found nor checked by their names anymore. The variables themselves are
+	// still kept for the local-variable indices.
 	counter := pseudoBlock.vars[0]
 	counter.forLoopCounter = true
-	counter.outOfScope = true
+	counter.name = ""
 	block.vars = append(block.vars, counter)
 	if stmt.Value != nil {
 		value := pseudoBlock.vars[1]
-		value.outOfScope = true
+		value.name = ""
 		block.vars = append(block.vars, value)
 	}
 

--- a/internal/shader/stmt.go
+++ b/internal/shader/stmt.go
@@ -525,6 +525,9 @@ func (cs *compileState) assign(block *block, fname string, pos token.Pos, lhs, r
 				name := e.(*ast.Ident).Name
 				if name != "_" {
 					for _, v := range block.vars {
+						if v.outOfScope {
+							continue
+						}
 						if v.name == name {
 							cs.addError(pos, fmt.Sprintf("duplicated local variable name: %s", name))
 							return nil, false
@@ -670,6 +673,9 @@ func (cs *compileState) assign(block *block, fname string, pos token.Pos, lhs, r
 				name := e.(*ast.Ident).Name
 				if name != "_" {
 					for _, v := range block.vars {
+						if v.outOfScope {
+							continue
+						}
 						if v.name == name {
 							cs.addError(pos, fmt.Sprintf("duplicated local variable name: %s", name))
 							return nil, false
@@ -910,8 +916,11 @@ func (cs *compileState) parseFor(block *block, fname string, stmt *ast.ForStmt, 
 	// As the pseudo block is not actually used, copy the variable part to the actual block.
 	// This must be done after parsing the for-loop is done, or the duplicated variables confuses the
 	// parsing.
+	// The scope of the counter variable ends with this for-loop, so the variable is marked as
+	// out-of-scope. The variable itself is still kept for the local-variable indices.
 	v := pseudoBlock.vars[0]
 	v.forLoopCounter = true
+	v.outOfScope = true
 	block.vars = append(block.vars, v)
 
 	return []shaderir.Stmt{
@@ -1069,11 +1078,16 @@ func (cs *compileState) parseForRange(block *block, fname string, stmt *ast.Rang
 	// As the pseudo block is not actually used, copy the variable part to the actual block.
 	// This must be done after parsing the for-loop is done, or the duplicated variables confuses the
 	// parsing.
+	// The scopes of the iteration variables end with this for-loop, so the variables are marked as
+	// out-of-scope. The variables themselves are still kept for the local-variable indices.
 	counter := pseudoBlock.vars[0]
 	counter.forLoopCounter = true
+	counter.outOfScope = true
 	block.vars = append(block.vars, counter)
 	if stmt.Value != nil {
-		block.vars = append(block.vars, pseudoBlock.vars[1])
+		value := pseudoBlock.vars[1]
+		value.outOfScope = true
+		block.vars = append(block.vars, value)
 	}
 
 	return []shaderir.Stmt{

--- a/internal/shader/syntax_test.go
+++ b/internal/shader/syntax_test.go
@@ -175,6 +175,130 @@ func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
 	}
 }
 
+func TestSyntaxLoopVariableScope(t *testing.T) {
+	// A loop variable's scope ends with the loop. Redeclaring a variable with the same name after
+	// the loop is fine.
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	for i := 0; i < 3; i++ {
+	}
+	i := 10.0
+	return vec4(i)
+}
+`)); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	for i := range 3 {
+		_ = i
+	}
+	i := 10.0
+	return vec4(i)
+}
+`)); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	a := [3]float{1, 2, 3}
+	sum := 0.0
+	for _, v := range a {
+		sum += v
+	}
+	v := 10.0
+	return vec4(sum + v)
+}
+`)); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	a := [3]float{1, 2, 3}
+	sum := 0.0
+	for _, v := range a {
+		sum += v
+	}
+	var v float = 10.0
+	return vec4(sum + v)
+}
+`)); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	for i := range 3 {
+		_ = i
+	}
+	const i = 10
+	return vec4(float(i))
+}
+`)); err != nil {
+		t.Error(err)
+	}
+
+	// After the loop, the name refers to the global variable, not the loop variable.
+	if _, err := compileToIR([]byte(`package main
+
+var I float
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	for I := 0; I < 3; I++ {
+	}
+	return vec4(sin(I))
+}
+`)); err != nil {
+		t.Error(err)
+	}
+
+	// A loop variable is not available after the loop.
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	for i := 0; i < 3; i++ {
+	}
+	return vec4(float(i))
+}
+`)); err == nil {
+		t.Errorf("error must be non-nil but was nil")
+	}
+
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	for i := range 3 {
+		_ = i
+	}
+	return vec4(float(i))
+}
+`)); err == nil {
+		t.Errorf("error must be non-nil but was nil")
+	}
+
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	a := [3]float{1, 2, 3}
+	sum := 0.0
+	for _, v := range a {
+		sum += v
+	}
+	return vec4(sum + v)
+}
+`)); err == nil {
+		t.Errorf("error must be non-nil but was nil")
+	}
+}
+
 func TestSyntaxWrongReturn(t *testing.T) {
 	if _, err := compileToIR([]byte(`package main
 


### PR DESCRIPTION


# What issue is this addressing?
None

## What _type_ of issue is this addressing?
Bug

## What this PR does | solves

A for-loop's iteration variables are appended to the enclosing block after the loop is parsed, so that the local-variable indices stay aligned. As the name of those variables was still resolved afterward, the scope leaked out of the loop:

```
  for i := 0; i < 3; i++ {
  }
  i := 10.0 // "duplicated local variable name: i", though valid in Go
```

Worse, when no such redeclaration existed, references after the loop silently bound to the iteration variable instead of falling back to an enclosing or global declaration:

```
  var I float

  func Fragment() vec4 {
      for I := 0; I < 3; I++ {
      }
      return vec4(sin(I)) // sin got the leaked int counter, not the global
  }
```

Mark the copied iteration variables as out-of-scope so that name resolution and duplicate-name checks ignore them, while their entries are kept for the local-variable indices. This applies to three-clause for-loops, and to range loops' counter and value variables alike.

Closes a bug that has existed since parseFor was introduced, and which the new range-over-integer/array statements (#2905, #1897) share.
