### PR TITLE
audio/internal/convert: stop padding trailing silence for unknown-length resampling

### DIFF
--- a/audio/internal/convert/resampling.go
+++ b/audio/internal/convert/resampling.go
@@ -85,6 +85,10 @@ type Resampling struct {
 	// size is the length of the source stream in bytes. 0 indicates the length is unknown.
 	size int64
 
+	// derivedSize is the length of the source stream in bytes, derived when the source reaches its end.
+	// derivedSize is used only when size is 0.
+	derivedSize int64
+
 	from            int
 	to              int
 	bitDepthInBytes int
@@ -118,7 +122,19 @@ func (r *Resampling) bytesPerSample() int {
 }
 
 func (r *Resampling) Length() int64 {
-	s := int64(float64(r.size) * float64(r.to) / float64(r.from))
+	return r.length(r.size)
+}
+
+// sourceSize returns the length of the source stream in bytes, or 0 if the length is unknown.
+func (r *Resampling) sourceSize() int64 {
+	if r.size > 0 {
+		return r.size
+	}
+	return r.derivedSize
+}
+
+func (r *Resampling) length(size int64) int64 {
+	s := int64(float64(size) * float64(r.to) / float64(r.from))
 	return s / int64(r.bytesPerSample()) * int64(r.bytesPerSample())
 }
 
@@ -147,6 +163,10 @@ func (r *Resampling) src(i int64) (float64, float64, error) {
 			c += n
 			if err != nil {
 				if err == io.EOF {
+					// Derive the source length the first time the source reaches its end.
+					if r.eofBufIndex < 0 && r.size == 0 {
+						r.derivedSize = nextPos*resamplingBufferSize*sizePerSample + int64(c)
+					}
 					r.eofBufIndex = nextPos
 					break
 				}
@@ -199,10 +219,13 @@ func (r *Resampling) src(i int64) (float64, float64, error) {
 	}
 	ii := i % resamplingBufferSize
 	var err error
-	if r.eofBufIndex == r.srcBlock && ii >= int64(len(r.srcBufL[r.srcBlock])-1) {
-		err = io.EOF
+	if r.eofBufIndex == r.srcBlock {
+		// The source size remains 0 only when the source is empty.
+		if r.sourceSize() == 0 || ii >= int64(len(r.srcBufL[r.srcBlock])-1) {
+			err = io.EOF
+		}
 	}
-	if r.size > 0 && r.size/sizePerSample <= i {
+	if size := r.sourceSize(); size > 0 && size/sizePerSample <= i {
 		err = io.EOF
 	}
 	return r.srcBufL[r.srcBlock][ii], r.srcBufR[r.srcBlock][ii], err
@@ -262,9 +285,11 @@ func (r *Resampling) Read(b []byte) (int, error) {
 				return 0, err
 			}
 			// EOF from the at method indicates that the source reaches the end, and doesn't indicate the resampled data ends.
-			// Continue the loop even if EOF is returned.
-			if err == io.EOF {
+			// If the length is still unknown at the source's end, the source is empty, and the resampled data ends here.
+			if err == io.EOF && r.sourceSize() == 0 {
+				n = 0
 				r.eof = true
+				break
 			}
 			l16 := int16(ldata * (1<<15 - 1))
 			r16 := int16(rdata * (1<<15 - 1))
@@ -272,9 +297,10 @@ func (r *Resampling) Read(b []byte) (int, error) {
 			b[4*i+1] = byte(l16 >> 8)
 			b[4*i+2] = byte(r16)
 			b[4*i+3] = byte(r16 >> 8)
-			// If the source is an io.Seeker and the length is known, check whether the resampled data ends (#3352).
-			if r.size > 0 && r.pos+int64(size*i) >= r.Length() {
+			// If the length is known, check whether the resampled data ends (#3352).
+			if srcSize := r.sourceSize(); srcSize > 0 && r.pos+int64(size*i) >= r.length(srcSize) {
 				n = size * i
+				r.eof = true
 				break
 			}
 		}
@@ -284,8 +310,10 @@ func (r *Resampling) Read(b []byte) (int, error) {
 			if err != nil && err != io.EOF {
 				return 0, err
 			}
-			if err == io.EOF {
+			if err == io.EOF && r.sourceSize() == 0 {
+				n = 0
 				r.eof = true
+				break
 			}
 			l32 := float32(ldata)
 			r32 := float32(rdata)
@@ -299,8 +327,9 @@ func (r *Resampling) Read(b []byte) (int, error) {
 			b[8*i+5] = byte(r32b >> 8)
 			b[8*i+6] = byte(r32b >> 16)
 			b[8*i+7] = byte(r32b >> 24)
-			if r.size > 0 && r.pos+int64(size*i) >= r.Length() {
+			if srcSize := r.sourceSize(); srcSize > 0 && r.pos+int64(size*i) >= r.length(srcSize) {
 				n = size * i
+				r.eof = true
 				break
 			}
 		}

--- a/audio/internal/convert/resampling_test.go
+++ b/audio/internal/convert/resampling_test.go
@@ -332,3 +332,111 @@ func TestResamplingSeekInvalidWhence(t *testing.T) {
 		}
 	}
 }
+
+func TestResamplingUnknownLengthTrailingSilence(t *testing.T) {
+	testCases := []struct {
+		name string
+		from int
+		to   int
+	}{
+		{
+			name: "1:1",
+			from: 44100,
+			to:   44100,
+		},
+		{
+			name: "upsample",
+			from: 44100,
+			to:   48000,
+		},
+		{
+			name: "downsample",
+			from: 48000,
+			to:   44100,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, bitDepthInBytes := range []int{2, 4} {
+				t.Run(fmt.Sprintf("bitDepthInBytes=%d", bitDepthInBytes), func(t *testing.T) {
+					// 8192 is an exact multiple of the 4096-sample block, 8190 ends within the sinc window of the boundary, and 1 and 3 are not a whole number of samples at bitDepthInBytes 4.
+					for _, size := range []int{1, 3, 100, 8190, 8192, 100000} {
+						t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+							inB := newSoundBytes(size, bitDepthInBytes)
+
+							known := convert.NewResampling(bytes.NewReader(inB), int64(len(inB)), tc.from, tc.to, bitDepthInBytes)
+							knownB, err := io.ReadAll(known)
+							if err != nil {
+								t.Fatal(err)
+							}
+
+							// The unknown length must end the stream at the source's real
+							// end for a seekable source and a non-seekable one alike.
+							for _, seekable := range []bool{true, false} {
+								t.Run(fmt.Sprintf("seekable=%v", seekable), func(t *testing.T) {
+									newSource := func() io.Reader {
+										var src io.Reader = bytes.NewReader(inB)
+										if !seekable {
+											src = &reader{r: src}
+										}
+										return src
+									}
+
+									unknown := convert.NewResampling(newSource(), 0, tc.from, tc.to, bitDepthInBytes)
+									unknownB, err := io.ReadAll(unknown)
+									if err != nil {
+										t.Fatal(err)
+									}
+
+									if !bytes.Equal(unknownB, knownB) {
+										t.Errorf("unknown-length output (%d bytes) is not equal to known-length output (%d bytes)", len(unknownB), len(knownB))
+									}
+
+									unknownWithSmallBuf := convert.NewResampling(newSource(), 0, tc.from, tc.to, bitDepthInBytes)
+									var buf [97]byte
+									var smallB []byte
+									for {
+										n, err := unknownWithSmallBuf.Read(buf[:])
+										smallB = append(smallB, buf[:n]...)
+										if err != nil {
+											if err != io.EOF {
+												t.Fatal(err)
+											}
+											break
+										}
+									}
+									if !bytes.Equal(smallB, knownB) {
+										t.Errorf("unknown-length output with a small read buffer (%d bytes) is not equal to known-length output (%d bytes)", len(smallB), len(knownB))
+									}
+								})
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestResamplingUnknownLengthEmptySource(t *testing.T) {
+	for _, bitDepthInBytes := range []int{2, 4} {
+		t.Run(fmt.Sprintf("bitDepthInBytes=%d", bitDepthInBytes), func(t *testing.T) {
+			for _, seekable := range []bool{true, false} {
+				t.Run(fmt.Sprintf("seekable=%v", seekable), func(t *testing.T) {
+					var src io.Reader = bytes.NewReader(nil)
+					if !seekable {
+						src = &reader{r: src}
+					}
+					r := convert.NewResampling(src, 0, 44100, 48000, bitDepthInBytes)
+					b, err := io.ReadAll(r)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if len(b) != 0 {
+						t.Errorf("got: %d, want: %d", len(b), 0)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None (the previous link to #3545 was unrelated: that issue is about `StereoI16ReadSeeker`/`StereoF32.Seek` returning a position in mono-byte space).

## What _type_ of issue is this addressing?
Bug

## What this PR does | solves
Resampling reads the source in resamplingBufferSize (4096) sample blocks. The final block can be shorter than a full block, but the buffer is always allocated at 4096 samples with the remainder zero-padded. The end-of-stream check compared the sample index against len(buffer)-1 (always 4095), so for an unknown-length source (size == 0) the resampler kept emitting the zero padding as trailing silence up to the block boundary instead of stopping at the source's real end.

When the end of the source is reached, derive its length into an unexported field from the EOF block position and its valid byte count, and terminate the resampled stream with the same length check the known-length path uses. The public Length() keeps returning 0 for an unknown-length source, as before. An empty (or shorter-than-a-sample) unknown-length source now returns (0, io.EOF) instead of trailing silence.

This also fixes a known-length bug: on main, a declared-size source read with a small (97-byte) buffer ended up to 12 bytes short of the same source read with io.ReadAll, because r.eof was set a sinc-window early and the read stopped at whatever buffer boundary came next. Moving r.eof onto the length check removes that buffer-size dependence.

Behavior change: for a source that ends before its declared size (e.g. a truncated WAV), the output is now zero-padded up to Length(), consistently with #3352, which requires the output length to match Length().

Add TestResamplingUnknownLengthTrailingSilence, which asserts that the unknown-length output is byte-identical to the known-length output for io.ReadAll and small reads, across ratios, bit depths, and sources including block-size multiples and sub-sample sources, and TestResamplingUnknownLengthEmptySource for the empty source.