### PR TITLE
internal/shader: point varying-signature errors at the entry point instead of line 1

### DIFF
--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -50,9 +50,6 @@ type compileState struct {
 	vertexEntry   string
 	fragmentEntry string
 
-	// vertexEntryPos and fragmentEntryPos are the positions of the vertex and
-	// fragment entry-point functions, used to report errors about their
-	// signatures at the function they belong to.
 	vertexEntryPos   token.Pos
 	fragmentEntryPos token.Pos
 

--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -50,6 +50,12 @@ type compileState struct {
 	vertexEntry   string
 	fragmentEntry string
 
+	// vertexEntryPos and fragmentEntryPos are the positions of the vertex and
+	// fragment entry-point functions, used to report errors about their
+	// signatures at the function they belong to.
+	vertexEntryPos   token.Pos
+	fragmentEntryPos token.Pos
+
 	ir shaderir.Program
 
 	funcs []function
@@ -268,11 +274,13 @@ func (cs *compileState) parse(f *ast.File) {
 		inParams, outParams, ret := cs.parseFuncParams(&cs.global, n, fd)
 
 		if n == cs.vertexEntry {
+			cs.vertexEntryPos = d.Pos()
 			vertexInParams = inParams
 			vertexOutParams = outParams
 			continue
 		}
 		if n == cs.fragmentEntry {
+			cs.fragmentEntryPos = d.Pos()
 			fragmentInParams = inParams
 			fragmentOutParams = outParams
 			fragmentReturnType = ret
@@ -308,19 +316,19 @@ func (cs *compileState) parse(f *ast.File) {
 			t := fragmentInParams[i].typ
 			if !p.typ.Equal(&t) {
 				name := fragmentInParams[i].name
-				cs.addError(0, fmt.Sprintf("fragment argument %s must be %s but was %s", name, p.typ.String(), t.String()))
+				cs.addError(cs.fragmentEntryPos, fmt.Sprintf("fragment argument %s must be %s but was %s", name, p.typ.String(), t.String()))
 			}
 		}
 		if len(fragmentInParams) > len(vertexOutParams) {
-			cs.addError(0, fmt.Sprintf("the number of the fragment arguments (%d) must not be greater than the number of the vertex returning values (%d)", len(fragmentInParams), len(vertexOutParams)))
+			cs.addError(cs.fragmentEntryPos, fmt.Sprintf("the number of the fragment arguments (%d) must not be greater than the number of the vertex returning values (%d)", len(fragmentInParams), len(vertexOutParams)))
 		}
 
 		// The first out-param is treated as gl_Position in GLSL.
 		if vertexOutParams[0].typ.Main != shaderir.Vec4 {
-			cs.addError(0, "vertex entry point must have at least one returning vec4 value for a position")
+			cs.addError(cs.vertexEntryPos, "vertex entry point must have at least one returning vec4 value for a position")
 		}
 		if len(fragmentOutParams) != 0 || fragmentReturnType.Main != shaderir.Vec4 {
-			cs.addError(0, "fragment entry point must have one returning vec4 value for a color")
+			cs.addError(cs.fragmentEntryPos, "fragment entry point must have one returning vec4 value for a color")
 		}
 	}
 

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -231,9 +231,8 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 	}
 }
 
-// TestCompileVaryingTypeMismatchPosition confirms that an error about a
-// mismatched fragment argument points at the fragment entry point, not at
-// line 1.
+// TestCompileVaryingTypeMismatchPosition confirms that the error position
+// points at the fragment entry point, not at line 1.
 func TestCompileVaryingTypeMismatchPosition(t *testing.T) {
 	src := `package main
 

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -231,8 +231,6 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 	}
 }
 
-// TestCompileVaryingTypeMismatchPosition confirms that the error position
-// points at the fragment entry point, not at line 1.
 func TestCompileVaryingTypeMismatchPosition(t *testing.T) {
 	src := `package main
 

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -230,3 +230,28 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 		t.Errorf("HLSL PSMain should not use the '%%' operator for integer modulo, but got:\n%s", body)
 	}
 }
+
+// TestCompileVaryingTypeMismatchPosition confirms that an error about a
+// mismatched fragment argument points at the fragment entry point, not at
+// line 1.
+func TestCompileVaryingTypeMismatchPosition(t *testing.T) {
+	src := `package main
+
+func Vertex(position vec4, texCoord vec2, color vec4) (vec4, vec2) {
+	return position, texCoord
+}
+
+func Fragment(position vec4, texCoord vec3, color vec4) vec4 {
+	return vec4(1)
+}`
+	_, err := shader.Compile([]byte(src), "Vertex", "Fragment", 0)
+	if err == nil {
+		t.Fatalf("Compile must return an error for a mismatched fragment argument, but got nil")
+	}
+	if strings.HasPrefix(err.Error(), "1:1:") {
+		t.Errorf("the error position must point at the fragment entry point, but got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "7:") {
+		t.Errorf("the error position must be around the fragment entry point (line 7), but got %q", err.Error())
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

The errors about a mismatched fragment argument, too many fragment arguments, and the entry-point return types used addError(0, ...), so every message was reported at 1:1 regardless of the actual code. Record the positions of the vertex and fragment entry points and report these errors at the function they belong to.
