### PR TITLE
vector: accept nil options at StrokePath

### DIFF
--- a/vector/util.go
+++ b/vector/util.go
@@ -323,6 +323,9 @@ func StrokeCircle(dst *ebiten.Image, cx, cy, r float32, strokeWidth float32, clr
 
 // StrokePath strokes the specified path with the specified options.
 func StrokePath(dst *ebiten.Image, path *Path, strokeOptions *StrokeOptions, drawPathOptions *DrawPathOptions) {
+	if strokeOptions == nil {
+		strokeOptions = &StrokeOptions{}
+	}
 	stroke := thePathPool.Get().(*Path)
 	defer func() {
 		stroke.Reset()

--- a/vector/util_test.go
+++ b/vector/util_test.go
@@ -146,3 +146,19 @@ func TestFillRectOnBigImage(t *testing.T) {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 }
+
+// nil options should be treated as the zero values, as FillPath does.
+func TestStrokePathNilOptions(t *testing.T) {
+	dst := ebiten.NewImage(16, 16)
+	defer dst.Deallocate()
+
+	var path vector.Path
+	path.MoveTo(4, 4)
+	path.LineTo(12, 12)
+	vector.StrokePath(dst, &path, nil, nil)
+
+	// A zero-width stroke renders nothing.
+	if got, want := dst.At(8, 8), (color.RGBA{}); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

StrokePath panicked with a nil-pointer dereference when strokeOptions was nil, while the other functions of the package treat nil options as the zero values: FillPath replaces its options with the zero values, and AddPath and AddStroke check their options against nil. Align StrokePath with them.