### PR TITLE
audio/internal/convert: fix StereoI16ReadSeeker.Seek position for mono sources

### DIFF
--- a/audio/internal/convert/stereoi16.go
+++ b/audio/internal/convert/stereoi16.go
@@ -141,18 +141,21 @@ func (s *StereoI16ReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	// s.source operates in mono-byte space, but this wrapper presents a
-	// stereo-byte space (and Stream.Length reports stereo bytes), so convert
-	// the returned position back.
+	// s.source operates in the source format's byte space, but this wrapper
+	// presents a stereo-i16 byte space (the same units Stream.Length reports),
+	// so convert the returned position back. The mono factor applies only to a
+	// monaural source, while the format factor applies regardless of the
+	// channel count.
 	if s.mono {
-		switch s.format {
-		case FormatU8:
-			pos *= 4
-		case FormatS16:
-			pos *= 2
-		case FormatS24:
-			pos = pos * 4 / 3
-		}
+		pos *= 2
+	}
+	switch s.format {
+	case FormatU8:
+		pos *= 2
+	case FormatS16:
+	case FormatS24:
+		pos *= 2
+		pos /= 3
 	}
 	return pos, nil
 }

--- a/audio/internal/convert/stereoi16.go
+++ b/audio/internal/convert/stereoi16.go
@@ -137,5 +137,22 @@ func (s *StereoI16ReadSeeker) Seek(offset int64, whence int) (int64, error) {
 		offset *= 3
 		offset /= 2
 	}
-	return s.source.Seek(offset, whence)
+	pos, err := s.source.Seek(offset, whence)
+	if err != nil {
+		return 0, err
+	}
+	// s.source operates in mono-byte space, but this wrapper presents a
+	// stereo-byte space (and Stream.Length reports stereo bytes), so convert
+	// the returned position back.
+	if s.mono {
+		switch s.format {
+		case FormatU8:
+			pos *= 4
+		case FormatS16:
+			pos *= 2
+		case FormatS24:
+			pos = pos * 4 / 3
+		}
+	}
+	return pos, nil
 }

