### PR TITLE
internal/shader: report a division by zero in a constant expression

### DIFF
--- a/internal/shader/expr.go
+++ b/internal/shader/expr.go
@@ -163,8 +163,16 @@ func (cs *compileState) parseExpr(block *block, fname string, expr ast.Expr, mar
 					cs.addError(e.Pos(), fmt.Sprintf("unexpected %s type for: %s", rhs[0].Const.String(), e.Op))
 					return nil, nil, nil, false
 				}
+				if shift < 0 {
+					cs.addError(e.Pos(), fmt.Sprintf("negative shift count: %s", rhs[0].Const.String()))
+					return nil, nil, nil, false
+				}
 				v = gconstant.Shift(lhs[0].Const, op, uint(shift))
 			default:
+				if (op == token.QUO || op == token.QUO_ASSIGN || op == token.REM) && gconstant.Sign(rhs[0].Const) == 0 {
+					cs.addError(e.Pos(), "division by zero")
+					return nil, nil, nil, false
+				}
 				v = gconstant.BinaryOp(lhs[0].Const, op, rhs[0].Const)
 			}
 

--- a/internal/shader/syntax_test.go
+++ b/internal/shader/syntax_test.go
@@ -909,6 +909,7 @@ func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
 }`)); err == nil {
 		t.Errorf("error must be non-nil but was nil")
 	}
+
 	if _, err := compileToIR([]byte(`package main
 
 func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
@@ -1057,6 +1058,69 @@ func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
 	return vec4(0)
 }`)); err == nil {
 		t.Errorf("error must be non-nil but was nil")
+	}
+
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	a := 1 / 0
+	_ = a
+	return vec4(0)
+}`)); err == nil {
+		t.Errorf("error must be non-nil but was nil")
+	}
+
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	a := 1 % 0
+	_ = a
+	return vec4(0)
+}`)); err == nil {
+		t.Errorf("error must be non-nil but was nil")
+	}
+
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	a := 1.0 / 0.0
+	_ = a
+	return vec4(0)
+}`)); err == nil {
+		t.Errorf("error must be non-nil but was nil")
+	}
+
+	// A division by a non-constant zero is not an error at the compile time.
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	a := 1
+	b := 0
+	c := a / b
+	_ = c
+	return vec4(0)
+}`)); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	a := 1 << -1
+	_ = a
+	return vec4(0)
+}`)); err == nil {
+		t.Errorf("error must be non-nil but was nil")
+	}
+
+	if _, err := compileToIR([]byte(`package main
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	a := 1 << 62
+	_ = a
+	return vec4(0)
+}`)); err != nil {
+		t.Error(err)
 	}
 
 	if _, err := compileToIR([]byte(`package main


### PR DESCRIPTION
# What issue is this addressing?
#3533 

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
A Kage shader with a constant expression like `1 / 0` made the compiler panic: go/constant panics on a division by zero, and ebiten.NewShader calls this compiler in the middle of a game. Report an error instead, as Go does for the same expression.

The guard has to cover token.QUO_ASSIGN as well as token.QUO, because the compiler rewrites the operator of an integer division to token.QUO_ASSIGN to force integer division in go/constant.

A negative shift count had the same problem: go/constant's Shift takes the count as uint, so `1 << -1` wrapped into a huge number. Report it as an error too.