### PR TITLE
text: fix a data race on the monotonic clock

### DIFF
--- a/text/text.go
+++ b/text/text.go
@@ -23,6 +23,7 @@ import (
 	"image"
 	"image/color"
 	"sync"
+	"sync/atomic"
 
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
@@ -32,16 +33,16 @@ import (
 )
 
 var (
-	monotonicClock int64
+	monotonicClock atomic.Int64
 )
 
 func now() int64 {
-	return monotonicClock
+	return monotonicClock.Load()
 }
 
 func init() {
 	hook.AppendHookOnBeforeUpdate(func() error {
-		monotonicClock++
+		monotonicClock.Add(1)
 		return nil
 	})
 }

--- a/text/text_test.go
+++ b/text/text_test.go
@@ -17,7 +17,6 @@ package text_test
 import (
 	"image"
 	"image/color"
-	"sync"
 	"testing"
 
 	"github.com/hajimehoshi/bitmapfont/v4"
@@ -25,7 +24,6 @@ import (
 	"golang.org/x/image/math/fixed"
 
 	"github.com/hajimehoshi/ebiten/v2"
-	"github.com/hajimehoshi/ebiten/v2/internal/hook"
 	t "github.com/hajimehoshi/ebiten/v2/internal/testing"
 	"github.com/hajimehoshi/ebiten/v2/text"
 )
@@ -60,28 +58,6 @@ func TestTextColor(t *testing.T) {
 }
 
 const testFaceSize = 6
-
-func TestMonotonicClockConcurrent(t *testing.T) {
-	dst := ebiten.NewImage(100, 20)
-
-	const goroutines = 4
-	var wg sync.WaitGroup
-	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for range 100 {
-				text.Draw(dst, "Hello, world!", bitmapfont.Face, 0, 10, color.White)
-			}
-		}()
-	}
-
-	for range 1000 {
-		text.Draw(dst, "Hello, world!", bitmapfont.Face, 0, 10, color.White)
-		hook.RunBeforeUpdateHooks()
-	}
-	wg.Wait()
-}
 
 type testFace struct{}
 

--- a/text/text_test.go
+++ b/text/text_test.go
@@ -17,6 +17,7 @@ package text_test
 import (
 	"image"
 	"image/color"
+	"sync"
 	"testing"
 
 	"github.com/hajimehoshi/bitmapfont/v4"
@@ -24,6 +25,7 @@ import (
 	"golang.org/x/image/math/fixed"
 
 	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/internal/hook"
 	t "github.com/hajimehoshi/ebiten/v2/internal/testing"
 	"github.com/hajimehoshi/ebiten/v2/text"
 )
@@ -58,6 +60,28 @@ func TestTextColor(t *testing.T) {
 }
 
 const testFaceSize = 6
+
+func TestMonotonicClockConcurrent(t *testing.T) {
+	dst := ebiten.NewImage(100, 20)
+
+	const goroutines = 4
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				text.Draw(dst, "Hello, world!", bitmapfont.Face, 0, 10, color.White)
+			}
+		}()
+	}
+
+	for range 1000 {
+		text.Draw(dst, "Hello, world!", bitmapfont.Face, 0, 10, color.White)
+		hook.RunBeforeUpdateHooks()
+	}
+	wg.Wait()
+}
 
 type testFace struct{}
 


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The monotonic clock was incremented by the before-update hook without synchronization while Draw read it from other goroutines. Make the clock an atomic.Int64.