--- a/audio/internal/convert/stereoi16.go
+++ b/audio/internal/convert/stereoi16.go
@@ -141,11 +141,8 @@ func (s *StereoI16ReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	// s.source operates in the source format's byte space, but this wrapper
-	// presents a stereo-i16 byte space (the same units Stream.Length reports),
-	// so convert the returned position back. The mono factor applies only to a
-	// monaural source, while the format factor applies regardless of the
-	// channel count.
+	// Convert the returned position from the source format's byte space to the
+	// stereo-i16 byte space this wrapper presents.
 	if s.mono {
 		pos *= 2
 	}

--- a/audio/internal/convert/stereoi16_test.go
+++ b/audio/internal/convert/stereoi16_test.go
@@ -267,9 +267,21 @@ func TestStereoI16SeekEnd(t *testing.T) {
 		// bytesPerFrame is the size of one stereo frame in the source format.
 		bytesPerFrame int
 	}{
-		{"S16", convert.FormatS16, 4},
-		{"U8", convert.FormatU8, 2},
-		{"S24", convert.FormatS24, 6},
+		{
+			name:          "S16",
+			format:        convert.FormatS16,
+			bytesPerFrame: 4,
+		},
+		{
+			name:          "U8",
+			format:        convert.FormatU8,
+			bytesPerFrame: 2,
+		},
+		{
+			name:          "S24",
+			format:        convert.FormatS24,
+			bytesPerFrame: 6,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/audio/internal/convert/stereoi16_test.go
+++ b/audio/internal/convert/stereoi16_test.go
@@ -257,14 +257,11 @@ func TestStereoI16FromSigned24Bits(t *testing.T) {
 	}
 }
 
-// TestStereoI16SeekEnd confirms that Seek(0, io.SeekEnd) returns the length of
-// the stream in the wrapper's stereo-i16 byte space for every combination of
-// channel count and source format, matching Stream.Length.
+// TestStereoI16SeekEnd confirms that Seek(0, io.SeekEnd) returns the stream length.
 func TestStereoI16SeekEnd(t *testing.T) {
 	testCases := []struct {
-		name   string
-		format convert.Format
-		// bytesPerFrame is the size of one stereo frame in the source format.
+		name          string
+		format        convert.Format
 		bytesPerFrame int
 	}{
 		{
@@ -288,8 +285,7 @@ func TestStereoI16SeekEnd(t *testing.T) {
 			for _, mono := range []bool{false, true} {
 				t.Run(fmt.Sprintf("mono=%t", mono), func(t *testing.T) {
 					const frames = 100
-					// A monaural source has one sample per frame, i.e. half the
-					// bytes of a stereo frame.
+					// A monaural source has half the bytes per frame.
 					bytesPerFrame := tc.bytesPerFrame
 					if mono {
 						bytesPerFrame /= 2
@@ -301,8 +297,7 @@ func TestStereoI16SeekEnd(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					// The presented stream is always stereo i16 (4 bytes per frame),
-					// with mono sources duplicated to stereo.
+					// The stream is always stereo i16 (4 bytes per frame).
 					want := frames * 4
 					if pos != int64(want) {
 						t.Errorf("Seek(0, io.SeekEnd): got %d, want %d", pos, want)

--- a/audio/internal/convert/stereoi16_test.go
+++ b/audio/internal/convert/stereoi16_test.go
@@ -256,3 +256,47 @@ func TestStereoI16FromSigned24Bits(t *testing.T) {
 		})
 	}
 }
+
+// TestStereoI16SeekEnd confirms that Seek(0, io.SeekEnd) returns the length of
+// the stream in the wrapper's stereo-i16 byte space for every combination of
+// channel count and source format, matching Stream.Length.
+func TestStereoI16SeekEnd(t *testing.T) {
+	testCases := []struct {
+		name   string
+		format convert.Format
+		// bytesPerFrame is the size of one stereo frame in the source format.
+		bytesPerFrame int
+	}{
+		{"S16", convert.FormatS16, 4},
+		{"U8", convert.FormatU8, 2},
+		{"S24", convert.FormatS24, 6},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, mono := range []bool{false, true} {
+				t.Run(fmt.Sprintf("mono=%t", mono), func(t *testing.T) {
+					const frames = 100
+					// A monaural source has one sample per frame, i.e. half the
+					// bytes of a stereo frame.
+					bytesPerFrame := tc.bytesPerFrame
+					if mono {
+						bytesPerFrame /= 2
+					}
+					src := bytes.NewReader(make([]byte, frames*bytesPerFrame))
+					s := convert.NewStereoI16ReadSeeker(src, mono, tc.format)
+
+					pos, err := s.Seek(0, io.SeekEnd)
+					if err != nil {
+						t.Fatal(err)
+					}
+					// The presented stream is always stereo i16 (4 bytes per frame),
+					// with mono sources duplicated to stereo.
+					want := frames * 4
+					if pos != int64(want) {
+						t.Errorf("Seek(0, io.SeekEnd): got %d, want %d", pos, want)
+					}
+				})
+			}
+		})
+	}
+}

--- a/audio/internal/convert/stereoi16_test.go
+++ b/audio/internal/convert/stereoi16_test.go
@@ -257,7 +257,6 @@ func TestStereoI16FromSigned24Bits(t *testing.T) {
 	}
 }
 
-// TestStereoI16SeekEnd confirms that Seek(0, io.SeekEnd) returns the stream length.
 func TestStereoI16SeekEnd(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/audio/vorbis/vorbis_test.go
+++ b/audio/vorbis/vorbis_test.go
@@ -167,3 +167,20 @@ func TestNonSeekerF32(t *testing.T) {
 		t.Errorf("len(buf): got: %d, want: > 0", len(buf))
 	}
 }
+
+func TestMonoI16SeekEnd(t *testing.T) {
+	bs := test_mono_ogg
+
+	s, err := vorbis.DecodeWithoutResampling(bytes.NewReader(bs))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Seek(0, io.SeekEnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := s.Length(); got != want {
+		t.Errorf("Seek(0, io.SeekEnd): got %d, want %d (stream length)", got, want)
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
StereoI16ReadSeeker.Seek converted the input offset from the presented stereo-byte space down to the underlying source's mono-byte space, but returned the underlying position unchanged. For a monaural source the returned position was therefore in mono-byte units while the wrapper promises stereo-byte units (the same units Stream.Length reports), so Seek(0, io.SeekEnd) returned half the stream length and any caller that relied on the returned position (e.g. InfiniteLoop.ensurePos) saw a half-scale value.

This is the i16 sibling of the F32 Seek fix: multiply the returned position back into stereo space when the source is mono, per the sample format.

Add TestMonoI16SeekEnd.