### PR TITLE
audio/internal/convert: fix StereoI16ReadSeeker's byte counts

### DIFF
--- a/audio/internal/convert/stereoi16.go
+++ b/audio/internal/convert/stereoi16.go
@@ -31,6 +31,9 @@ type StereoI16ReadSeeker struct {
 	mono   bool
 	format Format
 	buf    []byte
+	// rest is a partial source frame that was read from the source but is not
+	// converted yet, so the source is ahead of the consumer by len(rest).
+	rest []byte
 }
 
 func NewStereoI16ReadSeeker(source io.ReadSeeker, mono bool, format Format) *StereoI16ReadSeeker {
@@ -41,28 +44,58 @@ func NewStereoI16ReadSeeker(source io.ReadSeeker, mono bool, format Format) *Ste
 	}
 }
 
-func (s *StereoI16ReadSeeker) Read(b []byte) (int, error) {
-	l := len(b) / 4 * 4
-	if s.mono {
-		l /= 2
-	}
+const dstFrameSize = 4
+
+func (s *StereoI16ReadSeeker) srcFrameSize() int {
 	switch s.format {
 	case FormatU8:
-		l /= 2
+		if s.mono {
+			return 1
+		}
+		return 2
 	case FormatS16:
+		if s.mono {
+			return 2
+		}
+		return 4
 	case FormatS24:
-		l *= 3
-		l /= 2
+		if s.mono {
+			return 3
+		}
+		return 6
 	}
+	panic("not reached")
+}
+
+func (s *StereoI16ReadSeeker) Read(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+	if len(b) < dstFrameSize {
+		return 0, io.ErrShortBuffer
+	}
+	srcFrameSize := s.srcFrameSize()
+	l := len(b) / dstFrameSize * srcFrameSize
 
 	if cap(s.buf) < l {
 		s.buf = make([]byte, l)
 	}
+	s.buf = s.buf[:l]
 
-	n, err := s.source.Read(s.buf[:l])
-	if err != nil && err != io.EOF {
-		return 0, err
+	n := copy(s.buf, s.rest)
+	var err error
+	for n < srcFrameSize {
+		var dn int
+		dn, err = s.source.Read(s.buf[n:])
+		n += dn
+		if err != nil || dn == 0 {
+			break
+		}
 	}
+
+	s.rest = append(s.rest[:0], s.buf[n/srcFrameSize*srcFrameSize:n]...)
+	n = n / srcFrameSize * srcFrameSize
+
 	if s.mono {
 		switch s.format {
 		case FormatU8:
@@ -110,49 +143,23 @@ func (s *StereoI16ReadSeeker) Read(b []byte) (int, error) {
 			}
 		}
 	}
-	if s.mono {
-		n *= 2
-	}
-	switch s.format {
-	case FormatU8:
-		n *= 2
-	case FormatS16:
-	case FormatS24:
-		n *= 2
-		n /= 3
-	}
-	return n, err
+
+	return n / srcFrameSize * dstFrameSize, err
 }
 
 func (s *StereoI16ReadSeeker) Seek(offset int64, whence int) (int64, error) {
-	offset = offset / 4 * 4
-	if s.mono {
-		offset /= 2
+	srcFrameSize := int64(s.srcFrameSize())
+	o := offset / dstFrameSize * srcFrameSize
+	if whence == io.SeekCurrent {
+		o -= int64(len(s.rest))
 	}
-	switch s.format {
-	case FormatU8:
-		offset /= 2
-	case FormatS16:
-	case FormatS24:
-		offset *= 3
-		offset /= 2
-	}
-	pos, err := s.source.Seek(offset, whence)
+	pos, err := s.source.Seek(o, whence)
 	if err != nil {
 		return 0, err
 	}
+	s.rest = s.rest[:0]
+
 	// Convert the returned position from the source format's byte space to the
 	// stereo-i16 byte space this wrapper presents.
-	if s.mono {
-		pos *= 2
-	}
-	switch s.format {
-	case FormatU8:
-		pos *= 2
-	case FormatS16:
-	case FormatS24:
-		pos *= 2
-		pos /= 3
-	}
-	return pos, nil
+	return pos / srcFrameSize * dstFrameSize, nil
 }

--- a/audio/internal/convert/stereoi16_test.go
+++ b/audio/internal/convert/stereoi16_test.go
@@ -16,6 +16,7 @@ package convert_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -304,5 +305,272 @@ func TestStereoI16SeekEnd(t *testing.T) {
 				})
 			}
 		})
