### PR TITLE
exp/vmhost: return an error on out-of-range draw data

### DIFF
--- a/exp/vmhost/render.go
+++ b/exp/vmhost/render.go
@@ -180,16 +180,23 @@ func (f *frameRenderer) renderOne(c vmprotocol.GraphicsCommand) error {
 		// rebased to a zero origin.
 		offset := c.IndexOffset
 		for _, dr := range c.DstRegions {
-			idx := f.indices[offset : offset+dr.IndexCount]
-			offset += dr.IndexCount
-			if len(idx) == 0 {
+			if dr.IndexCount == 0 {
 				continue
 			}
+			if offset < 0 || offset+dr.IndexCount > len(f.indices) {
+				return fmt.Errorf("vmhost: DrawTriangles references indices out of range")
+			}
+			idx := f.indices[offset : offset+dr.IndexCount]
+			offset += dr.IndexCount
 
 			lo, hi := idx[0], idx[0]
 			for _, i := range idx[1:] {
 				lo = min(lo, i)
 				hi = max(hi, i)
+			}
+
+			if int(hi)*graphics.VertexFloatCount+graphics.VertexFloatCount > len(f.vertices) {
+				return fmt.Errorf("vmhost: DrawTriangles references vertices out of range")
 			}
 
 			f.vtxBuf = append(f.vtxBuf[:0], f.vertices[int(lo)*graphics.VertexFloatCount:(int(hi)+1)*graphics.VertexFloatCount]...)
@@ -207,6 +214,10 @@ func (f *frameRenderer) renderOne(c vmprotocol.GraphicsCommand) error {
 		hi, ok := f.images[c.ImageID]
 		if !ok {
 			return fmt.Errorf("vmhost: WritePixels references unknown image %d", c.ImageID)
+		}
+		if len(c.Pixels) != len(c.Regions) {
+			return fmt.Errorf("vmhost: the number of pixel buffers (%d) does not match the number of regions (%d)",
+				len(c.Pixels), len(c.Regions))
 		}
 		for i := range c.Regions {
 			hi.img.WritePixels(c.Pixels[i], c.Regions[i])

--- a/exp/vmhost/render_internal_test.go
+++ b/exp/vmhost/render_internal_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vmhost
+
+import (
+	"image"
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2/internal/graphics"
+	"github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver"
+	"github.com/hajimehoshi/ebiten/v2/internal/vmprotocol"
+)
+
+func TestRenderDrawTrianglesIndexOutOfRange(t *testing.T) {
+	renderer := newFrameRenderer()
+	renderer.images[1] = &hostImage{}
+	renderer.shaders[1] = &hostShader{}
+	renderer.vertices = make([]float32, 3*graphics.VertexFloatCount)
+	renderer.indices = []uint32{0, 1, 2}
+
+	cmd := vmprotocol.GraphicsCommand{
+		Kind:        vmprotocol.GraphicsCommandKindDrawTriangles,
+		Dst:         1,
+		ShaderID:    1,
+		IndexOffset: 2,
+		DstRegions: []graphicsdriver.DstRegion{
+			{Region: image.Rect(0, 0, 1, 1), IndexCount: 2},
+		},
+		Uniforms: make([]uint32, graphics.PreservedUniformDwordCount),
+	}
+	if err := renderer.renderOne(cmd); err == nil {
+		t.Errorf("DrawTriangles with an out-of-range index must return an error")
+	}
+
+	cmd.IndexOffset = 0
+	cmd.DstRegions = []graphicsdriver.DstRegion{
+		{Region: image.Rect(0, 0, 1, 1), IndexCount: 1},
+	}
+	renderer.indices = []uint32{3}
+	if err := renderer.renderOne(cmd); err == nil {
+		t.Errorf("DrawTriangles with an out-of-range vertex must return an error")
+	}
+}
+
+func TestRenderWritePixelsMismatchedRegions(t *testing.T) {
+	renderer := newFrameRenderer()
+	renderer.images[1] = &hostImage{}
+
+	cmd := vmprotocol.GraphicsCommand{
+		Kind:    vmprotocol.GraphicsCommandKindWritePixels,
+		ImageID: 1,
+		Regions: []image.Rectangle{
+			image.Rect(0, 0, 1, 1),
+			image.Rect(0, 0, 1, 1),
+		},
+		Pixels: [][]byte{
+			make([]byte, 4),
+		},
+	}
+	if err := renderer.renderOne(cmd); err == nil {
+		t.Errorf("WritePixels with mismatched regions and pixels must return an error")
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
renderOne replayed guest-recorded indices, vertices, and pixel buffers without checking their bounds, so a misbehaving guest could panic the host. Validate them and return an error like the other reference checks.
