### PR TITLE
internal/shader: report an error instead of panicking on an assignment from a no-return function

### DIFF
--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -564,6 +564,10 @@ func (s *compileState) parseVariable(block *block, fname string, vs *ast.ValueSp
 				if len(ts) > 1 {
 					s.addError(vs.Pos(), "the numbers of lhs and rhs don't match")
 				}
+				if len(ts) == 0 {
+					s.addError(vs.Pos(), "the right-hand side of the variable declaration has no value")
+					return nil, nil, nil, false
+				}
 				t = ts[0]
 				if t.Main == shaderir.None {
 					t = toDefaultType(es[0].Const)

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -200,6 +200,37 @@ func TestCompile(t *testing.T) {
 	}
 }
 
+// TestCompileAssignFromNoReturnValue confirms that assigning the result of a
+// function that returns nothing reports an error instead of panicking (#B1).
+func TestCompileAssignFromNoReturnValue(t *testing.T) {
+	srcs := []string{
+		`package main
+
+func bar() {
+}
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	x := bar()
+	return vec4(1)
+}`,
+		`package main
+
+func bar() {
+}
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	var x = bar()
+	return vec4(1)
+}`,
+	}
+	for _, src := range srcs {
+		_, err := shader.Compile([]byte(src), "Vertex", "Fragment", 0)
+		if err == nil {
+			t.Errorf("Compile must return an error for a function call with no return values, but got nil")
+		}
+	}
+}
+
 // TestCompileHLSLIntModulo confirms that integer modulo is emitted via the modInt
 // helper rather than the '%' operator.
 func TestCompileHLSLIntModulo(t *testing.T) {

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -200,8 +200,6 @@ func TestCompile(t *testing.T) {
 	}
 }
 
-// TestCompileAssignFromNoReturnValue confirms that assigning the result of a
-// function that returns nothing reports an error instead of panicking.
 func TestCompileAssignFromNoReturnValue(t *testing.T) {
 	srcs := []string{
 		`package main
@@ -231,8 +229,6 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	}
 }
 
-// TestCompileHLSLIntModulo confirms that integer modulo is emitted via the modInt
-// helper rather than the '%' operator.
 func TestCompileHLSLIntModulo(t *testing.T) {
 	src := []byte(`//kage:unit pixels
 

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -201,7 +201,7 @@ func TestCompile(t *testing.T) {
 }
 
 // TestCompileAssignFromNoReturnValue confirms that assigning the result of a
-// function that returns nothing reports an error instead of panicking (#B1).
+// function that returns nothing reports an error instead of panicking.
 func TestCompileAssignFromNoReturnValue(t *testing.T) {
 	srcs := []string{
 		`package main

--- a/internal/shader/stmt.go
+++ b/internal/shader/stmt.go
@@ -539,6 +539,10 @@ func (cs *compileState) assign(block *block, fname string, pos token.Pos, lhs, r
 					cs.addError(pos, "single-value context and multiple-value context cannot be mixed")
 					return nil, false
 				}
+				if len(ts) == 0 {
+					cs.addError(pos, "the right-hand side of := has no value")
+					return nil, false
+				}
 				t := ts[0]
 				if t.Main == shaderir.None {
 					t = toDefaultType(r[0].Const)


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Assigning or declaring a variable from a call to a function that returns nothing, like 'x := bar()' or 'var x = bar()', read ts[0] of the function's empty return-type list and panicked with an index out of range. The compiler must reject the misuse with an error instead.
    
Check for an empty return-type list in both the assignment (stmt.go) and the variable declaration (shader.go) paths, mirroring the existing single/multiple-value count checks.
