### PR TITLE
audio: clear the partial-frame remainder on InfiniteLoop.Seek

### DIFF
--- a/audio/loop.go
+++ b/audio/loop.go
@@ -262,7 +262,7 @@ func (i *InfiniteLoop) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekStart:
 		next = offset
 	case io.SeekCurrent:
-		next = i.pos + offset
+		next = i.pos - int64(len(i.extra)) + offset
 	case io.SeekEnd:
 		return 0, fmt.Errorf("audio: whence must be io.SeekStart or io.SeekCurrent for InfiniteLoop")
 	}
@@ -278,5 +278,6 @@ func (i *InfiniteLoop) Seek(offset int64, whence int) (int64, error) {
 		return 0, err
 	}
 	i.pos = next
+	i.extra = i.extra[:0]
 	return i.pos, nil
 }

--- a/audio/loop_test.go
+++ b/audio/loop_test.go
@@ -433,3 +433,65 @@ func TestInfiniteLoopBlendWithPartialFrameReads(t *testing.T) {
 		})
 	}
 }
+
+func TestInfiniteLoopSeekClearsExtra(t *testing.T) {
+	// The source returns 5 bytes at most, which is larger than any bit depth but not a multiple of
+	// any, so a read returns a complete value and leaves a remainder.
+	src := &partialFrameReader{
+		src:  bytes.NewReader(bytes.Repeat([]byte{1, 2, 3, 4, 5, 6, 7, 8}, 3)),
+		size: 5,
+	}
+	l := audio.NewInfiniteLoopF32(src, 8)
+
+	buf := make([]byte, 32)
+	if _, err := l.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := l.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	n, err := l.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{1, 2, 3, 4}
+	if !bytes.Equal(buf[:n], want) {
+		t.Errorf("got: %v, want: %v", buf[:n], want)
+	}
+}
+
+func TestInfiniteLoopSeekCurrentAfterPartialFrameRead(t *testing.T) {
+	// The source returns 5 bytes at most, which is larger than any bit depth but not a multiple of
+	// any, so a read returns a complete value and leaves a remainder.
+	src := &partialFrameReader{
+		src:  bytes.NewReader([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+		size: 5,
+	}
+	l := audio.NewInfiniteLoopF32(src, 8)
+
+	buf := make([]byte, 32)
+	// This read leaves a one-byte remainder in the internal buffer, so the source position is ahead of
+	// the logical position by 1.
+	if _, err := l.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seek with io.SeekCurrent must be relative to the logical position, so this must be a no-op.
+	pos, err := l.Seek(0, io.SeekCurrent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int64(4); pos != want {
+		t.Errorf("got: %d, want: %d", pos, want)
+	}
+
+	n, err := l.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{5, 6, 7, 8}
+	if !bytes.Equal(buf[:n], want) {
+		t.Errorf("got: %v, want: %v", buf[:n], want)
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
InfiniteLoop.Read keeps the remainder of a source read that is not a
multiple of the bit depth in the extra buffer and prepends it to the next
read. Seek moved the source position but did not clear extra, so a seek
left the remainder from the old position to be prepended to the data read
from the new position, corrupting the stream.

Clear extra in Seek. Add TestInfiniteLoopSeekClearsExtra, which observes
the stale bytes without this fix.