+	}
+}
+
+var partialFrameTestCases = []struct {
+	name string
+	src  []byte
+	mono bool
+	fmt  convert.Format
+	want []byte
+}{
+	{
+		name: "mono S16 with a trailing byte",
+		src:  []byte{0x80, 0x01, 0x02, 0x03, 0x04},
+		mono: true,
+		fmt:  convert.FormatS16,
+		want: []byte{0x80, 0x01, 0x80, 0x01, 0x02, 0x03, 0x02, 0x03},
+	},
+	{
+		name: "mono S16 aligned",
+		src:  []byte{0x80, 0x01, 0x02, 0x03},
+		mono: true,
+		fmt:  convert.FormatS16,
+		want: []byte{0x80, 0x01, 0x80, 0x01, 0x02, 0x03, 0x02, 0x03},
+	},
+	{
+		name: "mono S16 four samples",
+		src:  []byte{0x11, 0x11, 0x22, 0x22, 0x33, 0x33, 0x44, 0x44},
+		mono: true,
+		fmt:  convert.FormatS16,
+		want: []byte{0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22, 0x33, 0x33, 0x33, 0x33, 0x44, 0x44, 0x44, 0x44},
+	},
+	{
+		name: "stereo S16 with a trailing byte",
+		src:  []byte{0x80, 0x01, 0x02, 0x03, 0x04},
+		mono: false,
+		fmt:  convert.FormatS16,
+		want: []byte{0x80, 0x01, 0x02, 0x03},
+	},
+	{
+		name: "mono U8 aligned",
+		src:  []byte{0x80, 0x81, 0x7f},
+		mono: true,
+		fmt:  convert.FormatU8,
+		want: []byte{0x80, 0x00, 0x80, 0x00, 0x81, 0x01, 0x81, 0x01, 0x7f, 0xff, 0x7f, 0xff},
+	},
+	{
+		name: "stereo U8 with a trailing byte",
+		src:  []byte{0x80, 0x81, 0x7f, 0x7e, 0x01},
+		mono: false,
+		fmt:  convert.FormatU8,
+		want: []byte{0x80, 0x00, 0x81, 0x01, 0x7f, 0xff, 0x7e, 0xfe},
+	},
+	{
+		name: "mono S24 aligned",
+		src:  []byte{1, 2, 3, 4, 5, 6},
+		mono: true,
+		fmt:  convert.FormatS24,
+		want: []byte{2, 3, 2, 3, 5, 6, 5, 6},
+	},
+	{
+		name: "stereo S24 aligned",
+		src:  []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+		mono: false,
+		fmt:  convert.FormatS24,
+		want: []byte{2, 3, 5, 6, 8, 9, 11, 12},
+	},
+	{
+		name: "stereo S24 with a trailing partial frame",
+		src:  []byte{1, 2, 3, 4, 5, 6, 7, 8},
+		mono: false,
+		fmt:  convert.FormatS24,
+		want: []byte{2, 3, 5, 6},
+	},
+}
+
+func TestStereoI16ReadSeekerPartialFrame(t *testing.T) {
+	for _, tc := range partialFrameTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := convert.NewStereoI16ReadSeeker(bytes.NewReader(tc.src), tc.mono, tc.fmt)
+			buf := make([]byte, 64)
+			n, err := s.Read(buf)
+			if err != nil && err != io.EOF {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(buf[:n], tc.want) {
+				t.Errorf("Read: got %d bytes %x, want %x", n, buf[:n], tc.want)
+			}
+		})
+	}
+}
+
+type shortReader struct {
+	src   io.Reader
+	chunk int
+}
+
+func (r *shortReader) Read(p []byte) (int, error) {
+	if len(p) > r.chunk {
+		p = p[:r.chunk]
+	}
+	return r.src.Read(p)
+}
+
+func (r *shortReader) Seek(offset int64, whence int) (int64, error) {
+	return r.src.(io.Seeker).Seek(offset, whence)
+}
+
+func TestStereoI16ReadSeekerShortReads(t *testing.T) {
+	for _, chunk := range []int{1, 2, 3, 5} {
+		for _, tc := range partialFrameTestCases {
+			t.Run(fmt.Sprintf("%s/chunk=%d", tc.name, chunk), func(t *testing.T) {
+				s := convert.NewStereoI16ReadSeeker(&shortReader{src: bytes.NewReader(tc.src), chunk: chunk}, tc.mono, tc.fmt)
+				var got []byte
+				for {
+					buf := make([]byte, 8)
+					n, err := s.Read(buf)
+					if n == 0 && err == nil {
+						t.Fatalf("Read returned (0, nil) after %d bytes", len(got))
+					}
+					got = append(got, buf[:n]...)
+					pos, seekErr := s.Seek(0, io.SeekCurrent)
+					if seekErr != nil {
+						t.Fatal(seekErr)
+					}
+					if pos != int64(len(got)) {
+						t.Errorf("Seek(0, io.SeekCurrent): got %d, want %d", pos, len(got))
+					}
+					if err != nil {
+						if err != io.EOF {
+							t.Fatal(err)
+						}
+						break
+					}
+				}
+				if !bytes.Equal(got, tc.want) {
+					t.Errorf("got %x, want %x", got, tc.want)
+				}
+
+				if _, err := s.Seek(0, io.SeekStart); err != nil {
+					t.Fatal(err)
+				}
+				got = nil
+				for {
+					buf := make([]byte, 5)
+					n, err := s.Read(buf)
+					if n == 0 && err == nil {
+						t.Fatalf("Read returned (0, nil) after %d bytes", len(got))
+					}
+					got = append(got, buf[:n]...)
+					if err != nil {
+						if err != io.EOF {
+							t.Fatal(err)
+						}
+						break
+					}
+				}
+				if !bytes.Equal(got, tc.want) {
+					t.Errorf("after seeking: got %x, want %x", got, tc.want)
+				}
+			})
+		}
+	}
+}
+
+func TestStereoI16ReadSeekerTooShortBuffer(t *testing.T) {
+	for _, tc := range []struct {
+		bufSize int
+		want    error
+	}{
+		{0, nil},
+		{1, io.ErrShortBuffer},
+		{3, io.ErrShortBuffer},
+	} {
+		t.Run(fmt.Sprintf("buf=%d", tc.bufSize), func(t *testing.T) {
+			s := convert.NewStereoI16ReadSeeker(&shortReader{
+				src:   bytes.NewReader([]byte{1, 2, 3, 4, 5, 6}),
+				chunk: 5,
+			}, true, convert.FormatS24)
+			want := []byte{2, 3, 2, 3, 5, 6, 5, 6}
+
+			buf := make([]byte, 8)
+			n, err := s.Read(buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := buf[:n]
+
+			n, err = s.Read(make([]byte, tc.bufSize))
+			if n != 0 {
+				t.Errorf("Read with a %d-byte buffer: got %d bytes, want 0", tc.bufSize, n)
+			}
+			if !errors.Is(err, tc.want) {
+				t.Errorf("Read with a %d-byte buffer: got error %v, want %v", tc.bufSize, err, tc.want)
+			}
+
+			for {
+				buf := make([]byte, 8)
+				n, err := s.Read(buf)
+				got = append(got, buf[:n]...)
+				if err != nil {
+					if err != io.EOF {
+						t.Fatal(err)
+					}
+					break
+				}
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("got %x, want %x", got, want)
+			}
+		})
+	}
+}
+
+func TestStereoI16SeekEndPartialFrame(t *testing.T) {
+	for _, tc := range partialFrameTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := convert.NewStereoI16ReadSeeker(bytes.NewReader(tc.src), tc.mono, tc.fmt)
+			pos, err := s.Seek(0, io.SeekEnd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := len(tc.want)
+			if int(pos) != want {
+				t.Errorf("Seek(0, io.SeekEnd): got %d, want %d", pos, want)
+			}
+		})
+	}
+}
+
+type failedSeeker struct {
+	r   io.Reader
+	err error
+}
+
+func (f *failedSeeker) Read(p []byte) (int, error) {
+	return f.r.Read(p)
+}
+
+func (f *failedSeeker) Seek(offset int64, whence int) (int64, error) {
+	return 0, f.err
+}
+
+func TestStereoI16ReadSeekerFailedSeekKeepsRemainder(t *testing.T) {
+	src := []byte{1, 2, 3, 4, 5, 6}
+	want := []byte{2, 3, 2, 3, 5, 6, 5, 6}
+	s := convert.NewStereoI16ReadSeeker(&failedSeeker{
+		r:   &shortReader{src: bytes.NewReader(src), chunk: 5},
+		err: errors.New("seek failed"),
+	}, true, convert.FormatS24)
+
+	var got []byte
+	for {
+		buf := make([]byte, 8)
+		n, err := s.Read(buf)
+		got = append(got, buf[:n]...)
+		if _, seekErr := s.Seek(0, io.SeekStart); seekErr == nil {
+			t.Fatal("Seek: got nil error, want an error")
+		}
+		if err != nil {
+			if err != io.EOF {
+				t.Fatal(err)
+			}
+			break
+		}
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %x, want %x", got, want)
 	}
 }


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
`Read` scaled the raw source byte count after the conversion, so a source
returning a byte count with a trailing partial frame made `Read` report
more bytes than it actually wrote, sometimes a count that is not a
multiple of 4, and the caller played its own stale buffer contents as
audio. `Seek` had the same bug converting the source position back, so a
source whose length is not a whole number of frames made it report a
position that is not a multiple of 4 either.

Derive both counts from the number of whole source frames, and carry the
remainder of an incomplete frame over to the next `Read` instead of
dropping it, which desynced the stream whenever the source returned a
short read. `Read` now fills at least one whole frame before returning so
that it does not return `(0, nil)` for a source that dribbles bytes,
reports `io.ErrShortBuffer` for a non-empty buffer shorter than a frame
while a zero-length read reports `(0, nil)` as `io.Reader` expects, and
accounts for the carried-over remainder when seeking relative to the
current position.

Add tests for frame-unaligned source lengths and read sizes. They fail
without this fix.