### PR TITLE
internal/gamepaddb: reject a GUID not exactly 16 bytes in the Android default mappings

### DIFF
--- a/internal/gamepaddb/android_mappings_test.go
+++ b/internal/gamepaddb/android_mappings_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gamepaddb
+
+import "testing"
+
+// TestAndroidDefaultMappingsShortID confirms that a shorter-than-16-byte id is rejected.
+func TestAndroidDefaultMappingsShortID(t *testing.T) {
+	if addAndroidDefaultMappings("030000004c05000068020000") {
+		t.Errorf("a shorter-than-16-byte id must not be mapped")
+	}
+}

--- a/internal/gamepaddb/android_mappings_test.go
+++ b/internal/gamepaddb/android_mappings_test.go
@@ -16,9 +16,27 @@ package gamepaddb
 
 import "testing"
 
-// TestAndroidDefaultMappingsShortID confirms that a shorter-than-16-byte id is rejected.
-func TestAndroidDefaultMappingsShortID(t *testing.T) {
-	if addAndroidDefaultMappings("030000004c05000068020000") {
-		t.Errorf("a shorter-than-16-byte id must not be mapped")
+// TestAndroidDefaultMappingsIDLength confirms that an id whose decoded length is not 16 bytes is rejected.
+func TestAndroidDefaultMappingsIDLength(t *testing.T) {
+	cases := []struct {
+		Name string
+		ID   string
+	}{
+		{
+			Name: "ShorterThan16Bytes",
+			// 12 bytes
+			ID: "030000004c05000068020000",
+		},
+		{
+			Name: "LongerThan16Bytes",
+			// 17 bytes with a valid button mask
+			ID: "030000004c050000680200000f00000000",
+		},
+	}
+
+	for _, c := range cases {
+		if addAndroidDefaultMappings(c.ID) {
+			t.Errorf("%s: an id whose decoded length is not 16 bytes must not be mapped", c.Name)
+		}
 	}
 }

--- a/internal/gamepaddb/gamepaddb.go
+++ b/internal/gamepaddb/gamepaddb.go
@@ -556,6 +556,9 @@ func addAndroidDefaultMappings(id string) bool {
 	if err != nil {
 		return false
 	}
+	if len(idBytes) < 16 {
+		return false
+	}
 	buttonMask := uint16(idBytes[12]) | (uint16(idBytes[13]) << 8)
 	axisMask := uint16(idBytes[14]) | (uint16(idBytes[15]) << 8)
 	if buttonMask == 0 && axisMask == 0 {

--- a/internal/gamepaddb/gamepaddb.go
+++ b/internal/gamepaddb/gamepaddb.go
@@ -97,6 +97,11 @@ func parseLine(line string, platform platform) (id string, name string, buttons 
 		return "", "", nil, nil, fmt.Errorf("gamepaddb: syntax error")
 	}
 
+	// An id must be a hex-encoded GUID, which is exactly 16 bytes, on any platform.
+	if idBytes, err := hex.DecodeString(tokens[0]); err != nil || len(idBytes) != 16 {
+		return "", "", nil, nil, nil
+	}
+
 	for _, token := range tokens[2:] {
 		if len(token) == 0 {
 			continue

--- a/internal/gamepaddb/gamepaddb.go
+++ b/internal/gamepaddb/gamepaddb.go
@@ -556,7 +556,7 @@ func addAndroidDefaultMappings(id string) bool {
 	if err != nil {
 		return false
 	}
-	if len(idBytes) < 16 {
+	if len(idBytes) != 16 {
 		return false
 	}
 	buttonMask := uint16(idBytes[12]) | (uint16(idBytes[13]) << 8)

--- a/internal/gamepaddb/id_test.go
+++ b/internal/gamepaddb/id_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gamepaddb
+
+import "testing"
+
+// TestParseLineIDLength confirms that a line whose id is not a hex-encoded 16-byte GUID
+// is ignored on any platform.
+func TestParseLineIDLength(t *testing.T) {
+	const valid = "030000004c0500006802000000007200"
+
+	cases := []struct {
+		Name   string
+		Line   string
+		WantID string
+	}{
+		{
+			Name:   "Valid",
+			Line:   valid + ",DualShock 4,a:b0,",
+			WantID: valid,
+		},
+		{
+			Name: "ShorterThan16Bytes",
+			Line: "030000004c05000068020000,DualShock 4,a:b0,",
+		},
+		{
+			Name: "LongerThan16Bytes",
+			Line: valid + "00,DualShock 4,a:b0,",
+		},
+		{
+			Name: "NotHex",
+			Line: "xinput,XInput Controller,a:b0,",
+		},
+	}
+
+	for _, c := range cases {
+		for _, p := range []platform{platformWindows, platformDarwin, platformUnix, platformAndroid} {
+			id, _, _, _, err := parseLine(c.Line, p)
+			if err != nil {
+				t.Errorf("%s/%v: parseLine returned an unexpected error: %v", c.Name, p, err)
+				continue
+			}
+			if id != c.WantID {
+				t.Errorf("%s/%v: got id %q, want %q", c.Name, p, id, c.WantID)
+			}
+		}
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
addAndroidDefaultMappings decodes the id with hex.DecodeString and reads bytes 12..15 of the result without checking its length. A shorter id that still decodes (e.g. 12 bytes) panicked with an index out of range.

Check that the decoded id is at least 16 bytes and reject it otherwise.

Add TestAndroidDefaultMappingsShortID, which panics without this fix.
