### PR TITLE
audio/vorbis: fix F32 stream Seek position for mono sources

### DIFF
--- a/audio/internal/convert/stereof32.go
+++ b/audio/internal/convert/stereof32.go
@@ -68,5 +68,12 @@ func (s *StereoF32) Seek(offset int64, whence int) (int64, error) {
 	if s.mono {
 		offset /= 2
 	}
-	return s.source.Seek(offset, whence)
+	pos, err := s.source.Seek(offset, whence)
+	if err != nil {
+		return 0, err
+	}
+	if s.mono {
+		pos *= 2
+	}
+	return pos, nil
 }

--- a/audio/internal/convert/stereof32_test.go
+++ b/audio/internal/convert/stereof32_test.go
@@ -105,3 +105,28 @@ func TestStereoF32(t *testing.T) {
 		})
 	}
 }
+
+func TestStereoF32SeekEnd(t *testing.T) {
+	for _, mono := range []bool{false, true} {
+		t.Run(fmt.Sprintf("mono=%t", mono), func(t *testing.T) {
+			const frames = 100
+			// A monaural source has half the bytes per frame.
+			bytesPerFrame := 8
+			if mono {
+				bytesPerFrame /= 2
+			}
+			src := bytes.NewReader(make([]byte, frames*bytesPerFrame))
+			s := convert.NewStereoF32(src, mono)
+
+			pos, err := s.Seek(0, io.SeekEnd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The stream is always stereo f32 (8 bytes per frame).
+			want := frames * 8
+			if pos != int64(want) {
+				t.Errorf("Seek(0, io.SeekEnd): got %d, want %d", pos, want)
+			}
+		})
+	}
+}

--- a/audio/vorbis/vorbis_test.go
+++ b/audio/vorbis/vorbis_test.go
@@ -232,7 +232,7 @@ func TestMonoI16SeekEnd(t *testing.T) {
 	}
 }
 
-func TestMonoF32SeekEnd(t *testing.T) {
+func TestMonoF32Seek(t *testing.T) {
 	bs := test_mono_ogg
 
 	s, err := vorbis.DecodeF32(bytes.NewReader(bs))

--- a/audio/vorbis/vorbis_test.go
+++ b/audio/vorbis/vorbis_test.go
@@ -231,3 +231,47 @@ func TestMonoI16SeekEnd(t *testing.T) {
 		t.Errorf("Seek(0, io.SeekEnd): got %d, want %d (stream length)", got, want)
 	}
 }
+
+func TestMonoF32SeekEnd(t *testing.T) {
+	bs := test_mono_ogg
+
+	s, err := vorbis.DecodeF32(bytes.NewReader(bs))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("SeekEnd", func(t *testing.T) {
+		got, err := s.Seek(0, io.SeekEnd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := s.Length(); got != want {
+			t.Errorf("Seek(0, io.SeekEnd): got %d, want %d (stream length)", got, want)
+		}
+	})
+	t.Run("SeekEndWithNegativeOffset", func(t *testing.T) {
+		got, err := s.Seek(-8, io.SeekEnd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := s.Length() - 8; got != want {
+			t.Errorf("Seek(-8, io.SeekEnd): got %d, want %d", got, want)
+		}
+	})
+	t.Run("SeekStart", func(t *testing.T) {
+		got, err := s.Seek(0, io.SeekStart)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := int64(0); got != want {
+			t.Errorf("Seek(0, io.SeekStart): got %d, want %d", got, want)
+		}
+		got, err = s.Seek(8, io.SeekStart)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := int64(8); got != want {
+			t.Errorf("Seek(8, io.SeekStart): got %d, want %d", got, want)
+		}
+	})
+}


### PR DESCRIPTION
# What issue is this addressing?
#3545 

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
DecodeF32 wraps a mono float32BytesReadSeeker in convert.NewStereoF32 when the source is monaural, so the stream it returns is presented in stereo-byte space (length is samples * channels * 4 * 2).

convert.StereoF32.Seek converted the input offset from stereo to mono space before delegating, but returned the underlying (mono) position unchanged. For a mono source the returned position must be doubled back into stereo space. (The second half of the original bug, float32BytesReadSeeker.Seek adding a sample count instead of a byte count on io.SeekEnd, already landed on main in dfe64228a.)

For a monaural Ogg decoded to F32, Seek(0, io.SeekEnd) used to return 98410 (the raw sample count) instead of the correct 787280 bytes, and a forward Seek(8, io.SeekStart) returned 4 instead of 8.

Add TestMonoF32SeekEnd covering SeekEnd, a negative-offset SeekEnd, and SeekStart (including a forward seek), and TestStereoF32SeekEnd in audio/internal/convert mirroring TestStereoI16SeekEnd so the two sibling wrappers have symmetric coverage.