### PR TITLE
ebiten: fix the legacy AntiAlias and FillRule paths on a sub-image

### DIFF
--- a/stencilbuffer.go
+++ b/stencilbuffer.go
@@ -222,18 +222,17 @@ func doDrawTrianglesWithAntialias(dst *Image, vertices []Vertex, indices []uint3
 	stencilBufferM.Lock()
 	defer stencilBufferM.Unlock()
 
-	bounds := dst.Bounds()
-	bounds.Min.X *= 2
+	dstMin := dst.Bounds().Min
+	bounds := dst.Bounds().Sub(dstMin)
 	bounds.Max.X *= 2
-	bounds.Min.Y *= 2
 	bounds.Max.Y *= 2
 
 	tmpVerticesForStencilBuffer = slices.Grow(tmpVerticesForStencilBuffer, len(vertices))
 	vs := tmpVerticesForStencilBuffer[:len(vertices)]
 	copy(vs, vertices)
 	for i := range vs {
-		vs[i].DstX *= 2
-		vs[i].DstY *= 2
+		vs[i].DstX = 2 * (vs[i].DstX - float32(dstMin.X))
+		vs[i].DstY = 2 * (vs[i].DstY - float32(dstMin.Y))
 	}
 
 	var uncommonBlend bool
@@ -281,6 +280,7 @@ func doDrawTrianglesWithAntialias(dst *Image, vertices []Vertex, indices []uint3
 
 	op := &DrawImageOptions{}
 	op.GeoM.Scale(0.5, 0.5)
+	op.GeoM.Translate(float64(dstMin.X), float64(dstMin.Y))
 	op.Filter = FilterLinear
 	if uncommonBlend {
 		op.Blend = BlendCopy
@@ -297,20 +297,23 @@ func doDrawTrianglesShaderWithStencilBuffer(dst *Image, vertices []Vertex, indic
 	stencilBufferM.Lock()
 	defer stencilBufferM.Unlock()
 
-	vs := vertices
-	bounds := dst.Bounds()
+	dstMin := dst.Bounds().Min
+	bounds := dst.Bounds().Sub(dstMin)
+	var scale float32 = 1
 	if dtOptions != nil && dtOptions.AntiAlias || dtsOptions != nil && dtsOptions.AntiAlias {
-		bounds.Min.X *= 2
 		bounds.Max.X *= 2
-		bounds.Min.Y *= 2
 		bounds.Max.Y *= 2
+		scale = 2
+	}
 
+	vs := vertices
+	if scale != 1 || dstMin != (image.Point{}) {
 		tmpVerticesForStencilBuffer = slices.Grow(tmpVerticesForStencilBuffer, len(vertices))
 		vs = tmpVerticesForStencilBuffer[:len(vertices)]
 		copy(vs, vertices)
 		for i := range vs {
-			vs[i].DstX *= 2
-			vs[i].DstY *= 2
+			vs[i].DstX = scale * (vs[i].DstX - float32(dstMin.X))
+			vs[i].DstY = scale * (vs[i].DstY - float32(dstMin.Y))
 		}
 	}
 
@@ -377,5 +380,6 @@ func doDrawTrianglesShaderWithStencilBuffer(dst *Image, vertices []Vertex, indic
 			op.Filter = FilterLinear
 		}
 	}
+	op.GeoM.Translate(float64(dstMin.X), float64(dstMin.Y))
 	dst.DrawImage(finalOS, op)
 }

--- a/stencilbuffer_test.go
+++ b/stencilbuffer_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebiten_test
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+func TestImageDrawTrianglesWithStencilBufferOnSubImage(t *testing.T) {
+	whiteImage := ebiten.NewImage(3, 3)
+	whiteImage.Fill(color.White)
+	whiteSubImage := whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
+
+	shader, err := ebiten.NewShader([]byte(`//kage:unit pixels
+
+package main
+
+func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
+	return vec4(1, 0, 0, 1)
+}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const size = 20
+	// The sub-image's origin is at least as large as its own size, so that a
+	// draw lost by keeping the destination's coordinate space cannot
+	// accidentally fall inside the sub-image.
+	dstMin := image.Pt(40, 30)
+
+	vertices := func(ox, oy int) []ebiten.Vertex {
+		v := func(x, y int) ebiten.Vertex {
+			return ebiten.Vertex{
+				DstX:   float32(ox + x),
+				DstY:   float32(oy + y),
+				SrcX:   1,
+				SrcY:   1,
+				ColorR: 1,
+				ColorG: 1,
+				ColorB: 1,
+				ColorA: 1,
+			}
+		}
+		return []ebiten.Vertex{
+			v(2, 2),
+			v(18, 2),
+			v(2, 18),
+			v(4, 4),
+			v(10, 4),
+			v(4, 10),
+		}
+	}
+	// The second triangle is inside the first one with the same winding
+	// order, so that FillRuleNonZero and FillRuleEvenOdd result in different
+	// pixels.
+	is := []uint32{0, 1, 2, 3, 4, 5}
+
+	dt := func(options *ebiten.DrawTrianglesOptions) func(*ebiten.Image, int, int) {
+		return func(dst *ebiten.Image, ox, oy int) {
+			dst.DrawTriangles32(vertices(ox, oy), is, whiteSubImage, options)
+		}
+	}
+	dts := func(options *ebiten.DrawTrianglesShaderOptions) func(*ebiten.Image, int, int) {
+		return func(dst *ebiten.Image, ox, oy int) {
+			options.Images[0] = whiteSubImage
+			dst.DrawTrianglesShader32(vertices(ox, oy), is, shader, options)
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		draw func(dst *ebiten.Image, ox, oy int)
+	}{
+		{
+			name: "FillRuleNonZero",
+			draw: dt(&ebiten.DrawTrianglesOptions{
+				FillRule: ebiten.FillRuleNonZero,
+			}),
+		},
+		{
+			name: "FillRuleEvenOdd",
+			draw: dt(&ebiten.DrawTrianglesOptions{
+				FillRule: ebiten.FillRuleEvenOdd,
+			}),
+		},
+		{
+			name: "AntiAlias",
+			draw: dt(&ebiten.DrawTrianglesOptions{
+				AntiAlias: true,
+			}),
+		},
+		{
+			name: "AntiAliasFillRuleNonZero",
+			draw: dt(&ebiten.DrawTrianglesOptions{
+				AntiAlias: true,
+				FillRule:  ebiten.FillRuleNonZero,
+			}),
+		},
+		{
+			name: "AntiAliasBlendCopy",
+			draw: dt(&ebiten.DrawTrianglesOptions{
+				AntiAlias: true,
+				Blend:     ebiten.BlendCopy,
+			}),
+		},
+		{
+			name: "ShaderFillRuleNonZero",
+			draw: dts(&ebiten.DrawTrianglesShaderOptions{
+				FillRule: ebiten.FillRuleNonZero,
+			}),
+		},
+		{
+			name: "ShaderFillRuleEvenOdd",
+			draw: dts(&ebiten.DrawTrianglesShaderOptions{
+				FillRule: ebiten.FillRuleEvenOdd,
+			}),
+		},
+		{
+			name: "ShaderAntiAlias",
+			draw: dts(&ebiten.DrawTrianglesShaderOptions{
+				AntiAlias: true,
+			}),
+		},
+		{
+			name: "ShaderAntiAliasFillRuleNonZero",
+			draw: dts(&ebiten.DrawTrianglesShaderOptions{
+				AntiAlias: true,
+				FillRule:  ebiten.FillRuleNonZero,
+			}),
+		},
+		{
+			name: "ShaderAntiAliasBlendCopy",
+			draw: dts(&ebiten.DrawTrianglesShaderOptions{
+				AntiAlias: true,
+				Blend:     ebiten.BlendCopy,
+			}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			background := color.RGBA{0, 0, 0, 0xff}
+
+			dstPlain := ebiten.NewImage(size, size)
+			dstPlain.Fill(background)
+
+			base := ebiten.NewImage(dstMin.X+size, dstMin.Y+size)
+			base.Fill(background)
+			dstSub := base.SubImage(image.Rectangle{Min: dstMin, Max: dstMin.Add(image.Pt(size, size))}).(*ebiten.Image)
+
+			tc.draw(dstPlain, 0, 0)
+			tc.draw(dstSub, dstMin.X, dstMin.Y)
+
+			for j := range size {
+				for i := range size {
+					want := dstPlain.At(i, j).(color.RGBA)
+					got := dstSub.At(dstMin.X+i, dstMin.Y+j).(color.RGBA)
+					if got != want {
+						// Report only the first mismatch to keep the log readable.
+						t.Errorf("pixel (%d, %d) of the sub-image: got %v, want %v", i, j, got, want)
+						return
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The internal offscreen images for the legacy AntiAlias and FillRule paths of DrawTriangles were created with the destination's bounds as their own bounds. For a destination whose bounds' origin is not (0, 0), e.g. a sub-image, the rendering was offset by the bounds' origin and vanished.

Create the offscreen images with the origin at (0, 0), shift the doubled vertices by the bounds' origin, and shift the result back when rendering the offscreen onto the destination.

Add TestImageDrawTrianglesWithStencilBufferOnSubImage, which fails without this fix.