### PR TITLE
audio/internal/convert: fix Resampling.Seek's io.SeekEnd result

### DIFF
--- a/audio/internal/convert/resampling.go
+++ b/audio/internal/convert/resampling.go
@@ -326,7 +326,7 @@ func (r *Resampling) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekCurrent:
 		r.pos += offset
 	case io.SeekEnd:
-		r.pos += r.Length() + offset
+		r.pos = r.Length() + offset
 	}
 	if r.pos < 0 {
 		r.pos = 0

--- a/audio/internal/convert/resampling_test.go
+++ b/audio/internal/convert/resampling_test.go
@@ -181,3 +181,74 @@ func TestResamplingLen(t *testing.T) {
 		t.Errorf("got: %d, want: %d", got, want)
 	}
 }
+
+func newTestSoundBytes16(n int) []byte {
+	b := make([]byte, n*4)
+	for i := range n {
+		b[4*i] = byte(i)
+		b[4*i+1] = byte(i >> 8)
+		b[4*i+2] = byte(255 - i)
+		b[4*i+3] = byte((255 - i) >> 8)
+	}
+	return b
+}
+
+func TestResamplingSeekEndAbsolute(t *testing.T) {
+	in := newTestSoundBytes16(1000)
+
+	r := convert.NewResampling(bytes.NewReader(in), int64(len(in)), 44100, 44100, 2)
+	got, err := r.Seek(-4, io.SeekEnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := r.Length() - 4; got != want {
+		t.Errorf("Seek(-4, io.SeekEnd) from the start: got %d, want %d", got, want)
+	}
+
+	r2 := convert.NewResampling(bytes.NewReader(in), int64(len(in)), 44100, 44100, 2)
+	buf := make([]byte, 2000)
+	for len(buf) > 0 {
+		n, err := r2.Read(buf)
+		if err != nil && err != io.EOF {
+			t.Fatal(err)
+		}
+		if n == 0 {
+			t.Fatal("Read made no progress")
+		}
+		buf = buf[n:]
+	}
+	got2, err := r2.Seek(-4, io.SeekEnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got2 != got {
+		t.Errorf("Seek(-4, io.SeekEnd) after reading 2000 bytes: got %d, want %d (the result must not depend on the current position)", got2, got)
+	}
+
+	b := make([]byte, 8)
+	n, err := r2.Read(b)
+	if n != 4 || (err != nil && err != io.EOF) {
+		t.Errorf("Read at (Length-4) after Seek(-4, io.SeekEnd): got n=%d, err=%v; want n=4", n, err)
+	}
+}
+
+func TestResamplingSeekEndZero(t *testing.T) {
+	in := newTestSoundBytes16(500)
+	r := convert.NewResampling(bytes.NewReader(in), int64(len(in)), 44100, 44100, 2)
+
+	buf := make([]byte, 1000)
+	if _, err := r.Read(buf); err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+
+	got, err := r.Seek(0, io.SeekEnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := r.Length(); got != want {
+		t.Errorf("Seek(0, io.SeekEnd): got %d, want %d", got, want)
+	}
+	if want := int64(len(in)); r.Length() != want {
+		t.Errorf("Length: got %d, want %d", r.Length(), want)
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Resampling.Seek resolved io.SeekEnd relative to the current position: it added the resolved offset to r.pos instead of assigning it, so the seek result depended on how much data had been read before the seek. For example, Seek(-4, io.SeekEnd) after reading 2000 bytes returned Length() instead of Length()-4.

Resolve the position to Length()+offset as the io.Seeker contract requires.

Add TestResamplingSeekEndAbsolute, which fails without this fix.
