### PR TITLE
text/v2: guard runeToBoolMap with a mutex

### DIFF
--- a/text/v2/gotextfacesource.go
+++ b/text/v2/gotextfacesource.go
@@ -108,10 +108,13 @@ type goTextGlyphImageCacheKey struct {
 
 // runeToBoolMap is a map from rune to bool with performance optimizations.
 type runeToBoolMap struct {
-	m []uint64
+	m  []uint64
+	mu sync.Mutex
 }
 
 func (r *runeToBoolMap) get(rune rune) (value bool, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	index := rune / 32
 	if len(r.m) <= int(index) {
 		return false, false
@@ -122,6 +125,8 @@ func (r *runeToBoolMap) get(rune rune) (value bool, ok bool) {
 }
 
 func (r *runeToBoolMap) set(rune rune, value bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	index := rune / 32
 	if len(r.m) <= int(index) {
 		r.m = slices.Grow(r.m, int(index)+1)[:index+1]

--- a/text/v2/text_test.go
+++ b/text/v2/text_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/go-text/typesetting/bidi"
@@ -521,6 +522,27 @@ func TestRuneToBoolMap(t *testing.T) {
 			t.Fatalf("rune: %c, got: %v, %v; want: %v, %v", r, gotVal, gotOK, v != 0, true)
 		}
 	}
+}
+
+func TestRuneToBoolMapConcurrent(t *testing.T) {
+	var rtb text.RuneToBoolMap
+	const goroutines = 16
+	const perGoroutine = 64
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Go(func() {
+			for i := range perGoroutine {
+				// The rune ranges of the goroutines overlap.
+				r := rune(g*perGoroutine/2 + i)
+				v := r%2 == 0
+				rtb.Set(r, v)
+				if gotVal, gotOK := rtb.Get(r); !gotOK || gotVal != v {
+					t.Errorf("rune %d: got: %v, %v; want: %v, true", r, gotVal, gotOK, v)
+				}
+			}
+		})
+	}
+	wg.Wait()
 }
 
 // Issue #3284


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves

GoTextFaceSource.hasGlyph reads and writes runeToBoolMap without a lock.
hasGlyph is called concurrently from Draw and AppendLazyGlyphs,
which are documented as concurrent-safe.
runeToBoolMap.set can reallocate the backing slice with slices.Grow,
so concurrent get/set raced on the slice contents and the length check.

Add a mutex to runeToBoolMap. Add TestRuneToBoolMapConcurrent,
which reports data races with -race without this fix.
