### PR TITLE
Fix SetWindowIcon on Linux by setting WM_HINTS with icon flags

### DIFF
--- a/internal/glfw/x11_window_linbsd.go
+++ b/internal/glfw/x11_window_linbsd.go
@@ -2054,6 +2054,20 @@ func (w *Window) platformSetWindowIcon(images []*Image) error {
 			_glfw.platformWindow.NET_WM_ICON)
 	}
 
+
+	// Set ICCCM WM_HINTS with icon flags for Ubuntu/GNOME compatibility
+	{
+		hintsPtr := xAllocWMHints()
+		if hintsPtr != 0 {
+			hints := (*_XWMHints)(unsafe.Pointer(hintsPtr))
+			hints.Flags = 1 | 2 // IconPixmapHint (1) | IconMaskHint (2)
+			hints.IconPixmap = 0 // pixmap handled via _NET_WM_ICON
+			hints.IconMask = 0
+			xSetWMHints(_glfw.platformWindow.display, w.platform.handle, hints)
+			xFree(hintsPtr)
+		}
+	}
+
 	xFlush(_glfw.platformWindow.display)
 	return nil
 }


### PR DESCRIPTION
# What issue is this addressing?
#3202 

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
On X11, platformSetWindowIcon only set the _NET_WM_ICON property. Some window managers and shells (e.g., Ubuntu/GNOME) also inspect the ICCCM WM_HINTS property to determine whether an icon is provided, and without the icon-related flags set in WM_HINTS the window icon was ignored and the default icon remained (issue #3202).

To fix this, after setting _NET_WM_ICON, allocate a WM_HINTS structure with XAllocWMHints, set its flags field to IconPixmapHint (1) | IconMaskHint (2) with null IconPixmap and IconMask values, which signals that the actual icon data is delivered via _NET_WM_ICON, and apply it with XSetWMHints. The allocated structure is then released with XFree. This follows the same WM_HINTS handling pattern already used during window creation.

