### PR TITLE
text/v2: fix glyph indices after a multi-byte line break

### DIFF
--- a/text/v2/layout.go
+++ b/text/v2/layout.go
@@ -466,9 +466,6 @@ func forEachLine(text string, face Face, options *LayoutOptions, f func(text str
 			}
 		}
 
-		// Keep the original line length before trimming the trailing line break, so that
-		// indexOffset can advance by the entire line including its line break. A line break is
-		// not always one byte: it can be "\r\n" or a multi-byte character like \u2028.
 		l := len(line)
 		line = textutil.TrimTailingLineBreak(line)
 		f(line, indexOffset, originX+offsetX, originY+offsetY)

--- a/text/v2/layout.go
+++ b/text/v2/layout.go
@@ -466,10 +466,14 @@ func forEachLine(text string, face Face, options *LayoutOptions, f func(text str
 			}
 		}
 
+		// Keep the original line length before trimming the trailing line break, so that
+		// indexOffset can advance by the entire line including its line break. A line break is
+		// not always one byte: it can be "\r\n" or a multi-byte character like \u2028.
+		l := len(line)
 		line = textutil.TrimTailingLineBreak(line)
 		f(line, indexOffset, originX+offsetX, originY+offsetY)
 
-		indexOffset += len(line) + 1
+		indexOffset += l
 		i++
 
 		// Advance the origin position in the secondary direction.

--- a/text/v2/text_test.go
+++ b/text/v2/text_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/examples/resources/fonts"
 	t "github.com/hajimehoshi/ebiten/v2/internal/testing"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
+	"github.com/hajimehoshi/ebiten/v2/text/v2/internal/textutil"
 )
 
 func TestMain(m *testing.M) {
@@ -55,6 +56,31 @@ over the lazy dog.`
 	want := regexp.MustCompile(`\S`).ReplaceAllString(sampleText, " ")
 	if got != want {
 		t.Errorf("got: %q, want: %q", got, want)
+	}
+}
+
+func TestGlyphIndexWithLineBreaks(t *testing.T) {
+	// A line break is not always a single byte: it can be "\r\n" or a multi-byte character.
+	for _, lineBreak := range []string{"\n", "\v", "\f", "\r", "\r\n", "\u0085", "\u2028", "\u2029"} {
+		sampleText := "abc" + lineBreak + "defg" + lineBreak + "hijklmno"
+
+		f := text.NewGoXFace(bitmapfont.Face)
+		got := sampleText
+		for _, g := range text.AppendGlyphs(nil, sampleText, f, nil) {
+			if g.StartIndexInBytes < 0 || g.EndIndexInBytes > len(got) || g.StartIndexInBytes >= g.EndIndexInBytes {
+				t.Errorf("lineBreak: %q, invalid indices: [%d, %d)", lineBreak, g.StartIndexInBytes, g.EndIndexInBytes)
+				continue
+			}
+			got = got[:g.StartIndexInBytes] + strings.Repeat(" ", g.EndIndexInBytes-g.StartIndexInBytes) + got[g.EndIndexInBytes:]
+		}
+
+		// All the runes other than the line breaks should be covered by the glyphs.
+		for i, r := range got {
+			if r == ' ' || textutil.IsLineBreak(r) {
+				continue
+			}
+			t.Errorf("lineBreak: %q, unexpected rune %q at %d: %q", lineBreak, r, i, got)
+		}
 	}
 }
 


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Glyph indices were wrong for the lines after a line break that is not exactly one byte. forEachLine advanced its index offset by the trimmed line's length plus one, assuming every line break is "\n". A line break can also be "\r\n" or a multi-byte character like \u2028 though, so the offset was short by one or more bytes and the glyphs' StartIndexInBytes and EndIndexInBytes pointed at wrong positions.

Advance the offset by the untrimmed line's length instead, which includes whatever the line break is. With the new test TestGlyphIndexWithLineBreaks, every line break fails on main except "\n", and all of them pass with this change.

