### PR TITLE
internal/shader: reject a constant shift count that is too large

### DIFF
--- a/internal/shader/expr.go
+++ b/internal/shader/expr.go
@@ -34,6 +34,11 @@ func canTruncateToFloat(v gconstant.Value) bool {
 	return gconstant.ToFloat(v).Kind() != gconstant.Unknown
 }
 
+// maxConstShift is the maximum constant shift count accepted by the compiler.
+// Folding a constant with a shift count larger than this would allocate a
+// huge number (e.g. 1<<(1<<40) needs 2^40 bits) and exhaust memory.
+const maxConstShift = 1 << 16
+
 var textureVariableRe = regexp.MustCompile(`\A__t(\d+)\z`)
 
 func (cs *compileState) parseExpr(block *block, fname string, expr ast.Expr, markLocalVariableUsed bool) ([]shaderir.Expr, []shaderir.Type, []shaderir.Stmt, bool) {
@@ -165,6 +170,10 @@ func (cs *compileState) parseExpr(block *block, fname string, expr ast.Expr, mar
 				}
 				if shift < 0 {
 					cs.addError(e.Pos(), fmt.Sprintf("negative shift count: %s", rhs[0].Const.String()))
+					return nil, nil, nil, false
+				}
+				if shift > maxConstShift {
+					cs.addError(e.Pos(), fmt.Sprintf("shift count too large: %s", rhs[0].Const.String()))
 					return nil, nil, nil, false
 				}
 				v = gconstant.Shift(lhs[0].Const, op, uint(shift))

--- a/internal/shader/expr.go
+++ b/internal/shader/expr.go
@@ -34,9 +34,8 @@ func canTruncateToFloat(v gconstant.Value) bool {
 	return gconstant.ToFloat(v).Kind() != gconstant.Unknown
 }
 
-// maxConstShift is the maximum constant shift count accepted by the compiler.
-// Folding a constant with a shift count larger than this would allocate a
-// huge number (e.g. 1<<(1<<40) needs 2^40 bits) and exhaust memory.
+// maxConstShift bounds constant shifts so that folding cannot allocate an
+// enormous number (e.g. 1<<(1<<40)) and exhaust memory.
 const maxConstShift = 1 << 16
 
 var textureVariableRe = regexp.MustCompile(`\A__t(\d+)\z`)

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -230,3 +230,18 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 		t.Errorf("HLSL PSMain should not use the '%%' operator for integer modulo, but got:\n%s", body)
 	}
 }
+
+// TestCompileHugeShift confirms that a constant shift with an enormous shift
+// count reports an error instead of exhausting memory.
+func TestCompileHugeShift(t *testing.T) {
+	src := `package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	x := 1 << (1 << 40)
+	return vec4(x)
+}`
+	_, err := shader.Compile([]byte(src), "Vertex", "Fragment", 0)
+	if err == nil {
+		t.Errorf("Compile must return an error for a huge constant shift, but got nil")
+	}
+}

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -231,8 +231,7 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 	}
 }
 
-// TestCompileHugeShift confirms that a constant shift with an enormous shift
-// count reports an error instead of exhausting memory.
+// TestCompileHugeShift confirms that an enormous constant shift is rejected.
 func TestCompileHugeShift(t *testing.T) {
 	src := `package main
 

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -231,7 +231,6 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 	}
 }
 
-// TestCompileHugeShift confirms that an enormous constant shift is rejected.
 func TestCompileHugeShift(t *testing.T) {
 	src := `package main
 


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Folding a constant shift like 1<<(1<<40) passes a shift count of 2^40 to go/constant.Shift, which allocates a number of that many bits and exhausts memory, hanging or crashing the compiler. A constant shift by more than 1<<16 bits is meaningless for any shader integer type, so report an error for such counts instead of folding them.

Add TestCompileHugeShift, which hangs without this fix.

