### PR TITLE
audio/wav: avoid allocating a buffer for a huge chunk size

### DIFF
--- a/audio/wav/decode.go
+++ b/audio/wav/decode.go
@@ -176,19 +176,19 @@ chunks:
 			if size < 16 {
 				return nil, fmt.Errorf("wav: invalid header: maybe non-PCM file?")
 			}
-			buf := make([]byte, size)
-			n, err := io.ReadFull(src, buf)
-			if n != len(buf) {
+			var fmtBuf [16]byte
+			n, err := io.ReadFull(src, fmtBuf[:])
+			if n != len(fmtBuf) {
 				return nil, fmt.Errorf("wav: invalid header")
 			}
 			if err != nil {
 				return nil, err
 			}
-			format := int(buf[0]) | int(buf[1])<<8
+			format := int(fmtBuf[0]) | int(fmtBuf[1])<<8
 			if format != 1 {
 				return nil, fmt.Errorf("wav: format must be linear PCM")
 			}
-			channelCount := int(buf[2]) | int(buf[3])<<8
+			channelCount := int(fmtBuf[2]) | int(fmtBuf[3])<<8
 			switch channelCount {
 			case 1:
 				mono = true
@@ -197,24 +197,22 @@ chunks:
 			default:
 				return nil, fmt.Errorf("wav: number of channels must be 1 or 2 but was %d", channelCount)
 			}
-			bitsPerSample = int(buf[14]) | int(buf[15])<<8
+			bitsPerSample = int(fmtBuf[14]) | int(fmtBuf[15])<<8
 			// TODO: Support signed 24bit integer format (#2215).
 			if bitsPerSample != 8 && bitsPerSample != 16 {
 				return nil, fmt.Errorf("wav: bits per sample must be 8 or 16 but was %d", bitsPerSample)
 			}
-			sampleRate = int(buf[4]) | int(buf[5])<<8 | int(buf[6])<<16 | int(buf[7])<<24
+			sampleRate = int(fmtBuf[4]) | int(fmtBuf[5])<<8 | int(fmtBuf[6])<<16 | int(fmtBuf[7])<<24
+			if _, err := io.CopyN(io.Discard, src, size-16); err != nil {
+				return nil, fmt.Errorf("wav: invalid header")
+			}
 			headerSize += size
 		case bytes.Equal(buf[0:4], []byte("data")):
 			dataSize = size
 			break chunks
 		default:
-			buf := make([]byte, size)
-			n, err := io.ReadFull(src, buf)
-			if n != len(buf) {
+			if _, err := io.CopyN(io.Discard, src, size); err != nil {
 				return nil, fmt.Errorf("wav: invalid header")
-			}
-			if err != nil {
-				return nil, err
 			}
 			headerSize += size
 		}

--- a/audio/wav/decode_test.go
+++ b/audio/wav/decode_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wav_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2/audio/wav"
+)
+
+func TestDecodeInvalidHugeChunkSize(t *testing.T) {
+	buf := []byte("RIFF")
+	buf = binary.LittleEndian.AppendUint32(buf, 0)
+	buf = append(buf, "WAVE"...)
+	buf = append(buf, "fmt "...)
+	buf = binary.LittleEndian.AppendUint32(buf, 0x7fffffff)
+	buf = binary.LittleEndian.AppendUint16(buf, 1)
+	buf = binary.LittleEndian.AppendUint16(buf, 1)
+	buf = binary.LittleEndian.AppendUint32(buf, 8000)
+	buf = binary.LittleEndian.AppendUint32(buf, 8000)
+	buf = binary.LittleEndian.AppendUint16(buf, 1)
+	buf = binary.LittleEndian.AppendUint16(buf, 16)
+
+	if _, err := wav.DecodeWithoutResampling(bytes.NewReader(buf)); err == nil {
+		t.Errorf("DecodeWithoutResampling: got no error, want an error")
+	}
+}
+
+func TestDecodeInvalidHugeUnknownChunkSize(t *testing.T) {
+	buf := []byte("RIFF")
+	buf = binary.LittleEndian.AppendUint32(buf, 0)
+	buf = append(buf, "WAVE"...)
+	buf = append(buf, "JUNK"...)
+	buf = binary.LittleEndian.AppendUint32(buf, 0x7fffffff)
+	buf = append(buf, 0, 0)
+
+	if _, err := wav.DecodeWithoutResampling(bytes.NewReader(buf)); err == nil {
+		t.Errorf("DecodeWithoutResampling: got no error, want an error")
+	}
+}
+
+// TestDecodeFmtChunkLargerThan16 tests a 'fmt ' chunk larger than 16 bytes.
+func TestDecodeFmtChunkLargerThan16(t *testing.T) {
+	data := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	buf := []byte("RIFF")
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(data)+38))
+	buf = append(buf, "WAVE"...)
+	buf = append(buf, "fmt "...)
+	buf = binary.LittleEndian.AppendUint32(buf, 18)
+	buf = binary.LittleEndian.AppendUint16(buf, 1)
+	buf = binary.LittleEndian.AppendUint16(buf, 2)
+	buf = binary.LittleEndian.AppendUint32(buf, 8000)
+	buf = binary.LittleEndian.AppendUint32(buf, 32000)
+	buf = binary.LittleEndian.AppendUint16(buf, 4)
+	buf = binary.LittleEndian.AppendUint16(buf, 16)
+	buf = binary.LittleEndian.AppendUint16(buf, 0)
+	buf = append(buf, "data"...)
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(data)))
+	buf = append(buf, data...)
+
+	s, err := wav.DecodeWithoutResampling(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := s.Length(), int64(len(data)); got != want {
+		t.Errorf("Length(): got: %d, want: %d", got, want)
+	}
+	if _, err := s.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("data: got: %v, want: %v", got, data)
+	}
+}
+
+func TestDecodeValid(t *testing.T) {
+	data := make([]byte, 8000)
+	buf := []byte("RIFF")
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(data)+36))
+	buf = append(buf, "WAVE"...)
+	buf = append(buf, "fmt "...)
+	buf = binary.LittleEndian.AppendUint32(buf, 16)
+	buf = binary.LittleEndian.AppendUint16(buf, 1)
+	buf = binary.LittleEndian.AppendUint16(buf, 1)
+	buf = binary.LittleEndian.AppendUint32(buf, 8000)
+	buf = binary.LittleEndian.AppendUint32(buf, 8000)
+	buf = binary.LittleEndian.AppendUint16(buf, 1)
+	buf = binary.LittleEndian.AppendUint16(buf, 16)
+	buf = append(buf, "data"...)
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(data)))
+	buf = append(buf, data...)
+
+	s, err := wav.DecodeWithoutResampling(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := s.Length(), int64(len(data))*2; got != want {
+		t.Errorf("Length(): got: %d, want: %d", got, want)
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

The chunk size in a WAV header is unvalidated, and decode allocated a buffer of that size, so a corrupt file could exhaust memory. Read the fmt chunk's first 16 bytes into a fixed buffer and skip the rest with io.CopyN instead of allocating.
