### PR TITLE
internal/shader: reject more fragment arguments than the vertex returning values

### DIFF
--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -311,6 +311,9 @@ func (cs *compileState) parse(f *ast.File) {
 				cs.addError(0, fmt.Sprintf("fragment argument %s must be %s but was %s", name, p.typ.String(), t.String()))
 			}
 		}
+		if len(fragmentInParams) > len(vertexOutParams) {
+			cs.addError(0, fmt.Sprintf("the number of the fragment arguments (%d) must not be greater than the number of the vertex returning values (%d)", len(fragmentInParams), len(vertexOutParams)))
+		}
 
 		// The first out-param is treated as gl_Position in GLSL.
 		if vertexOutParams[0].typ.Main != shaderir.Vec4 {

--- a/internal/shader/syntax_test.go
+++ b/internal/shader/syntax_test.go
@@ -308,6 +308,21 @@ func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
 	}
 }
 
+func TestSyntaxTooManyFragmentArguments(t *testing.T) {
+	if _, err := compileToIR([]byte(`package main
+
+func Vertex(pos vec2) vec4 {
+	return vec4(pos, 0, 1)
+}
+
+func Fragment(dstPos vec4, srcPos vec2) vec4 {
+	return dstPos + vec4(srcPos, 0, 0)
+}
+`)); err == nil {
+		t.Errorf("error must be non-nil but was nil")
+	}
+}
+
 func TestSyntaxUnsupportedSyntax(t *testing.T) {
 	if _, err := compileToIR([]byte(`package main
 


### PR DESCRIPTION

# What issue is this addressing?

None

## What _type_ of issue is this addressing?

bug

## What this PR does | solves

When the fragment entry point takes more arguments than the vertex entry point returns, the arguments beyond the vertex's returning values have no corresponding varyings. The existing check only compares the types of the common prefix, so such a program compiled fine and then made the backends panic with an out-of-range access in LocalVariableType when the shader was actually built (e.g. at the first draw call):

```
    func Vertex(pos vec2) vec4 {
        return vec4(pos, 0, 1)
    }

    func Fragment(dstPos vec4, srcPos vec2) vec4 {
        return dstPos + vec4(srcPos, 0, 0)
    }
```

Reject the count mismatch at compile time instead. Programs where the vertex returns more values than the fragment takes are still fine: the fragment arguments are padded from the varyings in that case.

In the regular pipeline the vertex entry point is always the generated __vertex bridge with four returning values, so this only affects shaders whose fragment entry point takes five or more arguments.


