### PR TITLE
internal/shader: reject a Kage for-loop whose condition never becomes false

### DIFF
--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -292,3 +292,45 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("Compile must return an error for a huge constant shift, but got nil")
 	}
 }
+
+func TestCompileForLoopTermination(t *testing.T) {
+	testCases := []struct {
+		loop      string
+		wantError bool
+	}{
+		{"i := 0; i < 10; i += 1", false},
+		{"i := 10; i > 0; i -= 1", false},
+		{"i := 0; i != 10; i += 2", false},
+		{"i := 10; i != 0; i -= 2", false},
+		{"i := 10; i < 10; i += 1", false},
+		{"i := 0; i == 0; i += 1", false},
+		{"i := 0; i == 10; i += 1", false},
+		{"i := 0; i < 10; i += 0", true},
+		{"i := 0; i < 10; i -= 1", true},
+		{"i := 0; i <= 0; i -= 1", true},
+		{"i := 0; i > -10; i += 1", true},
+		{"i := 0; i >= 0; i += 1", true},
+		{"i := 0; i != 10; i += 3", true},
+		{"i := 10; i != 0; i -= 3", true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.loop, func(t *testing.T) {
+			src := `package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	x := 0
+	for ` + tc.loop + ` {
+		x += 1
+	}
+	return vec4(1)
+}`
+			_, err := shader.Compile([]byte(src), "Vertex", "Fragment", 0)
+			if tc.wantError && err == nil {
+				t.Errorf("Compile must return an error, but got nil")
+			}
+			if !tc.wantError && err != nil {
+				t.Errorf("Compile must not return an error, but got %v", err)
+			}
+		})
+	}
+}

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -370,7 +370,5 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	}
 	return vec4(1)
 }`
-	// A non-numeric loop variable cannot be analyzed, but this must not panic (Ebiten does not
-	// report the invalid source here yet).
-	shader.Compile([]byte(src), "Vertex", "Fragment", 0)
+	_, _ = shader.Compile([]byte(src), "Vertex", "Fragment", 0)
 }

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -296,31 +296,55 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 func TestCompileForLoopTermination(t *testing.T) {
 	testCases := []struct {
 		loop      string
+		body      string
 		wantError bool
 	}{
-		{"i := 0; i < 10; i += 1", false},
-		{"i := 10; i > 0; i -= 1", false},
-		{"i := 0; i != 10; i += 2", false},
-		{"i := 10; i != 0; i -= 2", false},
-		{"i := 10; i < 10; i += 1", false},
-		{"i := 0; i == 0; i += 1", false},
-		{"i := 0; i == 10; i += 1", false},
-		{"i := 0; i < 10; i += 0", true},
-		{"i := 0; i < 10; i -= 1", true},
-		{"i := 0; i <= 0; i -= 1", true},
-		{"i := 0; i > -10; i += 1", true},
-		{"i := 0; i >= 0; i += 1", true},
-		{"i := 0; i != 10; i += 3", true},
-		{"i := 10; i != 0; i -= 3", true},
+		{"i := 0; i < 10; i += 1", "", false},
+		{"i := 10; i > 0; i -= 1", "", false},
+		{"i := 0; i != 10; i += 2", "", false},
+		{"i := 10; i != 0; i -= 2", "", false},
+		{"i := 10; i < 10; i += 1", "", false},
+		{"i := 0; i == 0; i += 1", "", false},
+		{"i := 0; i == 10; i += 1", "", false},
+		{"i := 0; i < 10; i++", "", false},
+		{"i := 10; i > 0; i--", "", false},
+		{"i := 0.0; i < 10.0; i += 1.0", "", false},
+		{"i := 10.0; i > 0.0; i -= 1.0", "", false},
+		{"i := 0.0; i != 10.0; i += 2.0", "", false},
+		{"i := 0; i < 10; i += 0", "", true},
+		{"i := 0; i < 10; i -= 1", "", true},
+		{"i := 0; i <= 0; i -= 1", "", true},
+		{"i := 0; i > -10; i += 1", "", true},
+		{"i := 0; i >= 0; i += 1", "", true},
+		{"i := 0; i >= 0; i++", "", true},
+		{"i := 10; i <= 10; i--", "", true},
+		{"i := 0; i != 10; i += 3", "", true},
+		{"i := 10; i != 0; i -= 3", "", true},
+		{"i := 0.0; i < 10.0; i += 0.0", "", true},
+		{"i := 0.0; i < 10.0; i -= 1.0", "", true},
+		{"i := 0.5; i < 10.0; i -= 1.0", "", true},
+		{"i := 0.0; i < 10.0; i -= 0.5", "", true},
+		{"i := 0.0; i != 10.0; i -= 1.0", "", true},
+		{"i := 0.0; i != 10.0; i += 3.0", "", true},
+		{"i := 0; i >= 0; i++", "x += 1\n\t\tif x > 3 {\n\t\t\tbreak\n\t\t}", false},
+		{"i := 0; i >= 0; i += 1", "x += 1\n\t\treturn vec4(1)", false},
+		{"i := 0; i < 10; i += 0", "x += 1\n\t\tif x > 3 {\n\t\t\tbreak\n\t\t}", false},
+		{"i := 0; i >= 0; i++", "x += 1\n\t\tfor j := 0; j < 10; j++ {\n\t\t\tbreak\n\t\t}", true},
+		{"i := 0; i >= 0; i += 1", "x += 1\n\t\tfor j := 0; j < 10; j++ {\n\t\t\treturn vec4(1)\n\t\t}", false},
+		{"i := true; i == false; i += true", "", false},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.loop, func(t *testing.T) {
+			body := tc.body
+			if body == "" {
+				body = "x += 1"
+			}
 			src := `package main
 
 func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	x := 0
 	for ` + tc.loop + ` {
-		x += 1
+		` + body + `
 	}
 	return vec4(1)
 }`

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -328,13 +328,14 @@ func TestCompileForLoopTermination(t *testing.T) {
 		{"i := 0.0; i != 10.0; i += 3.0", "", true},
 		{"i := 0; i >= 0; i++", "x += 1\n\t\tif x > 3 {\n\t\t\tbreak\n\t\t}", false},
 		{"i := 0; i >= 0; i += 1", "x += 1\n\t\treturn vec4(1)", false},
+		{"i := 0; i >= 0; i++", "x += 1\n\t\tdiscard()", false},
+		{"i := 0; i >= 0; i += 1", "x += 1\n\t\tfor j := 0; j < 10; j++ {\n\t\t\tdiscard()\n\t\t}", false},
 		{"i := 0; i < 10; i += 0", "x += 1\n\t\tif x > 3 {\n\t\t\tbreak\n\t\t}", false},
 		{"i := 0; i >= 0; i++", "x += 1\n\t\tfor j := 0; j < 10; j++ {\n\t\t\tbreak\n\t\t}", true},
 		{"i := 0; i >= 0; i += 1", "x += 1\n\t\tfor j := 0; j < 10; j++ {\n\t\t\treturn vec4(1)\n\t\t}", false},
-		{"i := true; i == false; i += true", "", false},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.loop, func(t *testing.T) {
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%02d-%s", i, tc.loop), func(t *testing.T) {
 			body := tc.body
 			if body == "" {
 				body = "x += 1"
@@ -357,4 +358,19 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 			}
 		})
 	}
+}
+
+func TestCompileForLoopNonNumericConstant(t *testing.T) {
+	src := `package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	x := 0
+	for i := true; i == false; i += true {
+		x += 1
+	}
+	return vec4(1)
+}`
+	// A non-numeric loop variable cannot be analyzed, but this must not panic (Ebiten does not
+	// report the invalid source here yet).
+	shader.Compile([]byte(src), "Vertex", "Fragment", 0)
 }

--- a/internal/shader/stmt.go
+++ b/internal/shader/stmt.go
@@ -901,14 +901,6 @@ func (cs *compileState) parseFor(block *block, fname string, stmt *ast.ForStmt, 
 		cs.addError(stmt.Pos(), "for-statement's post statement must have one of these operators: +=, -=, ++, --")
 		return nil, false
 	}
-	if gconstant.Sign(delta) == 0 {
-		cs.addError(stmt.Pos(), "for-statement's post statement must change the loop variable, but the delta is 0")
-		return nil, false
-	}
-	if forLoopNeverTerminates(op, init, end, delta) {
-		cs.addError(stmt.Pos(), "for-statement's condition never becomes false")
-		return nil, false
-	}
 
 	b, ok := cs.parseBlock(pseudoBlock, fname, []ast.Stmt{stmt.Body}, inParams, outParams, returnType, true)
 	if !ok {
@@ -917,6 +909,13 @@ func (cs *compileState) parseFor(block *block, fname string, stmt *ast.ForStmt, 
 	bodyir := b.ir
 	for len(bodyir.Stmts) == 1 && bodyir.Stmts[0].Type == shaderir.BlockStmt {
 		bodyir = bodyir.Stmts[0].Blocks[0]
+	}
+
+	// A loop whose condition never becomes false can still end by a break- or a return-statement in
+	// its body.
+	if !blockExitsLoop(bodyir, false) && forLoopConditionAlwaysTrue(op, init, end, delta) {
+		cs.addError(stmt.Pos(), "for-statement's condition never becomes false")
+		return nil, false
 	}
 
 	// As the pseudo block is not actually used, copy the variable part to the actual block.
@@ -944,11 +943,13 @@ func (cs *compileState) parseFor(block *block, fname string, stmt *ast.ForStmt, 
 	}, true
 }
 
-func forLoopNeverTerminates(op shaderir.Op, init, end, delta gconstant.Value) bool {
-	init = gconstant.ToInt(init)
-	end = gconstant.ToInt(end)
-	delta = gconstant.ToInt(delta)
-	if init.Kind() == gconstant.Unknown || end.Kind() == gconstant.Unknown || delta.Kind() == gconstant.Unknown {
+// forLoopConditionAlwaysTrue reports whether the condition of a for-loop never becomes false.
+// The initial value, the end value and the delta are constants, so this can be decided at compile time.
+// The loop can still end by a break- or a return-statement in its body.
+func forLoopConditionAlwaysTrue(op shaderir.Op, init, end, delta gconstant.Value) bool {
+	// A non-numeric constant cannot be analyzed here. Such a constant is invalid, but reporting it is
+	// another issue.
+	if !isNumeric(init) || !isNumeric(end) || !isNumeric(delta) {
 		return false
 	}
 
@@ -978,17 +979,61 @@ func forLoopNeverTerminates(op shaderir.Op, init, end, delta gconstant.Value) bo
 		if d == 0 {
 			return gconstant.Compare(init, token.NEQ, end)
 		}
-		var diff gconstant.Value
+		var diff, step gconstant.Value
 		if d > 0 {
 			diff = gconstant.BinaryOp(end, token.SUB, init)
+			step = delta
 		} else {
 			diff = gconstant.BinaryOp(init, token.SUB, end)
-			delta = gconstant.UnaryOp(token.SUB, delta, 0)
+			step = gconstant.UnaryOp(token.SUB, delta, 0)
 		}
 		if gconstant.Sign(diff) < 0 {
 			return true
 		}
-		return gconstant.Sign(gconstant.BinaryOp(diff, token.REM, delta)) != 0
+		// Whether the loop variable reaches the end value exactly can be decided only with integers.
+		diff = gconstant.ToInt(diff)
+		step = gconstant.ToInt(step)
+		if diff.Kind() == gconstant.Unknown || step.Kind() == gconstant.Unknown {
+			return false
+		}
+		return gconstant.Sign(gconstant.BinaryOp(diff, token.REM, step)) != 0
+	}
+	return false
+}
+
+func isNumeric(v gconstant.Value) bool {
+	switch v.Kind() {
+	case gconstant.Int, gconstant.Float:
+		return true
+	}
+	return false
+}
+
+// blockExitsLoop reports whether the block contains a break- or a return-statement, which exits the
+// enclosing loop even if the loop condition never becomes false.
+// A break-statement in a nested for-loop exits only the nested loop, so it is not counted.
+func blockExitsLoop(block *shaderir.Block, inForLoop bool) bool {
+	for _, s := range block.Stmts {
+		switch s.Type {
+		case shaderir.Break:
+			if !inForLoop {
+				return true
+			}
+		case shaderir.Return:
+			return true
+		case shaderir.For:
+			for _, b := range s.Blocks {
+				if blockExitsLoop(b, true) {
+					return true
+				}
+			}
+		default:
+			for _, b := range s.Blocks {
+				if blockExitsLoop(b, inForLoop) {
+					return true
+				}
+			}
+		}
 	}
 	return false
 }

--- a/internal/shader/stmt.go
+++ b/internal/shader/stmt.go
@@ -911,9 +911,9 @@ func (cs *compileState) parseFor(block *block, fname string, stmt *ast.ForStmt, 
 		bodyir = bodyir.Stmts[0].Blocks[0]
 	}
 
-	// A loop whose condition never becomes false can still end by a break- or a return-statement in
-	// its body.
-	if !blockExitsLoop(bodyir, false) && forLoopConditionAlwaysTrue(op, init, end, delta) {
+	// A loop whose condition never becomes false can still end by a break-, a return- or a
+	// discard-statement in its body.
+	if forLoopConditionAlwaysTrue(op, init, end, delta) && !blockExitsLoop(bodyir, false) {
 		cs.addError(stmt.Pos(), "for-statement's condition never becomes false")
 		return nil, false
 	}
@@ -945,11 +945,11 @@ func (cs *compileState) parseFor(block *block, fname string, stmt *ast.ForStmt, 
 
 // forLoopConditionAlwaysTrue reports whether the condition of a for-loop never becomes false.
 // The initial value, the end value and the delta are constants, so this can be decided at compile time.
-// The loop can still end by a break- or a return-statement in its body.
+// The loop can still end by a break-, a return- or a discard-statement in its body.
 func forLoopConditionAlwaysTrue(op shaderir.Op, init, end, delta gconstant.Value) bool {
 	// A non-numeric constant cannot be analyzed here. Such a constant is invalid, but reporting it is
 	// another issue.
-	if !isNumeric(init) || !isNumeric(end) || !isNumeric(delta) {
+	if !isNumericConstant(init) || !isNumericConstant(end) || !isNumericConstant(delta) {
 		return false
 	}
 
@@ -1001,7 +1001,7 @@ func forLoopConditionAlwaysTrue(op shaderir.Op, init, end, delta gconstant.Value
 	return false
 }
 
-func isNumeric(v gconstant.Value) bool {
+func isNumericConstant(v gconstant.Value) bool {
 	switch v.Kind() {
 	case gconstant.Int, gconstant.Float:
 		return true
@@ -1009,8 +1009,8 @@ func isNumeric(v gconstant.Value) bool {
 	return false
 }
 
-// blockExitsLoop reports whether the block contains a break- or a return-statement, which exits the
-// enclosing loop even if the loop condition never becomes false.
+// blockExitsLoop reports whether the block contains a break-, a return- or a discard-statement, which
+// exits the enclosing loop even if the loop condition never becomes false.
 // A break-statement in a nested for-loop exits only the nested loop, so it is not counted.
 func blockExitsLoop(block *shaderir.Block, inForLoop bool) bool {
 	for _, s := range block.Stmts {
@@ -1019,7 +1019,7 @@ func blockExitsLoop(block *shaderir.Block, inForLoop bool) bool {
 			if !inForLoop {
 				return true
 			}
-		case shaderir.Return:
+		case shaderir.Return, shaderir.Discard:
 			return true
 		case shaderir.For:
 			for _, b := range s.Blocks {

--- a/internal/shader/stmt.go
+++ b/internal/shader/stmt.go
@@ -901,6 +901,14 @@ func (cs *compileState) parseFor(block *block, fname string, stmt *ast.ForStmt, 
 		cs.addError(stmt.Pos(), "for-statement's post statement must have one of these operators: +=, -=, ++, --")
 		return nil, false
 	}
+	if gconstant.Sign(delta) == 0 {
+		cs.addError(stmt.Pos(), "for-statement's post statement must change the loop variable, but the delta is 0")
+		return nil, false
+	}
+	if forLoopNeverTerminates(op, init, end, delta) {
+		cs.addError(stmt.Pos(), "for-statement's condition never becomes false")
+		return nil, false
+	}
 
 	b, ok := cs.parseBlock(pseudoBlock, fname, []ast.Stmt{stmt.Body}, inParams, outParams, returnType, true)
 	if !ok {
@@ -934,6 +942,55 @@ func (cs *compileState) parseFor(block *block, fname string, stmt *ast.ForStmt, 
 			ForDelta:    delta,
 		},
 	}, true
+}
+
+func forLoopNeverTerminates(op shaderir.Op, init, end, delta gconstant.Value) bool {
+	init = gconstant.ToInt(init)
+	end = gconstant.ToInt(end)
+	delta = gconstant.ToInt(delta)
+	if init.Kind() == gconstant.Unknown || end.Kind() == gconstant.Unknown || delta.Kind() == gconstant.Unknown {
+		return false
+	}
+
+	d := gconstant.Sign(delta)
+	switch op {
+	case shaderir.LessThanOp, shaderir.LessThanEqualOp:
+		if d > 0 {
+			return false
+		}
+		tok := token.LSS
+		if op == shaderir.LessThanEqualOp {
+			tok = token.LEQ
+		}
+		return gconstant.Compare(init, tok, end)
+	case shaderir.GreaterThanOp, shaderir.GreaterThanEqualOp:
+		if d < 0 {
+			return false
+		}
+		tok := token.GTR
+		if op == shaderir.GreaterThanEqualOp {
+			tok = token.GEQ
+		}
+		return gconstant.Compare(init, tok, end)
+	case shaderir.EqualOp:
+		return d == 0 && gconstant.Compare(init, token.EQL, end)
+	case shaderir.NotEqualOp:
+		if d == 0 {
+			return gconstant.Compare(init, token.NEQ, end)
+		}
+		var diff gconstant.Value
+		if d > 0 {
+			diff = gconstant.BinaryOp(end, token.SUB, init)
+		} else {
+			diff = gconstant.BinaryOp(init, token.SUB, end)
+			delta = gconstant.UnaryOp(token.SUB, delta, 0)
+		}
+		if gconstant.Sign(diff) < 0 {
+			return true
+		}
+		return gconstant.Sign(gconstant.BinaryOp(diff, token.REM, delta)) != 0
+	}
+	return false
 }
 
 // parseRangeVar returns the name and the position of an iteration variable of a range-statement.


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Whether a Kage for-loop condition can ever become false is decidable at compile time: the loop variable's initial value, the end value and the post statement's delta are all constants. A loop like `for i := 0; i < 10; i += 0 {}` or `for i := 0; i >= 0; i++ {}` whose condition never becomes false would hang the GPU (or be rejected by the driver, far from the mistake), so reject it at compile time — unless the loop body can exit the loop.

- `forLoopConditionAlwaysTrue` decides, from the init value, the end value, the delta and the comparison operator, whether the condition can never become false. A zero delta (`i += 0`) is not a special case but one case of this analysis: `for i := 10; i < 10; i += 0 {}` never runs and is still valid.
- The analysis runs on the original constants and uses go/constant's exact rational arithmetic, so float loop variables are treated like integers. Non-numeric constants (e.g. a bool, a pre-existing type-check hole) skip the analysis instead of crashing the compiler.
- The check runs after the body is parsed and is skipped when the body contains a `break` exiting this loop, a `return` or a `discard()` (all backends return from the fragment function after a discard). A `break` in a nested for-loop exits only the nested loop and is not counted. Loop-until-`break` sources like `for i := 0; i >= 0; i++ { … break }` keep compiling; `for { }` is not expressible in Kage, so this is the only way to write such a loop.

`TestCompileForLoopTermination` covers integer and float loop variables, `+=` / `-=` / `++` / `--`, conditions that are false at init, and bodies with `break`, `return` or `discard()` including inside nested loops. `TestCompileForLoopNonNumericConstant` only requires that a non-numeric loop variable does not panic the compiler.

No shader in the repository or the examples is affected. Sources like `for i := 0; i >= 0; i++ {}` without a loop-exiting body stop compiling; they were never valid Kage and may deserve a release note.
