### PR TITLE
text/v2: fix data races in concurrent glyph realization

### DIFF
--- a/text/v2/gotext.go
+++ b/text/v2/gotext.go
@@ -15,10 +15,10 @@
 package text
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"image"
+	"math"
 	"slices"
 
 	"github.com/go-text/typesetting/di"
@@ -208,12 +208,12 @@ func encodeVariations(variations []font.Variation) string {
 	if len(variations) == 0 {
 		return ""
 	}
-	var buf bytes.Buffer
+	buf := make([]byte, 0, 8*len(variations))
 	for _, t := range variations {
-		_ = binary.Write(&buf, binary.LittleEndian, t.Tag)
-		_ = binary.Write(&buf, binary.LittleEndian, t.Value)
+		buf = binary.LittleEndian.AppendUint32(buf, uint32(t.Tag))
+		buf = binary.LittleEndian.AppendUint32(buf, math.Float32bits(t.Value))
 	}
-	return buf.String()
+	return string(buf)
 }
 
 // encodeFeatures returns a binary string encoding of features
@@ -222,12 +222,12 @@ func encodeFeatures(features []shaping.FontFeature) string {
 	if len(features) == 0 {
 		return ""
 	}
-	var buf bytes.Buffer
+	buf := make([]byte, 0, 8*len(features))
 	for _, t := range features {
-		_ = binary.Write(&buf, binary.LittleEndian, t.Tag)
-		_ = binary.Write(&buf, binary.LittleEndian, t.Value)
+		buf = binary.LittleEndian.AppendUint32(buf, uint32(t.Tag))
+		buf = binary.LittleEndian.AppendUint32(buf, t.Value)
 	}
-	return buf.String()
+	return string(buf)
 }
 
 func (g *GoTextFace) outputCacheKey(text string) goTextOutputCacheKey {

--- a/text/v2/gotext.go
+++ b/text/v2/gotext.go
@@ -41,6 +41,10 @@ var _ Face = (*GoTextFace)(nil)
 // Unlike GoXFace, one GoTextFace instance doesn't have its own glyph image cache.
 // Instead, a GoTextFaceSource has a glyph image cache.
 // You can casually create multiple GoTextFace instances from the same GoTextFaceSource.
+//
+// Mutating a GoTextFace, including assigning to its fields, while the same face
+// is used for drawing in another goroutine is not allowed.
+// Mutate a face before drawing with it, or use another face.
 type GoTextFace struct {
 	// Source is the font face source.
 	Source *GoTextFaceSource
@@ -87,7 +91,7 @@ func (g *GoTextFace) SetVariation(tag Tag, value float32) {
 			return
 		}
 		g.variations[i].Value = value
-		g.variationsString = ""
+		g.variationsString = encodeVariations(g.variations)
 		return
 	}
 
@@ -98,7 +102,7 @@ func (g *GoTextFace) SetVariation(tag Tag, value float32) {
 		Tag:   font.Tag(tag),
 		Value: value,
 	}
-	g.variationsString = ""
+	g.variationsString = encodeVariations(g.variations)
 }
 
 // RemoveVariation removes a variation value.
@@ -113,7 +117,7 @@ func (g *GoTextFace) RemoveVariation(tag Tag) {
 
 		copy(g.variations[i:], g.variations[i+1:])
 		g.variations = g.variations[:len(g.variations)-1]
-		g.variationsString = ""
+		g.variationsString = encodeVariations(g.variations)
 		return
 	}
 }
@@ -134,7 +138,7 @@ func (g *GoTextFace) SetFeature(tag Tag, value uint32) {
 			return
 		}
 		g.features[i].Value = value
-		g.featuresString = ""
+		g.featuresString = encodeFeatures(g.features)
 		return
 	}
 
@@ -145,7 +149,7 @@ func (g *GoTextFace) SetFeature(tag Tag, value uint32) {
 		Tag:   font.Tag(tag),
 		Value: value,
 	}
-	g.featuresString = ""
+	g.featuresString = encodeFeatures(g.features)
 }
 
 // RemoveFeature removes a feature value.
@@ -160,7 +164,7 @@ func (g *GoTextFace) RemoveFeature(tag Tag) {
 
 		copy(g.features[i:], g.features[i+1:])
 		g.features = g.features[:len(g.features)-1]
-		g.featuresString = ""
+		g.featuresString = encodeFeatures(g.features)
 		return
 	}
 }
@@ -197,14 +201,6 @@ func (g *GoTextFace) Metrics() Metrics {
 	return g.Source.metrics(g.Size)
 }
 
-func (g *GoTextFace) ensureVariationsString() string {
-	if g.variationsString != "" {
-		return g.variationsString
-	}
-	g.variationsString = encodeVariations(g.variations)
-	return g.variationsString
-}
-
 // encodeVariations returns a binary string encoding of variations
 // suitable for use as a cache key. It is the canonical form referenced
 // by glyphDataCacheKey and glyphRenderDataCacheKey.
