### PR TITLE
audio: fix an int64 overflow when converting a duration and a position

### DIFF
--- a/audio/audio_test.go
+++ b/audio/audio_test.go
@@ -239,6 +239,27 @@ func TestSetPositionBeforeDeviceCreation(t *testing.T) {
 	}
 }
 
+func TestSetPositionLongDuration(t *testing.T) {
+	setup()
+	defer teardown()
+
+	p, err := context.NewPlayerF32(bytes.NewReader(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 10 milliseconds is exactly 441 samples at 44100 Hz, so the position
+	// round-trips exactly while exercising both the whole-seconds and the
+	// remainder terms of the conversion.
+	const duration = 8*time.Hour + 10*time.Millisecond
+	if err := p.SetPosition(duration); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := p.Position(), duration; got != want {
+		t.Errorf("Position(): got: %v, want: %v", got, want)
+	}
+}
+
 // Issue #3438
 func TestRewindNonSeekableBeforeDeviceCreation(t *testing.T) {
 	setup()

--- a/audio/player.go
+++ b/audio/player.go
@@ -566,7 +566,13 @@ func (p *playerImpl) updatePosition() {
 	}
 
 	// Update the adjusted position every tick. This is necessary to keep the position accurate.
-	p.adjustedPosition = int64(time.Duration(samples)*time.Second/time.Duration(p.factory.sampleRate) + adjustingTime)
+	p.adjustedPosition = mulDiv(samples, int64(time.Second), int64(p.factory.sampleRate)) + int64(adjustingTime)
+}
+
+// mulDiv returns x * mul / div, avoiding the overflow of the intermediate x * mul.
+// mul * div must fit in int64.
+func mulDiv(x, mul, div int64) int64 {
+	return x/div*mul + x%div*mul/div
 }
 
 type timeStream struct {
@@ -631,7 +637,8 @@ func (s *timeStream) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (s *timeStream) timeDurationToPos(offset time.Duration) int64 {
-	o := int64(offset) * int64(s.bytesPerSample) * int64(s.sampleRate) / int64(time.Second)
+	bytesPerSecond := int64(s.bytesPerSample) * int64(s.sampleRate)
+	o := mulDiv(int64(offset), bytesPerSecond, int64(time.Second))
 
 	// Align the byte position with the samples.
 	o -= o % int64(s.bytesPerSample)
@@ -645,5 +652,6 @@ func (s *timeStream) position() int64 {
 }
 
 func (s *timeStream) positionInTimeDuration() time.Duration {
-	return time.Duration(s.pos.Load()) * time.Second / (time.Duration(s.sampleRate * s.bytesPerSample))
+	bytesPerSecond := int64(s.sampleRate) * int64(s.bytesPerSample)
+	return time.Duration(mulDiv(s.pos.Load(), int64(time.Second), bytesPerSecond))
 }


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

Three duration/position conversions in audio multiplied before dividing, which overflowed int64:

- `timeDurationToPos`: `offset * bytesPerSample * sampleRate` overflowed above about 7.3 hours of duration for 32bit float stereo at 44.1 kHz (about 14.5 hours for 16bit stereo).
- `positionInTimeDuration`: `pos * time.Second` overflowed above about 9.2 GB of stream position, i.e. about 6.5 hours of 32bit float stereo at 44.1 kHz, so a long-running app with an `audio.InfiniteLoop` BGM hits it even without any `SetPosition` call.
- `updatePosition`: `samples * time.Second` overflowed above about 9.22e9 samples (about 58 hours at 44.1 kHz).

All three now share a single unexported `mulDiv` helper, which splits the multiplication so that it cannot overflow int64. The result is bit-identical to the previous expressions wherever the exact result fits in int64.

`SetBufferSize` has the same multiplication shape but needs a buffer longer than about 7 hours to overflow, so it is left as is.
