### PR TITLE
make Fill and Set no-op on nil color instead of panicking

### DIFF
--- a/image.go
+++ b/image.go
@@ -133,17 +133,9 @@ func (i *Image) Clear() {
 
 // Fill fills the image with a solid color.
 //
-// If the image is disposed, Fill does nothing.
-//
-// As of v2.10, Fill does not panic if clr is nil; it treats nil as a no-op.
 func (i *Image) Fill(clr color.Color) {
 	i.copyCheck()
-
-	if clr == nil {
-		return
-	}
-
-	if i.isDisposed() {
+	if i.isDisposed() || clr == nil {
 		return
 	}
 	i.invokeUsageCallbacks()
@@ -1339,14 +1331,9 @@ func (i *Image) at(x, y int) (r, g, b, a byte) {
 // If the image is disposed, Set does nothing.
 //
 // For performance, it is recommended to use WritePixels instead of Set whenever possible.
-//
-// As of v2.10, Set does not panic if clr is nil; it treats nil as a no-op.
 func (i *Image) Set(x, y int, clr color.Color) {
 	i.copyCheck()
-	if clr == nil {
-		return
-	}
-	if i.isDisposed() {
+	if i.isDisposed() || clr == nil {
 		return
 	}
 

--- a/image.go
+++ b/image.go
@@ -133,13 +133,19 @@ func (i *Image) Clear() {
 
 // Fill fills the image with a solid color.
 //
-// When the image is disposed, Fill does nothing.
+// If the image is disposed, Fill does nothing.
+//
+// As of v2.10, Fill does not panic if clr is nil; it treats nil as a no-op.
 func (i *Image) Fill(clr color.Color) {
 	i.copyCheck()
-	if i.isDisposed() {
+
+	if clr == nil {
 		return
 	}
 
+	if i.isDisposed() {
+		return
+	}
 	i.invokeUsageCallbacks()
 
 	i.updateAccessTime()
@@ -1333,8 +1339,13 @@ func (i *Image) at(x, y int) (r, g, b, a byte) {
 // If the image is disposed, Set does nothing.
 //
 // For performance, it is recommended to use WritePixels instead of Set whenever possible.
+//
+// As of v2.10, Set does not panic if clr is nil; it treats nil as a no-op.
 func (i *Image) Set(x, y int, clr color.Color) {
 	i.copyCheck()
+	if clr == nil {
+		return
+	}
 	if i.isDisposed() {
 		return
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -435,6 +435,31 @@ func TestImageFill(t *testing.T) {
 	}
 }
 
+// TestImageFillSetNilColor checks that a nil color value passed to Fill or Set is treated as a no-op
+// instead of panicking. nil.RGBA() panics in the standard library, so without this guard any caller
+// that happened to pass nil (e.g. from a default-constructed color.Color field) would crash the game.
+func TestImageFillSetNilColor(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("test PANIC: %v", r)
+		}
+	}()
+
+	for _, tc := range []struct {
+		name string
+		f    func(img *ebiten.Image)
+	}{
+		{"Fill", func(img *ebiten.Image) { img.Fill(nil) }},
+		{"Set", func(img *ebiten.Image) { img.Set(2, 2, nil) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			img := ebiten.NewImage(8, 8)
+			defer img.Deallocate()
+			tc.f(img) // must not panic.
+		})
+	}
+}
+
 // Issue #740
 func TestImageClear(t *testing.T) {
 	const w, h = 128, 256

--- a/image_test.go
+++ b/image_test.go
@@ -435,9 +435,6 @@ func TestImageFill(t *testing.T) {
 	}
 }
 
-// TestImageFillSetNilColor checks that a nil color value passed to Fill or Set is treated as a no-op
-// instead of panicking. nil.RGBA() panics in the standard library, so without this guard any caller
-// that happened to pass nil (e.g. from a default-constructed color.Color field) would crash the game.
 func TestImageFillSetNilColor(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

`Image.Fill` and `Image.Set` called `clr.RGBA()` on the given color without a nil check. A nil `color.Color` interface value has no method table, so either function panicked with a nil-pointer dereference:

```    
img.Fill(nil)        // panic: invalid memory address or nil pointer dereference
img.Set(2, 2, nil)   // panic: invalid memory address or nil pointer dereference
```
  
This is easy to hit in practice. A `color.Color` field left at its zero value, an untyped nil returned from a helper, or a color decoded from external data can all be nil, and the resulting panic takes down the entire game with an unhelpful message and no hint about the cause.

Treat a nil color as a no-op in both functions. This mirrors how `Fill` and `Set` already return early when the image itself is disposed, so a degenerate color now joins the other safe no-op cases instead of crashing.

Add a regression test that passes a nil color to `Fill` and `Set` and asserts the call returns without panicking.
