### PR TITLE
internal/shader: reject recursive function calls at compile time

### DIFF
--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -40,6 +40,7 @@ type constant struct {
 
 type function struct {
 	name string
+	pos  token.Pos
 
 	ir shaderir.Func
 }
@@ -202,6 +203,11 @@ func Compile(src []byte, vertexEntry, fragmentEntry string, textureCount int) (*
 		return nil, &ParseError{s.errs}
 	}
 
+	s.checkRecursion()
+	if len(s.errs) > 0 {
+		return nil, &ParseError{s.errs}
+	}
+
 	// TODO: Resolve identifiers?
 	// TODO: Resolve constants
 
@@ -293,6 +299,7 @@ func (cs *compileState) parse(f *ast.File) {
 		}
 		cs.funcs = append(cs.funcs, function{
 			name: n,
+			pos:  fd.Pos(),
 			ir: shaderir.Func{
 				Index:     len(cs.funcs),
 				InParams:  inT,
@@ -480,6 +487,7 @@ func (cs *compileState) parseDecl(b *block, fname string, d ast.Decl) ([]shaderi
 				if cs.funcs[i].name == d.Name.Name {
 					// Index is already determined by the provisional parsing.
 					f.ir.Index = cs.funcs[i].ir.Index
+					f.pos = cs.funcs[i].pos
 					cs.funcs[i] = f
 					break
 				}
@@ -916,4 +924,83 @@ func (cs *compileState) parseBlock(outer *block, fname string, stmts []ast.Stmt,
 	}
 
 	return block, true
+}
+
+func (cs *compileState) checkRecursion() {
+	callees := make([][]int, len(cs.funcs))
+	for i, f := range cs.funcs {
+		seen := map[int]struct{}{}
+		walkBlockCalls(f.ir.Block, func(idx int) {
+			if _, ok := seen[idx]; ok {
+				return
+			}
+			seen[idx] = struct{}{}
+			callees[i] = append(callees[i], idx)
+		})
+	}
+
+	const (
+		unvisited  = 0
+		inProgress = 1
+		done       = 2
+	)
+	state := make([]int, len(cs.funcs))
+	var stack []string
+
+	var dfs func(int)
+	dfs = func(u int) {
+		state[u] = inProgress
+		stack = append(stack, cs.funcs[u].name)
+		for _, v := range callees[u] {
+			switch state[v] {
+			case inProgress:
+				start := 0
+				for i, name := range stack {
+					if name == cs.funcs[v].name {
+						start = i
+						break
+					}
+				}
+				path := append(append([]string{}, stack[start:]...), cs.funcs[v].name)
+				cs.addError(cs.funcs[u].pos, fmt.Sprintf("recursive function call is not supported: %s", strings.Join(path, " calls ")))
+			case unvisited:
+				dfs(v)
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[u] = done
+	}
+	for i := range cs.funcs {
+		if state[i] == unvisited {
+			dfs(i)
+		}
+	}
+}
+
+func walkBlockCalls(block *shaderir.Block, fn func(int)) {
+	if block == nil {
+		return
+	}
+	for _, s := range block.Stmts {
+		for i := range s.Exprs {
+			walkExprCalls(&s.Exprs[i], fn)
+		}
+		for _, b := range s.Blocks {
+			walkBlockCalls(b, fn)
+		}
+	}
+}
+
+func walkExprCalls(e *shaderir.Expr, fn func(int)) {
+	if e == nil {
+		return
+	}
+	if e.Type == shaderir.Call {
+		if len(e.Exprs) > 0 && e.Exprs[0].Type == shaderir.FunctionExpr {
+			fn(e.Exprs[0].Index)
+		}
+	}
+	for i := range e.Exprs {
+		walkExprCalls(&e.Exprs[i], fn)
+	}
 }

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -292,3 +292,87 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("Compile must return an error for a huge constant shift, but got nil")
 	}
 }
+
+func TestCompileRecursion(t *testing.T) {
+	const selfRecursive = `package main
+
+func fact(n int) int {
+	if n <= 1 {
+		return 1
+	}
+	return n * fact(n-1)
+}
+
+func Vertex(pos vec2) vec4 {
+	_ = fact(5)
+	return vec4(pos, 0, 1)
+}
+
+func Fragment(pos vec4) vec4 {
+	return vec4(vec3(float(fact(5)) / 255), 1)
+}
+`
+	const mutualRecursive = `package main
+
+func a() int {
+	return b()
+}
+
+func b() int {
+	return a()
+}
+
+func Vertex(pos vec2) vec4 {
+	_ = a()
+	return vec4(pos, 0, 1)
+}
+
+func Fragment(pos vec4) vec4 {
+	return vec4(vec3(float(a()) / 255), 1)
+}
+`
+	const nonRecursive = `package main
+
+func add1(n int) int {
+	return n + 1
+}
+
+func double(n int) int {
+	return add1(n) + add1(n)
+}
+
+func Vertex(pos vec2) vec4 {
+	_ = double(5)
+	return vec4(pos, 0, 1)
+}
+
+func Fragment(pos vec4) vec4 {
+	return vec4(vec3(float(double(5)) / 255), 1)
+}
+`
+	for _, tc := range []struct {
+		name    string
+		src     string
+		wantErr bool
+	}{
+		{"SelfRecursive", selfRecursive, true},
+		{"MutualRecursive", mutualRecursive, true},
+		{"NonRecursive", nonRecursive, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := shader.Compile([]byte(tc.src), "Vertex", "Fragment", 0)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected a compile error for a recursive shader, but got nil")
+				}
+				if !strings.Contains(err.Error(), "recursive function call is not supported") {
+					t.Errorf("unexpected error for a recursive shader:\n%v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected compile error for a non-recursive shader:\n%v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
Closes #3536

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
A Kage shader with a recursive function (direct or mutual) was accepted by the compiler, but the shading languages Ebiten targets do not support recursion consistently: GLSL/GLSL ES forbid it and reject the shader at the driver when it is first used, while on some drivers (e.g. Mesa) the recursion is miscompiled into silently wrong output. The failure surfaces far from the actual mistake and can be silent.

Detect cycles in the function call graph (over the IR Call expressions) and report an error at compile time instead.

