### PR TITLE
exp/textinput: don't index empty composition buffers on Windows

### DIFF
--- a/exp/textinput/api_windows.go
+++ b/exp/textinput/api_windows.go
@@ -105,8 +105,12 @@ func _ImmAssociateContext(hwnd windows.HWND, hIMC uintptr) (uintptr, error) {
 	return r, nil
 }
 
-func _ImmGetCompositionStringW(unnamedParam1 _HIMC, unnamedParam2 uint32, lpBuf unsafe.Pointer, dwBufLen uint32) (uint32, error) {
-	r, _, e := procImmGetCompositionStringW.Call(uintptr(unnamedParam1), uintptr(unnamedParam2), uintptr(lpBuf), uintptr(dwBufLen))
+func _ImmGetCompositionStringW[T byte | uint16 | uint32](unnamedParam1 _HIMC, unnamedParam2 uint32, lpBuf []T) (uint32, error) {
+	var p unsafe.Pointer
+	if len(lpBuf) > 0 {
+		p = unsafe.Pointer(&lpBuf[0])
+	}
+	r, _, e := procImmGetCompositionStringW.Call(uintptr(unnamedParam1), uintptr(unnamedParam2), uintptr(p), uintptr(len(lpBuf))*unsafe.Sizeof(T(0)))
 	runtime.KeepAlive(lpBuf)
 	if r < 0 {
 		return 0, fmt.Errorf("textinput: ImmGetCompositionStringW failed: %d", r)
@@ -115,6 +119,22 @@ func _ImmGetCompositionStringW(unnamedParam1 _HIMC, unnamedParam2 uint32, lpBuf 
 		return 0, fmt.Errorf("textinput: ImmGetCompositionStringW failed: %w", e)
 	}
 	return uint32(r), nil
+}
+
+func immGetCompositionStringW[T byte | uint16 | uint32](hIMC _HIMC, dwIndex uint32) ([]T, error) {
+	size, err := _ImmGetCompositionStringW[T](hIMC, dwIndex, nil)
+	if err != nil {
+		return nil, err
+	}
+	n := size / uint32(unsafe.Sizeof(T(0)))
+	if n == 0 {
+		return nil, nil
+	}
+	lpBuf := make([]T, n)
+	if _, err := _ImmGetCompositionStringW(hIMC, dwIndex, lpBuf); err != nil {
+		return nil, err
+	}
+	return lpBuf, nil
 }
 
 func _ImmGetContext(unnamedParam1 windows.HWND) _HIMC {

--- a/exp/textinput/textinput_windows.go
+++ b/exp/textinput/textinput_windows.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"image"
 	"sync"
-	"unsafe"
 
 	"golang.org/x/sys/windows"
 
@@ -231,34 +230,21 @@ func (t *textInputImpl) update() (err error) {
 		}
 	}()
 
-	bufferLen, err := _ImmGetCompositionStringW(hIMC, _GCS_COMPSTR, nil, 0)
+	buffer16, err := immGetCompositionStringW[uint16](hIMC, _GCS_COMPSTR)
 	if err != nil {
 		return err
 	}
-	if bufferLen == 0 {
+	if len(buffer16) == 0 {
 		return nil
 	}
 
-	buffer16 := make([]uint16, bufferLen/uint32(unsafe.Sizeof(uint16(0))))
-	if _, err := _ImmGetCompositionStringW(hIMC, _GCS_COMPSTR, unsafe.Pointer(&buffer16[0]), bufferLen); err != nil {
-		return err
-	}
-
-	attrLen, err := _ImmGetCompositionStringW(hIMC, _GCS_COMPATTR, nil, 0)
+	attr, err := immGetCompositionStringW[byte](hIMC, _GCS_COMPATTR)
 	if err != nil {
 		return err
 	}
-	attr := make([]byte, attrLen)
-	if _, err := _ImmGetCompositionStringW(hIMC, _GCS_COMPATTR, unsafe.Pointer(&attr[0]), attrLen); err != nil {
-		return err
-	}
 
-	clauseLen, err := _ImmGetCompositionStringW(hIMC, _GCS_COMPCLAUSE, nil, 0)
+	clause, err := immGetCompositionStringW[uint32](hIMC, _GCS_COMPCLAUSE)
 	if err != nil {
-		return err
-	}
-	clause := make([]uint32, clauseLen/uint32(unsafe.Sizeof(uint32(0))))
-	if _, err := _ImmGetCompositionStringW(hIMC, _GCS_COMPCLAUSE, unsafe.Pointer(&clause[0]), clauseLen); err != nil {
 		return err
 	}
 
@@ -295,17 +281,12 @@ func (t *textInputImpl) commit() (err error) {
 		}
 	}()
 
-	bufferLen, err := _ImmGetCompositionStringW(hIMC, _GCS_RESULTSTR, nil, 0)
+	buffer16, err := immGetCompositionStringW[uint16](hIMC, _GCS_RESULTSTR)
 	if err != nil {
 		return err
 	}
-	if bufferLen == 0 {
+	if len(buffer16) == 0 {
 		return nil
-	}
-
-	buffer16 := make([]uint16, bufferLen/uint32(unsafe.Sizeof(uint16(0))))
-	if _, err := _ImmGetCompositionStringW(hIMC, _GCS_RESULTSTR, unsafe.Pointer(&buffer16[0]), bufferLen); err != nil {
-		return err
 	}
 
 	text := windows.UTF16ToString(buffer16)


### PR DESCRIPTION
ImmGetCompositionStringW reports a zero length for GCS_COMPATTR and GCS_COMPCLAUSE when the IME has no attributes or clauses to describe. Hangul IMEs always do: a composition is a single unsegmented run with nothing to convert. The attribute and clause buffers then come back empty, and taking &attr[0] or &clause[0] to pass them to the second query panics inside the window procedure, killing the process as soon as the first syllable is composed.

Guard both queries so they are skipped when the buffer is empty. The code that follows already handles an empty clause buffer, keeping start16 and end16 at their defaults, so no further change is needed.

Reproducible with examples/textinput and the Microsoft Korean IME.


# What issue is this addressing?
Closes #3539 

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
`ImmGetCompositionStringW` reports a zero length for `GCS_COMPATTR` and `GCS_COMPCLAUSE` when the IME has no attributes or clauses to describe. Hangul IMEs always do: a composition is a single unsegmented run with nothing to convert. The buffers then come back empty, and taking `&attr[0]` / `&clause[0]` to pass them to the second query panics inside the window procedure, killing the process as soon as the first syllable is composed:

```
    panic: runtime error: index out of range [0] with length 0
```

This guards both queries so they are skipped when the buffer is empty. The code that follows already handles an empty clause buffer (keeping `start16`/`end16` at their defaults), so no further change is needed. Non-Korean IMEs report non-empty buffers and take the unchanged path.



Test app:

[hangul-ime-repro.zip](https://github.com/user-attachments/files/31523467/hangul-ime-repro.zip)

Test video:

https://github.com/user-attachments/assets/1809c042-c5e0-4a7d-affc-350d706a9200