@@ -220,20 +216,18 @@ func encodeVariations(variations []font.Variation) string {
 	return buf.String()
 }
 
-func (g *GoTextFace) ensureFeaturesString() string {
-	if g.featuresString != "" {
-		return g.featuresString
-	}
-	if len(g.features) == 0 {
+// encodeFeatures returns a binary string encoding of features
+// suitable for use as a cache key.
+func encodeFeatures(features []shaping.FontFeature) string {
+	if len(features) == 0 {
 		return ""
 	}
 	var buf bytes.Buffer
-	for _, t := range g.features {
+	for _, t := range features {
 		_ = binary.Write(&buf, binary.LittleEndian, t.Tag)
 		_ = binary.Write(&buf, binary.LittleEndian, t.Value)
 	}
-	g.featuresString = buf.String()
-	return g.featuresString
+	return buf.String()
 }
 
 func (g *GoTextFace) outputCacheKey(text string) goTextOutputCacheKey {
@@ -243,8 +237,8 @@ func (g *GoTextFace) outputCacheKey(text string) goTextOutputCacheKey {
 		size:       g.Size,
 		language:   g.Language,
 		script:     g.Script,
-		variations: g.ensureVariationsString(),
-		features:   g.ensureFeaturesString(),
+		variations: g.variationsString,
+		features:   g.featuresString,
 	}
 }
 
@@ -396,7 +390,7 @@ func (im *goTextLineImager) glyphImage(index int) *ebiten.Image {
 		gid:        glyph.shapingGlyph.GlyphID,
 		xoffset:    args.subpixelOffset.X,
 		yoffset:    args.subpixelOffset.Y,
-		variations: face.ensureVariationsString(),
+		variations: face.variationsString,
 	}
 	subpixelOffset := args.subpixelOffset
 	return face.Source.getOrCreateGlyphImage(face, key, func() (*ebiten.Image, bool) {

--- a/text/v2/gotextfacesource.go
+++ b/text/v2/gotextfacesource.go
@@ -701,7 +701,7 @@ type faceBitmapState struct {
 //
 // The caller must hold g.shapeMu.
 func (g *GoTextFaceSource) applyFaceState(face *GoTextFace) faceBitmapState {
-	if s := face.ensureVariationsString(); s != g.lastVariationsString {
+	if s := face.variationsString; s != g.lastVariationsString {
 		g.f.SetVariations(face.variations)
 		g.lastVariationsString = s
 	}
@@ -869,7 +869,7 @@ func (g *GoTextFaceSource) buildGlyphs(outputs []shaping.Output, text string, fa
 	}
 	indices = append(indices, len(text))
 
-	variations := face.ensureVariationsString()
+	variations := face.variationsString
 
 	// Snapshot the variations slice once; every glyphRenderData built
 	// in this call shares the same underlying copy. The user-facing

--- a/text/v2/gotextfacesource_test.go
+++ b/text/v2/gotextfacesource_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package text_test
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"golang.org/x/image/font/gofont/goregular"
+
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
+)
+
+func TestGlyphImageCacheConcurrent(t *testing.T) {
+	src, err := text.NewGoTextFaceSource(bytes.NewReader(goregular.TTF))
+	if err != nil {
+		t.Fatal(err)
+	}
+	face := &text.GoTextFace{Source: src, Size: 16}
+	glyphs := text.AppendLazyGlyphs(nil, "Hello, 世界!", face, nil)
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			for _, gl := range glyphs {
+				// A space or a control character has no image.
+				if gl.ImageBounds.Empty() {
+					continue
+				}
+				if gl.Image() == nil {
+					t.Error("Image() returned nil for a glyph which should have an image")
+				}
+			}
+		})
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
`Draw`, `AppendGlyphs`, `AppendLazyGlyphs`, `Measure` and `CacheGlyphs` are documented as concurrent-safe, but `ensureVariationsString` and `ensureFeaturesString` computed the face's cache strings lazily and wrote them back, so two goroutines realizing glyphs from the same `GoTextFace` raced on the write. The variations case fired for *every* face, not only faces with variations, since the empty result was written back on every call.

Encode the cache strings eagerly in the four setters, which are the only writers of `variations` and `features`, and read the fields directly at the call sites. The readers become plain field reads, so no lock is needed and `GoTextFace` stays copyable, which a mutex field in the exported struct would have broken. Document that a face must not be mutated while it is used for drawing.

Add `TestGlyphImageCacheConcurrent`, which reports a data race with `-race` without this fix.

(The `glyphImageCache` half of the original race was fixed separately in main by e3e564bb1, so it is no longer part of this PR.)
