### PR TITLE
text/v2: scale the glyph culling margins with geoM

### DIFF
--- a/text/v2/cull_scaled_test.go
+++ b/text/v2/cull_scaled_test.go
@@ -1,0 +1,59 @@
+package text_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/hajimehoshi/bitmapfont/v4"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
+)
+
+// TestDrawScaledAgainstAppendGlyphs compares text.Draw with an unculled reference rendering built
+// from AppendGlyphs. Draw's offscreen-glyph culling must not drop any glyph that the reference
+// renders, especially with a scaled GeoM where a glyph's extent on dst is larger than its extent
+// in text space.
+func TestDrawScaledAgainstAppendGlyphs(t *testing.T) {
+	face := text.NewGoXFace(bitmapfont.Face)
+	m := face.Metrics()
+	txt := "AAAA\nBBBB\nCCCC\nDDDD\nEEEE\nFFFF\nGGGG\nHHHH"
+	layout := &text.LayoutOptions{LineSpacing: m.HAscent + m.HDescent}
+
+	const w, h = 120, 120
+	for _, scale := range []float64{1, 2, 4} {
+		for _, ty := range []float64{-400, -300, -200, -100, -50, 0, 50, 80, 95} {
+			dstDraw := ebiten.NewImage(w, h)
+			defer dstDraw.Deallocate()
+			dstRef := ebiten.NewImage(w, h)
+			defer dstRef.Deallocate()
+
+			geoM := ebiten.GeoM{}
+			geoM.Scale(scale, scale)
+			geoM.Translate(10, ty)
+
+			op := &text.DrawOptions{}
+			op.GeoM = geoM
+			op.LayoutOptions = *layout
+			text.Draw(dstDraw, txt, face, op)
+
+			for _, g := range text.AppendGlyphs(nil, txt, face, layout) {
+				if g.Image == nil {
+					continue
+				}
+				gop := &ebiten.DrawImageOptions{}
+				gop.GeoM.Translate(g.X, g.Y)
+				gop.GeoM.Concat(geoM)
+				dstRef.DrawImage(g.Image, gop)
+			}
+
+			bufDraw := make([]byte, 4*w*h)
+			bufRef := make([]byte, 4*w*h)
+			dstDraw.ReadPixels(bufDraw)
+			dstRef.ReadPixels(bufRef)
+			if !bytes.Equal(bufDraw, bufRef) {
+				t.Errorf("scale: %g, ty: %g: Draw differs from AppendGlyphs-based rendering", scale, ty)
+			}
+		}
+	}
+}

--- a/text/v2/cull_scaled_test.go
+++ b/text/v2/cull_scaled_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package text_test
 
 import (

--- a/text/v2/layout.go
+++ b/text/v2/layout.go
@@ -212,6 +212,12 @@ func Draw(dst *ebiten.Image, text string, face Face, options *DrawOptions) {
 // near the edge are kept and re-checked by the precise per-glyph cull in
 // Draw.
 //
+// The margins are in the destination's coordinates, so they account for geoM's
+// scale: a glyph's extent on the destination scales with geoM, and an unscaled
+// margin would wrongly cull glyphs at the edges of a scaled destination. The
+// absolute values are used so that flipped (negative-scale) geoMs are covered
+// as well.
+//
 // The cull applies only when geoM has no shear or rotation. Otherwise nil
 // is returned and no glyph-level cull happens.
 func keepGlyphFilter(face Face, geoM ebiten.GeoM, dstBounds image.Rectangle) func(originX, originY float64) bool {
@@ -227,20 +233,23 @@ func keepGlyphFilter(face Face, geoM ebiten.GeoM, dstBounds image.Rectangle) fun
 	// the cull benefit.
 	const advanceMarginFactor = 100
 	m := face.Metrics()
-	var marginX, marginY float64
-	if face.direction().isHorizontal() {
-		height := m.HAscent + m.HDescent
-		marginX = advanceMarginFactor * height
-		marginY = height + m.HLineGap
-	} else {
-		width := m.VAscent + m.VDescent
-		marginY = advanceMarginFactor * width
-		marginX = width + m.VLineGap
-	}
 	a := geoM.Element(0, 0)
 	d := geoM.Element(1, 1)
 	tx := geoM.Element(0, 2)
 	ty := geoM.Element(1, 2)
+	// scale is the larger absolute scale factor of geoM. The margins are in the destination's
+	// coordinates, so they have to cover a glyph's extent after scaling.
+	scale := max(math.Abs(a), math.Abs(d))
+	var marginX, marginY float64
+	if face.direction().isHorizontal() {
+		height := m.HAscent + m.HDescent
+		marginX = advanceMarginFactor * height * scale
+		marginY = (height + m.HLineGap) * scale
+	} else {
+		width := m.VAscent + m.VDescent
+		marginY = advanceMarginFactor * width * scale
+		marginX = (width + m.VLineGap) * scale
+	}
 	dstMinX := float64(dstBounds.Min.X) - marginX
 	dstMaxX := float64(dstBounds.Max.X) + marginX
 	dstMinY := float64(dstBounds.Min.Y) - marginY


### PR DESCRIPTION
# What issue is this addressing?
#3529 

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Draw's offscreen-glyph culling skips a glyph when its projected origin lies outside dst plus a slack on each side. The slack was computed from the face metrics alone, in text-space sizes, while the check compares positions in the destination's coordinates. With a scaled GeoM, a glyph's extent on the destination scales accordingly, so the fixed slack was too small and glyphs whose bodies still overlapped dst were wrongly culled: at a scale of 4, a line straddling the destination's edge lost its visible part.

Multiply both margins by the larger absolute scale factor of geoM, so that the slack covers the scaled glyph extents regardless of the zoom. The advance-axis margin keeps its 100-line-heights factor on top of the scale, so wide ligatures stay covered when zoomed in as well.

This also fixes flipped (negative-scale) geoMs, where the same wrong culling could happen for the same reason.

