### PR TITLE
audio: reject a loop length shorter than one frame in InfiniteLoop

### DIFF
--- a/audio/loop.go
+++ b/audio/loop.go
@@ -100,10 +100,15 @@ func NewInfiniteLoopWithIntroF32(src io.ReadSeeker, introLength int64, loopLengt
 
 func newInfiniteLoopWithIntro(src io.ReadSeeker, introLength int64, loopLength int64, bitDepthInBytes int) *InfiniteLoop {
 	bytesPerSample := bitDepthInBytes * channelCount
+	lstart := introLength / int64(bytesPerSample) * int64(bytesPerSample)
+	llength := loopLength / int64(bytesPerSample) * int64(bytesPerSample)
+	if llength <= 0 {
+		panic(fmt.Sprintf("audio: loop length must be a positive multiple of %d bytes but was %d", bytesPerSample, loopLength))
+	}
 	return &InfiniteLoop{
 		src:             src,
-		lstart:          introLength / int64(bytesPerSample) * int64(bytesPerSample),
-		llength:         loopLength / int64(bytesPerSample) * int64(bytesPerSample),
+		lstart:          lstart,
+		llength:         llength,
 		pos:             -1,
 		bitDepthInBytes: bitDepthInBytes,
 		bytesPerSample:  bytesPerSample,

--- a/audio/loop_test.go
+++ b/audio/loop_test.go
@@ -495,3 +495,23 @@ func TestInfiniteLoopSeekCurrentAfterPartialFrameRead(t *testing.T) {
 		t.Errorf("got: %v, want: %v", buf[:n], want)
 	}
 }
+
+func TestInfiniteLoopZeroLoopLength(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		introLength int64
+		loopLength  int64
+	}{
+		{"ShortLoop", 8, 3},
+		{"ZeroLoop", 8, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected a panic for a zero loop length, but got none")
+				}
+			}()
+			audio.NewInfiniteLoopWithIntro(bytes.NewReader(make([]byte, 64)), tc.introLength, tc.loopLength)
+		})
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
InfiniteLoopWithIntro aligns introLength and loopLength down to frame boundaries, so a loopLength shorter than one frame (e.g. 3 bytes for 16-bit stereo) became llength == 0 with no error. With such a stream, Seek wrapped positions with a modulo by zero and panicked, and Read consumed the intro and then returned (0, nil) forever, violating the io.Reader contract.

Panic at construction time with a descriptive message instead, which removes both downstream failure modes. Add TestInfiniteLoopZeroLoopLength.