### PR TITLE
audio/wav: reject a non-positive sample rate

### DIFF
--- a/audio/wav/decode.go
+++ b/audio/wav/decode.go
@@ -205,6 +205,9 @@ chunks:
 				return nil, fmt.Errorf("wav: bits per sample must be 8 or 16 but was %d", bitsPerSample)
 			}
 			sampleRate = int(fmtBuf[4]) | int(fmtBuf[5])<<8 | int(fmtBuf[6])<<16 | int(fmtBuf[7])<<24
+			if sampleRate <= 0 {
+				return nil, fmt.Errorf("wav: sample rate must be positive but was %d", sampleRate)
+			}
 			if _, err := io.CopyN(io.Discard, src, paddedSize-16); err != nil {
 				return nil, fmt.Errorf("wav: invalid header")
 			}

--- a/audio/wav/decode_test.go
+++ b/audio/wav/decode_test.go
@@ -137,25 +137,25 @@ func appendChunk(dst []byte, id string, data []byte) []byte {
 }
 
 // stereoI16FmtChunkData returns the content of a 'fmt ' chunk for 2 channels signed 16bit little endian PCM.
-func stereoI16FmtChunkData() []byte {
+func stereoI16FmtChunkData(sampleRate uint32) []byte {
 	var buf []byte
-	buf = binary.LittleEndian.AppendUint16(buf, 1)                  // Format tag (linear PCM)
-	buf = binary.LittleEndian.AppendUint16(buf, 2)                  // Channel count
-	buf = binary.LittleEndian.AppendUint32(buf, testSampleRate)     // Sample rate
-	buf = binary.LittleEndian.AppendUint32(buf, testSampleRate*2*2) // Byte rate
-	buf = binary.LittleEndian.AppendUint16(buf, 4)                  // Block align
-	buf = binary.LittleEndian.AppendUint16(buf, 16)                 // Bits per sample
+	buf = binary.LittleEndian.AppendUint16(buf, 1)              // Format tag (linear PCM)
+	buf = binary.LittleEndian.AppendUint16(buf, 2)              // Channel count
+	buf = binary.LittleEndian.AppendUint32(buf, sampleRate)     // Sample rate
+	buf = binary.LittleEndian.AppendUint32(buf, sampleRate*2*2) // Byte rate
+	buf = binary.LittleEndian.AppendUint16(buf, 4)              // Block align
+	buf = binary.LittleEndian.AppendUint16(buf, 16)             // Bits per sample
 	return buf
 }
 
 // wavFile returns a WAV file whose 'data' chunk holds data.
 // beforeFmt and afterFmt are put before and after the 'fmt ' chunk respectively.
-func wavFile(beforeFmt []chunk, afterFmt []chunk, data []byte) []byte {
+func wavFile(sampleRate uint32, beforeFmt []chunk, afterFmt []chunk, data []byte) []byte {
 	var body []byte
 	for _, c := range beforeFmt {
 		body = appendChunk(body, c.id, []byte(c.data))
 	}
-	body = appendChunk(body, "fmt ", stereoI16FmtChunkData())
+	body = appendChunk(body, "fmt ", stereoI16FmtChunkData(sampleRate))
 	for _, c := range afterFmt {
 		body = appendChunk(body, c.id, []byte(c.data))
 	}
@@ -208,7 +208,7 @@ func TestDecodeChunkPadding(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			src := wavFile(tc.beforeFmt, tc.afterFmt, data)
+			src := wavFile(testSampleRate, tc.beforeFmt, tc.afterFmt, data)
 			s, err := wav.DecodeWithoutResampling(bytes.NewReader(src))
 			if err != nil {
 				t.Fatal(err)
@@ -287,6 +287,40 @@ func TestDecodeSeekInvalidWhence(t *testing.T) {
 				if _, err := s.Seek(0, whence); err == nil {
 					t.Errorf("Seek(0, %d): got no error, want an error", whence)
 				}
+			}
+		})
+	}
+}
+
+func TestDecodeInvalidSampleRate(t *testing.T) {
+	testCases := []struct {
+		name       string
+		sampleRate uint32
+		wantErr    bool
+	}{
+		{
+			name:       "zero",
+			sampleRate: 0,
+			wantErr:    true,
+		},
+		{
+			name:       "valid",
+			sampleRate: testSampleRate,
+			wantErr:    false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := wavFile(tc.sampleRate, nil, nil, []byte{1, 2, 3, 4})
+
+			if _, err := wav.DecodeWithoutResampling(bytes.NewReader(data)); (err != nil) != tc.wantErr {
+				t.Errorf("wav.DecodeWithoutResampling: err %v, wantErr %v", err, tc.wantErr)
+			}
+			if _, err := wav.DecodeWithSampleRate(testSampleRate, bytes.NewReader(data)); (err != nil) != tc.wantErr {
+				t.Errorf("wav.DecodeWithSampleRate: err %v, wantErr %v", err, tc.wantErr)
+			}
+			if _, err := wav.DecodeF32(bytes.NewReader(data)); (err != nil) != tc.wantErr {
+				t.Errorf("wav.DecodeF32: err %v, wantErr %v", err, tc.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
A WAV whose fmt chunk declared a sample rate of 0 was accepted, and DecodeWithSampleRate then created a resampler whose Length() divided by zero: the float-to-int64 conversion overflowed and returned the minimum int64 value.

Reject a non-positive sample rate as an invalid header.

Add TestWavZeroSampleRate, which fails without this fix.

