### PR TITLE
audio: fix an out-of-bounds panic in InfiniteLoop blending with a short after-loop tail

### DIFF
--- a/audio/loop.go
+++ b/audio/loop.go
@@ -136,10 +136,6 @@ func (i *InfiniteLoop) blendRate(pos int64) float32 {
 	p := (pos - i.lstart) / int64(i.bytesPerSample)
 	l := len(i.afterLoop) / i.bytesPerSample
 	if l == 0 {
-		// The after-loop data is shorter than one frame, so there is nothing to
-		// blend with. Return 0 to skip blending: dividing p by l would be a
-		// division by zero and produce NaN, and reading a frame past the end of
-		// afterLoop would be out of bounds.
 		return 0
 	}
 	return 1 - float32(p)/float32(l)

--- a/audio/loop.go
+++ b/audio/loop.go
@@ -135,6 +135,13 @@ func (i *InfiniteLoop) blendRate(pos int64) float32 {
 	}
 	p := (pos - i.lstart) / int64(i.bytesPerSample)
 	l := len(i.afterLoop) / i.bytesPerSample
+	if l == 0 {
+		// The after-loop data is shorter than one frame, so there is nothing to
+		// blend with. Return 0 to skip blending: dividing p by l would be a
+		// division by zero and produce NaN, and reading a frame past the end of
+		// afterLoop would be out of bounds.
+		return 0
+	}
 	return 1 - float32(p)/float32(l)
 }
 

--- a/audio/loop_test.go
+++ b/audio/loop_test.go
@@ -152,9 +152,6 @@ func TestInfiniteLoopWithIntro(t *testing.T) {
 }
 
 func TestInfiniteLoopWithPartialFrameAfterLoop(t *testing.T) {
-	// The after-loop data is shorter than one frame (4 bytes for int16 stereo).
-	// The blend loop used to divide by zero in blendRate and then read past the
-	// end of afterLoop, panicking.
 	src := bytes.NewReader([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9})
 	l := audio.NewInfiniteLoop(src, 8)
 

--- a/audio/loop_test.go
+++ b/audio/loop_test.go
@@ -151,6 +151,22 @@ func TestInfiniteLoopWithIntro(t *testing.T) {
 	}
 }
 
+func TestInfiniteLoopWithPartialFrameAfterLoop(t *testing.T) {
+	// The after-loop data is shorter than one frame (4 bytes for int16 stereo).
+	// The blend loop used to divide by zero in blendRate and then read past the
+	// end of afterLoop, panicking.
+	src := bytes.NewReader([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9})
+	l := audio.NewInfiniteLoop(src, 8)
+
+	buf := make([]byte, 16)
+	if _, err := l.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestInfiniteLoopWithIncompleteSize(t *testing.T) {
 	// s1 should work as if 4092 is given.
 	s1 := audio.NewInfiniteLoop(bytes.NewReader(make([]byte, 4096)), 4095)


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

When the data after the loop end is shorter than one frame, blendRate divided by the frame count of afterLoop, which is zero. The result was NaN, which slipped past the rate == 0 check, and the blend loop then read relpos+1 (int16) or relpos+3 (float32) past the end of afterLoop, panicking.

Return 0 from blendRate when afterLoop is shorter than one frame so that blending is skipped.

Add TestInfiniteLoopWithPartialFrameAfterLoop, which panics without this fix.