### PR TITLE
audio: reject a negative seek result

### DIFF
--- a/audio/internal/convert/resampling.go
+++ b/audio/internal/convert/resampling.go
@@ -319,23 +319,25 @@ func (r *Resampling) Seek(offset int64, whence int) (int64, error) {
 		return 0, fmt.Errorf("convert: source must be io.Seeker: %w", errors.ErrUnsupported)
 	}
 
+	pos := r.pos
 	switch whence {
 	case io.SeekStart:
-		r.pos = offset
+		pos = offset
 	case io.SeekCurrent:
-		r.pos += offset
+		pos += offset
 	case io.SeekEnd:
 		if r.size <= 0 {
 			return 0, fmt.Errorf("convert: seeking from the end is not possible when the length is unknown: %w", errors.ErrUnsupported)
 		}
-		r.pos = r.Length() + offset
+		pos = r.Length() + offset
 	default:
 		return 0, fmt.Errorf("convert: whence must be io.SeekStart, io.SeekCurrent, or io.SeekEnd but was %d", whence)
 	}
-	r.eof = false
-	if r.pos < 0 {
-		r.pos = 0
+	if pos < 0 {
+		return 0, fmt.Errorf("convert: position must be >= 0 but was %d", pos)
 	}
+	r.eof = false
+	r.pos = pos
 	// The position can be clamped by the length only when the length is known.
 	if r.size > 0 && r.Length() <= r.pos {
 		r.pos = r.Length()

--- a/audio/internal/convert/resampling_test.go
+++ b/audio/internal/convert/resampling_test.go
@@ -166,6 +166,68 @@ func TestResampling(t *testing.T) {
 	}
 }
 
+func TestResamplingSeekNegative(t *testing.T) {
+	for _, bitDepthInBytes := range []int{2, 4} {
+		t.Run(fmt.Sprintf("bitDepthInBytes=%d", bitDepthInBytes), func(t *testing.T) {
+			inB := newSoundBytes(44100, bitDepthInBytes)
+			r := convert.NewResampling(bytes.NewReader(inB), int64(len(inB)), 44100, 48000, bitDepthInBytes)
+
+			if _, err := r.Seek(-1, io.SeekStart); err == nil {
+				t.Error("Seek(-1, io.SeekStart): expected an error but got none")
+			}
+			if _, err := r.Seek(0, io.SeekStart); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := r.Seek(-1, io.SeekCurrent); err == nil {
+				t.Error("Seek(-1, io.SeekCurrent): expected an error but got none")
+			}
+
+			// io.SeekEnd must be relative to the end, not to the current position.
+			if _, err := r.Seek(0, io.SeekStart); err != nil {
+				t.Fatal(err)
+			}
+			fromStart, err := r.Seek(-1000, io.SeekEnd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := r.Seek(4000, io.SeekStart); err != nil {
+				t.Fatal(err)
+			}
+			fromMiddle, err := r.Seek(-1000, io.SeekEnd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if fromStart != fromMiddle {
+				t.Errorf("Seek(-1000, io.SeekEnd) must not depend on the current position: from 0: %d, from 4000: %d", fromStart, fromMiddle)
+			}
+
+			// A negative result from io.SeekEnd must be rejected even from a non-zero position.
+			if _, err := r.Seek(4000, io.SeekStart); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := r.Seek(-r.Length()-1, io.SeekEnd); err == nil {
+				t.Error("Seek(-Length()-1, io.SeekEnd): expected an error but got none")
+			}
+
+			// The stream must not be broken by the failed seeks.
+			pos, err := r.Seek(0, io.SeekStart)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := pos, int64(0); got != want {
+				t.Errorf("Seek(0, io.SeekStart): got: %d, want: %d", got, want)
+			}
+			n, err := r.Read(make([]byte, 64))
+			if err != nil {
+				t.Fatalf("Read after Seek(0): %v", err)
+			}
+			if got, want := n, 64; got != want {
+				t.Errorf("Read: got: %d, want: %d", got, want)
+			}
+		})
+	}
+}
+
 // Issue #3352
 func TestResamplingLen(t *testing.T) {
 	buf := make([]byte, 8*48000)

--- a/audio/vorbis/float32.go
+++ b/audio/vorbis/float32.go
@@ -84,6 +84,9 @@ func (r *float32BytesReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	default:
 		return 0, fmt.Errorf("vorbis: whence must be io.SeekStart, io.SeekCurrent, or io.SeekEnd but was %d", whence)
 	}
+	if offset < 0 {
+		return 0, fmt.Errorf("vorbis: position must be >= 0 but was %d", offset)
+	}
 	r.pos = offset
 	if err := r.r.SetPosition(r.pos / sampleSize); err != nil {
 		return 0, err

--- a/audio/vorbis/float32.go
+++ b/audio/vorbis/float32.go
@@ -73,7 +73,6 @@ func (r *float32BytesReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	}
 
 	sampleSize := int64(r.r.Channels()) * 4
-	offset = offset / sampleSize * sampleSize
 
 	switch whence {
 	case io.SeekStart:
@@ -87,9 +86,10 @@ func (r *float32BytesReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	if offset < 0 {
 		return 0, fmt.Errorf("vorbis: position must be >= 0 but was %d", offset)
 	}
-	r.pos = offset
-	if err := r.r.SetPosition(r.pos / sampleSize); err != nil {
+	pos := offset / sampleSize * sampleSize
+	if err := r.r.SetPosition(pos / sampleSize); err != nil {
 		return 0, err
 	}
+	r.pos = pos
 	return r.pos, nil
 }

--- a/audio/vorbis/vorbis.go
+++ b/audio/vorbis/vorbis.go
@@ -150,12 +150,13 @@ func (s *i16Stream) Seek(offset int64, whence int) (int64, error) {
 		return 0, fmt.Errorf("vorbis: position must be >= 0 but was %d", next)
 	}
 	sampleSize := int64(s.vorbisReader.Channels()) * bitDepthInBytesInt16
-	s.posInBytes = next / sampleSize * sampleSize
-	if err := s.vorbisReader.SetPosition(next / sampleSize); err != nil {
+	pos := next / sampleSize * sampleSize
+	if err := s.vorbisReader.SetPosition(pos / sampleSize); err != nil {
 		return 0, err
 	}
+	s.posInBytes = pos
 	s.i16Reader = nil
-	return next, nil
+	return s.posInBytes, nil
 }
 
 func (s *i16Stream) totalBytes() int64 {

--- a/audio/vorbis/vorbis.go
+++ b/audio/vorbis/vorbis.go
@@ -146,6 +146,9 @@ func (s *i16Stream) Seek(offset int64, whence int) (int64, error) {
 	default:
 		return 0, fmt.Errorf("vorbis: whence must be io.SeekStart, io.SeekCurrent, or io.SeekEnd but was %d", whence)
 	}
+	if next < 0 {
+		return 0, fmt.Errorf("vorbis: position must be >= 0 but was %d", next)
+	}
 	sampleSize := int64(s.vorbisReader.Channels()) * bitDepthInBytesInt16
 	s.posInBytes = next / sampleSize * sampleSize
 	if err := s.vorbisReader.SetPosition(next / sampleSize); err != nil {

--- a/audio/vorbis/vorbis_test.go
+++ b/audio/vorbis/vorbis_test.go
@@ -408,3 +408,23 @@ func TestStereoI16SeekUnalignedPosition(t *testing.T) {
 		t.Errorf("Read: got: %d, want: %d", got, want)
 	}
 }
+
+func TestStereoF32SeekUnalignedNegativeOffset(t *testing.T) {
+	bs := test_stereo_ogg
+
+	s, err := vorbis.DecodeF32(bytes.NewReader(bs))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A negative offset from io.SeekEnd must be aligned toward the start,
+	// as well as the int16 stream does.
+	got, err := s.Seek(-5, io.SeekEnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const sampleSize = 2 * 4
+	if want := (s.Length() - 5) / sampleSize * sampleSize; got != want {
+		t.Errorf("Seek(-5, io.SeekEnd): got: %d, want: %d", got, want)
+	}
+}

--- a/audio/vorbis/vorbis_test.go
+++ b/audio/vorbis/vorbis_test.go
@@ -297,3 +297,87 @@ func TestSeekInvalidWhence(t *testing.T) {
 		})
 	}
 }
+
+func TestSeekNegativePosition(t *testing.T) {
+	for _, file := range []struct {
+		name string
+		bs   []byte
+	}{
+		{
+			name: "Mono",
+			bs:   test_mono_ogg,
+		},
+		{
+			name: "Stereo",
+			bs:   test_stereo_ogg,
+		},
+	} {
+		t.Run(file.name, func(t *testing.T) {
+			for _, decode := range []struct {
+				name string
+				f    func(io.Reader) (*vorbis.Stream, error)
+			}{
+				{
+					name: "I16",
+					f: func(r io.Reader) (*vorbis.Stream, error) {
+						return vorbis.DecodeWithoutResampling(r)
+					},
+				},
+				{
+					name: "F32",
+					f: func(r io.Reader) (*vorbis.Stream, error) {
+						return vorbis.DecodeF32(r)
+					},
+				},
+				{
+					name: "Resampling",
+					f: func(r io.Reader) (*vorbis.Stream, error) {
+						// The test files are 44100Hz, so this resamples the stream.
+						return vorbis.DecodeWithSampleRate(48000, r)
+					},
+				},
+			} {
+				t.Run(decode.name, func(t *testing.T) {
+					s, err := decode.f(bytes.NewReader(file.bs))
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if _, err := s.Seek(-100, io.SeekStart); err == nil {
+						t.Error("Seek(-100, io.SeekStart): expected an error but got none")
+					}
+					if _, err := s.Seek(0, io.SeekStart); err != nil {
+						t.Fatal(err)
+					}
+					if _, err := s.Seek(-1000, io.SeekCurrent); err == nil {
+						t.Error("Seek(-1000, io.SeekCurrent): expected an error but got none")
+					}
+					// A negative result from io.SeekEnd must be rejected even from a non-zero position.
+					if _, err := s.Seek(4096, io.SeekStart); err != nil {
+						t.Fatal(err)
+					}
+					if _, err := s.Seek(-s.Length()-1024, io.SeekEnd); err == nil {
+						t.Error("Seek(-Length()-1024, io.SeekEnd): expected an error but got none")
+					}
+
+					// The stream must not be broken by the failed seeks.
+					pos, err := s.Seek(0, io.SeekStart)
+					if err != nil {
+						t.Fatalf("Seek(0, io.SeekStart) after failed seeks: %v", err)
+					}
+					if got, want := pos, int64(0); got != want {
+						t.Errorf("Seek(0, io.SeekStart): got: %d, want: %d", got, want)
+					}
+					buf := make([]byte, 64)
+					n, err := s.Read(buf)
+					if err != nil {
+						t.Fatalf("Read after Seek(0): %v", err)
+					}
+					if got, want := n, len(buf); got != want {
+						t.Errorf("Read: got: %d, want: %d", got, want)
+					}
+				})
+			}
+		})
+	}
+}

--- a/audio/vorbis/vorbis_test.go
+++ b/audio/vorbis/vorbis_test.go
@@ -381,3 +381,30 @@ func TestSeekNegativePosition(t *testing.T) {
 		})
 	}
 }
+
+func TestStereoI16SeekUnalignedPosition(t *testing.T) {
+	bs := test_stereo_ogg
+
+	s, err := vorbis.DecodeWithoutResampling(bytes.NewReader(bs))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A seek result must be the actual frame-aligned position in the stream.
+	got, err := s.Seek(5, io.SeekStart)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int64(4); got != want {
+		t.Errorf("Seek(5, io.SeekStart): got: %d, want: %d", got, want)
+	}
+
+	buf := make([]byte, 8)
+	n, err := s.Read(buf)
+	if err != nil {
+		t.Fatalf("Read after Seek(5, io.SeekStart): %v", err)
+	}
+	if got, want := n, len(buf); got != want {
+		t.Errorf("Read: got: %d, want: %d", got, want)
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Both the int16 and the float32 streams accepted a seek resolving to a negative position without an error. Following reads then failed with "vorbis: decoding error" until a valid seek happened again. The prefix is broadened to `audio:` because `convert.Resampling` is public surface (returned by `audio.Resample*` and wrapped by `audio/mp3` and `audio/wav` whenever they resample), so this is a user-visible change beyond Ogg/Vorbis.

* `audio/internal/convert`: make `Resampling.Seek` return an error for a negative position instead of clamping it to 0, so the behavior does not depend on whether resampling is needed, and so a rejected seek leaves the state (`pos`, `eof`) untouched. Also fix `io.SeekEnd`, which was relative to the current position rather than the end.
* `audio/vorbis`: return an error for a negative seek result (before any state mutation).
* `audio/vorbis`: return the actual frame-aligned position from the int16 stream's `Seek`, and update the position fields (`posInBytes` / `pos`) only after `SetPosition` succeeds so a failed seek does not desync the stream.
* `audio/vorbis`: align the float32 offset after applying the whence, so a negative `io.SeekEnd` offset rounds the same direction as the int16 stream.

Note: this makes `audio.Player.SetPosition` with a negative duration return an error instead of silently rewinding to 0 for any resampled source, which matches the documented behavior. This belongs in the release notes.

Add tests which fail without these fixes (including a mono/stereo x i16/f32/resampling matrix with non-zero-position `io.SeekEnd` cases).
