### PR TITLE
ebiten: document ReadPixels panic on disposed images

### DIFF
--- a/image.go
+++ b/image.go
@@ -1243,7 +1243,7 @@ func (i *Image) ColorModel() color.Model {
 //
 // ReadPixels loads pixels from GPU to system memory if necessary, which means that ReadPixels can be slow.
 //
-// ReadPixels always sets a transparent color if the image is disposed.
+// ReadPixels panics if the image is disposed.
 //
 // len(pixels) must be 4 * (bounds width) * (bounds height).
 // If len(pixels) is not correct, ReadPixels panics.
@@ -1255,16 +1255,9 @@ func (i *Image) ColorModel() color.Model {
 //
 // ReadPixels can't be called outside the main loop (ebiten.Run's updating function) starts.
 func (i *Image) ReadPixels(pixels []byte) {
-	b := i.bounds
+	b := i.Bounds()
 	if got, want := len(pixels), 4*b.Dx()*b.Dy(); got != want {
 		panic(fmt.Sprintf("ebiten: len(pixels) must be %d but %d at ReadPixels", want, got))
-	}
-
-	if i.isDisposed() {
-		for i := range pixels {
-			pixels[i] = 0
-		}
-		return
 	}
 
 	i.invokeUsageCallbacks()

--- a/image.go
+++ b/image.go
@@ -1255,7 +1255,7 @@ func (i *Image) ColorModel() color.Model {
 //
 // ReadPixels can't be called outside the main loop (ebiten.Run's updating function) starts.
 func (i *Image) ReadPixels(pixels []byte) {
-	b := i.Bounds()
+	b := i.bounds
 	if got, want := len(pixels), 4*b.Dx()*b.Dy(); got != want {
 		panic(fmt.Sprintf("ebiten: len(pixels) must be %d but %d at ReadPixels", want, got))
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -333,33 +333,15 @@ func TestImageDispose(t *testing.T) {
 }
 
 func TestImageReadPixelsDispose(t *testing.T) {
-	img := ebiten.NewImageWithOptions(image.Rect(-1, -2, 2, 2), nil)
-	img.Fill(color.White)
-
-	pix := make([]byte, 4*3*4)
-	img.ReadPixels(pix)
-	for i, got := range pix {
-		if got != 0xff {
-			t.Errorf("pix[%d] before Dispose: got %d, want %d", i, got, 0xff)
-		}
-	}
-
+	img := ebiten.NewImage(16, 16)
 	img.Dispose()
-	img.ReadPixels(pix)
-	for i, got := range pix {
-		if got != 0 {
-			t.Errorf("pix[%d] after Dispose: got %d, want %d", i, got, 0)
-		}
-	}
 
-	t.Run("InvalidLength", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("ReadPixels with an invalid length must panic")
-			}
-		}()
-		img.ReadPixels(pix[:len(pix)-1])
-	})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("ReadPixels on a disposed image must panic")
+		}
+	}()
+	img.ReadPixels(make([]byte, 4*16*16))
 }
 
 func TestImageDeallocate(t *testing.T) {

--- a/image_test.go
+++ b/image_test.go
@@ -332,6 +332,36 @@ func TestImageDispose(t *testing.T) {
 	}
 }
 
+func TestImageReadPixelsDispose(t *testing.T) {
+	img := ebiten.NewImageWithOptions(image.Rect(-1, -2, 2, 2), nil)
+	img.Fill(color.White)
+
+	pix := make([]byte, 4*3*4)
+	img.ReadPixels(pix)
+	for i, got := range pix {
+		if got != 0xff {
+			t.Errorf("pix[%d] before Dispose: got %d, want %d", i, got, 0xff)
+		}
+	}
+
+	img.Dispose()
+	img.ReadPixels(pix)
+	for i, got := range pix {
+		if got != 0 {
+			t.Errorf("pix[%d] after Dispose: got %d, want %d", i, got, 0)
+		}
+	}
+
+	t.Run("InvalidLength", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("ReadPixels with an invalid length must panic")
+			}
+		}()
+		img.ReadPixels(pix[:len(pix)-1])
+	})
+}
+
 func TestImageDeallocate(t *testing.T) {
 	img := ebiten.NewImage(16, 16)
 	img.Fill(color.White)


### PR DESCRIPTION
# What issue is this addressing?
Closes #3556

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
`ReadPixels` now documents its existing panic for disposed images and removes the unreachable transparent-fill branch. This keeps the API from treating a disposed image as if it still had bounds.

The regression test asserts that `ReadPixels` panics after `Dispose`.

Tests:
- `go test -run '^TestImageReadPixelsDispose$' .`
- `go test .`
- `go vet .`