### PR TITLE
internal/processtest: build test programs in parallel

### DIFF
--- a/internal/processtest/processtest_test.go
+++ b/internal/processtest/processtest_test.go
@@ -60,9 +60,13 @@ func TestPrograms(t *testing.T) {
 
 	tmpdir := t.TempDir()
 
-	// Run sub-tests one by one, not in parallel (#2571).
-	var m sync.Mutex
-
+	type buildResult struct {
+		name string
+		bin  string
+		err  error
+		out  []byte
+	}
+	results := make([]buildResult, 0, len(ents))
 	for _, e := range ents {
 		if e.IsDir() {
 			continue
@@ -71,20 +75,40 @@ func TestPrograms(t *testing.T) {
 		if !strings.HasSuffix(n, ".go") {
 			continue
 		}
+		results = append(results, buildResult{name: n, bin: filepath.Join(tmpdir, n)})
+	}
 
-		t.Run(n, func(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if out, err := exec.Command("go", "build", "-o", results[i].bin, filepath.Join(dir, results[i].name)).CombinedOutput(); err != nil {
+				results[i].err = err
+				results[i].out = out
+			}
+		}(i)
+	}
+	wg.Wait()
+	for _, r := range results {
+		if r.err != nil {
+			t.Fatalf("%v\n%s", r.err, r.out)
+		}
+	}
+
+	// Run sub-tests one by one, not in parallel (#2571).
+	var m sync.Mutex
+
+	for _, r := range results {
+		r := r
+		t.Run(r.name, func(t *testing.T) {
 			m.Lock()
 			defer m.Unlock()
-
-			bin := filepath.Join(tmpdir, n)
-			if out, err := exec.Command("go", "build", "-o", bin, filepath.Join(dir, n)).CombinedOutput(); err != nil {
-				t.Fatalf("%v\n%s", err, string(out))
-			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			cmd := exec.CommandContext(ctx, bin)
+			cmd := exec.CommandContext(ctx, r.bin)
 			stderr := &bytes.Buffer{}
 			cmd.Stderr = stderr
 			if err := cmd.Run(); err != nil {

--- a/internal/processtest/processtest_test.go
+++ b/internal/processtest/processtest_test.go
@@ -17,10 +17,11 @@ package processtest_test
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"flag"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -39,6 +40,24 @@ func isWSL() (bool, error) {
 		return false, err
 	}
 	return strings.HasPrefix(abs, `\\wsl$\`), nil
+}
+
+// isSelected reports whether a subtest named name is selected by the -run
+// flag, so that only the programs that will run are built.
+func isSelected(name string) bool {
+	f := flag.Lookup("test.run")
+	if f == nil {
+		return true
+	}
+	parts := strings.Split(f.Value.String(), "/")
+	if len(parts) < 2 || parts[1] == "" {
+		return true
+	}
+	re, err := regexp.Compile(parts[1])
+	if err != nil {
+		return true
+	}
+	return re.MatchString(name)
 }
 
 func TestPrograms(t *testing.T) {
@@ -63,11 +82,11 @@ func TestPrograms(t *testing.T) {
 
 	tmpdir := t.TempDir()
 
-	type buildResult struct {
+	type program struct {
 		name string
 		bin  string
 	}
-	results := make([]buildResult, 0, len(ents))
+	programs := make([]program, 0, len(ents))
 	for _, e := range ents {
 		if e.IsDir() {
 			continue
@@ -76,15 +95,35 @@ func TestPrograms(t *testing.T) {
 		if !strings.HasSuffix(n, ".go") {
 			continue
 		}
-		results = append(results, buildResult{name: n, bin: filepath.Join(tmpdir, n)})
+		if !isSelected(n) {
+			continue
+		}
+		programs = append(programs, program{name: n, bin: filepath.Join(tmpdir, n)})
+	}
+
+	errs := make([]error, len(programs))
+	outs := make([][]byte, len(programs))
+
+	build := func(i int) {
+		if out, err := exec.Command("go", "build", "-o", programs[i].bin, filepath.Join(dir, programs[i].name)).CombinedOutput(); err != nil {
+			errs[i] = err
+			outs[i] = out
+		}
+	}
+
+	// Build the first program serially so that the shared dependencies are
+	// put into the build cache before the fan-out. Concurrent go build
+	// invocations don't share in-flight compile actions, so a cold cache
+	// would otherwise recompile the whole tree for each program.
+	if len(programs) > 0 {
+		build(0)
 	}
 
 	var wg errgroup.Group
-	for i := range results {
+	wg.SetLimit(runtime.NumCPU())
+	for i := 1; i < len(programs); i++ {
 		wg.Go(func() error {
-			if out, err := exec.Command("go", "build", "-o", results[i].bin, filepath.Join(dir, results[i].name)).CombinedOutput(); err != nil {
-				return fmt.Errorf("%s: %w\n%s", results[i].name, err, out)
-			}
+			build(i)
 			return nil
 		})
 	}
@@ -95,16 +134,19 @@ func TestPrograms(t *testing.T) {
 	// Run sub-tests one by one, not in parallel (#2571).
 	var m sync.Mutex
 
-	for _, r := range results {
-		r := r
-		t.Run(r.name, func(t *testing.T) {
+	for i, p := range programs {
+		t.Run(p.name, func(t *testing.T) {
 			m.Lock()
 			defer m.Unlock()
+
+			if errs[i] != nil {
+				t.Fatalf("%v\n%s", errs[i], outs[i])
+			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			cmd := exec.CommandContext(ctx, r.bin)
+			cmd := exec.CommandContext(ctx, p.bin)
 			stderr := &bytes.Buffer{}
 			cmd.Stderr = stderr
 			if err := cmd.Run(); err != nil {

--- a/internal/processtest/processtest_test.go
+++ b/internal/processtest/processtest_test.go
@@ -104,7 +104,7 @@ func TestPrograms(t *testing.T) {
 			return nil
 		})
 	}
-	eg.Wait()
+	_ = eg.Wait()
 
 	// Run sub-tests one by one, not in parallel (#2571).
 	var m sync.Mutex

--- a/internal/processtest/processtest_test.go
+++ b/internal/processtest/processtest_test.go
@@ -17,11 +17,9 @@ package processtest_test
 import (
 	"bytes"
 	"context"
-	"flag"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -40,24 +38,6 @@ func isWSL() (bool, error) {
 		return false, err
 	}
 	return strings.HasPrefix(abs, `\\wsl$\`), nil
-}
-
-// isSelected reports whether a subtest named name is selected by the -run
-// flag, so that only the programs that will run are built.
-func isSelected(name string) bool {
-	f := flag.Lookup("test.run")
-	if f == nil {
-		return true
-	}
-	parts := strings.Split(f.Value.String(), "/")
-	if len(parts) < 2 || parts[1] == "" {
-		return true
-	}
-	re, err := regexp.Compile(parts[1])
-	if err != nil {
-		return true
-	}
-	return re.MatchString(name)
 }
 
 func TestPrograms(t *testing.T) {
@@ -95,9 +75,6 @@ func TestPrograms(t *testing.T) {
 		if !strings.HasSuffix(n, ".go") {
 			continue
 		}
-		if !isSelected(n) {
-			continue
-		}
 		programs = append(programs, program{name: n, bin: filepath.Join(tmpdir, n)})
 	}
 
@@ -119,17 +96,15 @@ func TestPrograms(t *testing.T) {
 		build(0)
 	}
 
-	var wg errgroup.Group
-	wg.SetLimit(runtime.NumCPU())
+	var eg errgroup.Group
+	eg.SetLimit(runtime.NumCPU())
 	for i := 1; i < len(programs); i++ {
-		wg.Go(func() error {
+		eg.Go(func() error {
 			build(i)
 			return nil
 		})
 	}
-	if err := wg.Wait(); err != nil {
-		t.Fatal(err)
-	}
+	eg.Wait()
 
 	// Run sub-tests one by one, not in parallel (#2571).
 	var m sync.Mutex

--- a/internal/processtest/processtest_test.go
+++ b/internal/processtest/processtest_test.go
@@ -17,6 +17,7 @@ package processtest_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,6 +26,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 func isWSL() (bool, error) {
@@ -63,8 +66,6 @@ func TestPrograms(t *testing.T) {
 	type buildResult struct {
 		name string
 		bin  string
-		err  error
-		out  []byte
 	}
 	results := make([]buildResult, 0, len(ents))
 	for _, e := range ents {
@@ -78,22 +79,17 @@ func TestPrograms(t *testing.T) {
 		results = append(results, buildResult{name: n, bin: filepath.Join(tmpdir, n)})
 	}
 
-	var wg sync.WaitGroup
+	var wg errgroup.Group
 	for i := range results {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() error {
 			if out, err := exec.Command("go", "build", "-o", results[i].bin, filepath.Join(dir, results[i].name)).CombinedOutput(); err != nil {
-				results[i].err = err
-				results[i].out = out
+				return fmt.Errorf("%s: %w\n%s", results[i].name, err, out)
 			}
-		}(i)
+			return nil
+		})
 	}
-	wg.Wait()
-	for _, r := range results {
-		if r.err != nil {
-			t.Fatalf("%v\n%s", r.err, r.out)
-		}
+	if err := wg.Wait(); err != nil {
+		t.Fatal(err)
 	}
 
 	// Run sub-tests one by one, not in parallel (#2571).


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
TestPrograms built and ran each testdata program inside a single subtest while holding a mutex, so each of the 20 programs was built one at a time (~11 s total). Building is CPU/IO bound and independent between the programs, so serializing it only wastes wall time.

Build all the programs in parallel first, then run the subtests one by one as before (#2571).