### PR TITLE
gamepaddb: reject an empty mapping element

### DIFF
--- a/internal/gamepaddb/gamepaddb.go
+++ b/internal/gamepaddb/gamepaddb.go
@@ -166,6 +166,9 @@ func parseLine(line string, platform platform) (id string, name string, buttons 
 }
 
 func parseMappingElement(str string) (mapping, error) {
+	if len(str) == 0 {
+		return mapping{}, fmt.Errorf("gamepaddb: unexpected empty mapping")
+	}
 	switch {
 	case str[0] == 'a' || strings.HasPrefix(str, "+a") || strings.HasPrefix(str, "-a"):
 		var tilda bool
@@ -251,7 +254,7 @@ func parseMappingElement(str string) (mapping, error) {
 		}, nil
 	}
 
-	return mapping{}, fmt.Errorf("gamepaddb: unepxected mapping: %s", str)
+	return mapping{}, fmt.Errorf("gamepaddb: unexpected mapping: %s", str)
 }
 
 func toStandardGamepadButton(str string) (StandardButton, bool) {

--- a/internal/gamepaddb/gamepaddb_test.go
+++ b/internal/gamepaddb/gamepaddb_test.go
@@ -54,6 +54,15 @@ func TestUpdate(t *testing.T) {
 			Input: "00000000000000000000000000000000,foo,platform:Windows",
 			Err:   false,
 		},
+		{
+			// An empty binding after ':' used to panic.
+			Input: "00000000000000000000000000000000,foo,a:",
+			Err:   true,
+		},
+		{
+			Input: "00000000000000000000000000000000,foo,leftx:a:",
+			Err:   true,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
UpdateStandardGamepadLayoutMappings accepts user-provided mappings in the SDL_GameControllerDB format and is documented to return an error when parsing fails. A line with an empty binding after ':' such as

    00000000000000000000000000000000,foo,a:

made parseMappingElement index its argument's first byte unconditionally and panic instead. Return an error for the empty element.

Also fix the 'unepxected' typo in this function's fallback error message.
