### PR TITLE
internal/ui: queue browser key events and stamp them when read

### DIFF
--- a/internal/ui/input_js.go
+++ b/internal/ui/input_js.go
@@ -96,38 +96,95 @@ func eventToKeys(e js.Value) (key0, key1 Key) {
 	return -1, -1
 }
 
+// An inputButtonEvent is a key or mouse-button state change reported by a browser event handler,
+// queued without a timestamp.
+//
+// A browser fires its event handlers on its own event loop, so an event can arrive at any moment —
+// even after the game loop has already read the input snapshot for the current tick. Stamping such
+// an event with the live tick would attribute its edge to a tick that was already sampled, so a key
+// pressed and released between two samples would go unnoticed (#3317). The handlers queue the event
+// here and (*UserInterface).applyInputEvents stamps it with InputTime when the game loop drains the
+// queue, so the edge is always attributed to the tick that observes it.
+type inputButtonEvent struct {
+	key     Key
+	button  MouseButton
+	pressed bool
+
+	// isKey distinguishes a key event (key) from a mouse-button event (button).
+	isKey bool
+}
+
+func (u *UserInterface) enqueueKeys(key0, key1 Key, pressed bool) {
+	if key0 < 0 && key1 < 0 {
+		return
+	}
+	u.inputMu.Lock()
+	defer u.inputMu.Unlock()
+	if key0 >= 0 {
+		u.inputEvents = append(u.inputEvents, inputButtonEvent{key: key0, pressed: pressed, isKey: true})
+	}
+	if key1 >= 0 {
+		u.inputEvents = append(u.inputEvents, inputButtonEvent{key: key1, pressed: pressed, isKey: true})
+	}
+}
+
+func (u *UserInterface) enqueueMouseButton(button MouseButton, pressed bool) {
+	if button < 0 || MouseButtonMax < button {
+		return
+	}
+	u.inputMu.Lock()
+	defer u.inputMu.Unlock()
+	u.inputEvents = append(u.inputEvents, inputButtonEvent{button: button, pressed: pressed})
+}
+
 func (u *UserInterface) keyDown(event js.Value) {
 	// Ignore key repeats for now.
 	if event.Get("repeat").Bool() {
 		return
 	}
-	now := u.InputTime()
 	key0, key1 := eventToKeys(event)
-	if key0 >= 0 {
-		u.inputState.setKeyPressed(key0, now)
-	}
-	if key1 >= 0 {
-		u.inputState.setKeyPressed(key1, now)
-	}
+	u.enqueueKeys(key0, key1, true)
 }
 
 func (u *UserInterface) keyUp(event js.Value) {
-	now := u.InputTime()
 	key0, key1 := eventToKeys(event)
-	if key0 >= 0 {
-		u.inputState.setKeyReleased(key0, now)
-	}
-	if key1 >= 0 {
-		u.inputState.setKeyReleased(key1, now)
-	}
+	u.enqueueKeys(key0, key1, false)
 }
 
 func (u *UserInterface) mouseDown(code int) {
-	u.inputState.setMouseButtonPressed(codeToMouseButton[code], u.InputTime())
+	u.enqueueMouseButton(codeToMouseButton[code], true)
 }
 
 func (u *UserInterface) mouseUp(code int) {
-	u.inputState.setMouseButtonReleased(codeToMouseButton[code], u.InputTime())
+	u.enqueueMouseButton(codeToMouseButton[code], false)
+}
+
+// applyInputEvents folds the queued key and mouse-button events into the input state, stamping each
+// with the current input time so the edge belongs to the tick that reads it (#3317). The caller must
+// hold inputMu.
+func (u *UserInterface) applyInputEvents() {
+	for _, e := range u.inputEvents {
+		t := u.InputTime()
+		if e.isKey {
+			if e.pressed {
+				u.inputState.setKeyPressed(e.key, t)
+			} else {
+				u.inputState.setKeyReleased(e.key, t)
+			}
+			continue
+		}
+		if e.pressed {
+			u.inputState.setMouseButtonPressed(e.button, t)
+		} else {
+			u.inputState.setMouseButtonReleased(e.button, t)
+		}
+	}
+	u.inputEvents = u.inputEvents[:0]
+
+	if u.releaseAllPending {
+		u.inputState.releaseAllButtons(u.InputTime())
+		u.releaseAllPending = false
+	}
 }
 
 func (u *UserInterface) updateInputFromEvent(e js.Value) error {
@@ -137,9 +194,11 @@ func (u *UserInterface) updateInputFromEvent(e js.Value) error {
 	switch {
 	case t.Equal(stringKeydown):
 		if str := e.Get("key").String(); isKeyString(str) {
+			u.inputMu.Lock()
 			for _, r := range str {
 				u.inputState.appendRune(r)
 			}
+			u.inputMu.Unlock()
 		}
 		u.keyDown(e)
 	case t.Equal(stringKeyup):
@@ -154,8 +213,12 @@ func (u *UserInterface) updateInputFromEvent(e js.Value) error {
 		u.setMouseCursorFromEvent(e)
 	case t.Equal(stringWheel):
 		// TODO: What if e.deltaMode is not DOM_DELTA_PIXEL?
-		u.inputState.WheelX += -e.Get("deltaX").Float()
-		u.inputState.WheelY += -e.Get("deltaY").Float()
+		dx := -e.Get("deltaX").Float()
+		dy := -e.Get("deltaY").Float()
+		u.inputMu.Lock()
+		u.inputState.WheelX += dx
+		u.inputState.WheelY += dy
+		u.inputMu.Unlock()
 	case t.Equal(stringTouchstart) || t.Equal(stringTouchend) || t.Equal(stringTouchmove):
 		u.updateTouchesFromEvent(e)
 	}
@@ -165,8 +228,12 @@ func (u *UserInterface) updateInputFromEvent(e js.Value) error {
 	switch {
 	case t.Equal(stringKeydown), t.Equal(stringKeyup), t.Equal(stringMousedown), t.Equal(stringMouseup),
 		t.Equal(stringMousemove), t.Equal(stringWheel):
-		u.inputState.CapsLock = NewLockKeyStateFromBool(e.Call("getModifierState", stringCapsLock).Bool())
-		u.inputState.NumLock = NewLockKeyStateFromBool(e.Call("getModifierState", stringNumLock).Bool())
+		capsLock := NewLockKeyStateFromBool(e.Call("getModifierState", stringCapsLock).Bool())
+		numLock := NewLockKeyStateFromBool(e.Call("getModifierState", stringNumLock).Bool())
+		u.inputMu.Lock()
+		u.inputState.CapsLock = capsLock
+		u.inputState.NumLock = numLock
+		u.inputMu.Unlock()
 	}
 
 	u.forceUpdateOnMinimumFPSMode()
@@ -177,6 +244,9 @@ func (u *UserInterface) setMouseCursorFromEvent(e js.Value) {
 	if u.context == nil {
 		return
 	}
+
+	u.inputMu.Lock()
+	defer u.inputMu.Unlock()
 
 	u.origCursorXInClient = e.Get("clientX").Float()
 	u.origCursorYInClient = e.Get("clientY").Float()
@@ -192,11 +262,16 @@ func (u *UserInterface) setMouseCursorFromEvent(e js.Value) {
 }
 
 func (u *UserInterface) recoverCursorPosition() {
+	u.inputMu.Lock()
+	defer u.inputMu.Unlock()
 	u.cursorXInClient = u.origCursorXInClient
 	u.cursorYInClient = u.origCursorYInClient
 }
 
 func (u *UserInterface) updateTouchesFromEvent(e js.Value) {
+	u.inputMu.Lock()
+	defer u.inputMu.Unlock()
+
 	u.touchesInClient = u.touchesInClient[:0]
 
 	touches := e.Get("targetTouches")
@@ -300,15 +375,24 @@ func (u *UserInterface) UpdateInputFromEvent(e js.Value) {
 }
 
 func (u *UserInterface) saveCursorPosition() {
+	w, h := u.outsideSize()
+
+	u.inputMu.Lock()
+	defer u.inputMu.Unlock()
+
 	u.savedCursorX = u.inputState.CursorX
 	u.savedCursorY = u.inputState.CursorY
-	w, h := u.outsideSize()
 	u.savedOutsideWidth = w
 	u.savedOutsideHeight = h
 }
 
 func (u *UserInterface) updateInputStateForFrame(deviceScaleFactor float64) error {
 	s := deviceScaleFactor
+
+	// cursorXInClient and touchesInClient are written by the browser's mouse and touch handlers, so
+	// read and reset them under inputMu.
+	u.inputMu.Lock()
+	defer u.inputMu.Unlock()
 
 	if !math.IsNaN(u.savedCursorX) && !math.IsNaN(u.savedCursorY) {
 		// If savedCursorX and savedCursorY are valid values, the cursor is saved just before entering or exiting from fullscreen.

--- a/internal/ui/input_js_test.go
+++ b/internal/ui/input_js_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build js && wasm
+
+package ui
+
+import (
+	"testing"
+)
+
+// TestQueuedKeyEventsAreStampedAtDrain verifies that a key pressed and released while the game loop
+// is not reading the input is folded into the input state with the tick that drains it, so the press
+// is observed by the tick that reads it and not lost to a stale tick (#3317).
+func TestQueuedKeyEventsAreStampedAtDrain(t *testing.T) {
+	u := &UserInterface{}
+
+	// A tick boundary passes while the browser delivers a full tap (down then up) of Key A.
+	u.incrementTick()
+	u.enqueueKeys(KeyA, -1, true)
+	u.enqueueKeys(KeyA, -1, false)
+
+	// The game loop reads: drain the queue into the input state and snapshot it, as readInputState does.
+	var snap InputState
+	u.inputMu.Lock()
+	u.applyInputEvents()
+	u.inputState.copyAndReset(&snap)
+	u.inputMu.Unlock()
+
+	now := u.Tick()
+	if got, want := snap.IsKeyJustPressed(KeyA, now), true; got != want {
+		t.Errorf("just pressed in the draining tick: got: %v, want: %v", got, want)
+	}
+	if got, want := snap.IsKeyPressed(KeyA, now), true; got != want {
+		t.Errorf("pressed in the draining tick: got: %v, want: %v", got, want)
+	}
+
+	// In the next tick the tap is over: the press and release were both stamped with the previous tick.
+	u.inputMu.Lock()
+	pressed := u.inputState.IsKeyPressed(KeyA, u.Tick()+1)
+	justPressed := u.inputState.IsKeyJustPressed(KeyA, u.Tick()+1)
+	u.inputMu.Unlock()
+	if pressed {
+		t.Errorf("still pressed in the next tick")
+	}
+	if justPressed {
+		t.Errorf("still just pressed in the next tick")
+	}
+}
+
+// TestQueuedKeyEventsAreAppliedInOrder verifies that the queued events keep their order, so a release
+// that precedes a later press of the same key does not cancel the press (#3317).
+func TestQueuedKeyEventsAreAppliedInOrder(t *testing.T) {
+	u := &UserInterface{}
+
+	// A tap followed by a held press, all delivered between two reads. The release must not end the
+	// press because the press comes after it.
+	u.incrementTick()
+	u.enqueueKeys(KeyA, -1, true)
+	u.enqueueKeys(KeyA, -1, false)
+	u.enqueueKeys(KeyA, -1, true)
+
+	u.inputMu.Lock()
+	u.applyInputEvents()
+	var snap InputState
+	u.inputState.copyAndReset(&snap)
+	u.inputMu.Unlock()
+
+	now := u.Tick()
+	if got, want := snap.IsKeyPressed(KeyA, now), true; got != want {
+		t.Errorf("held press after a release: got: %v, want: %v", got, want)
+	}
+	if got, want := snap.IsKeyJustPressed(KeyA, now), true; got != want {
+		t.Errorf("last event was a press: got: %v, want: %v", got, want)
+	}
+}

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -223,6 +223,34 @@ func TestNonModifierKeyReleasedInTick(t *testing.T) {
 	}
 }
 
+// TestKeyPressedAndReleasedInSameTick tests that a key pressed and released within one tick — as the
+// browser delivers it when the press and the release both land between two input reads — is still
+// observed by the read that stamps it (#3317).
+func TestKeyPressedAndReleasedInSameTick(t *testing.T) {
+	const baseTick = 100
+	var inputState ui.InputState
+
+	// Both events are stamped with the tick that will read them, as the browsers do by folding the
+	// queued events in at read time with the current input time.
+	inputState.SetKeyPressed(ui.KeyA, ui.NewInputTimeFromTick(baseTick)+1)
+	inputState.SetKeyReleased(ui.KeyA, ui.NewInputTimeFromTick(baseTick)+2)
+
+	if got, want := inputState.IsKeyJustPressed(ui.KeyA, baseTick), true; got != want {
+		t.Errorf("just pressed: got: %v, want: %v", got, want)
+	}
+	if got, want := inputState.IsKeyPressed(ui.KeyA, baseTick), true; got != want {
+		t.Errorf("pressed: got: %v, want: %v", got, want)
+	}
+
+	// The press is gone once the tick has passed.
+	if got, want := inputState.IsKeyPressed(ui.KeyA, baseTick+1), false; got != want {
+		t.Errorf("pressed in the next tick: got: %v, want: %v", got, want)
+	}
+	if got, want := inputState.IsKeyJustPressed(ui.KeyA, baseTick+1), false; got != want {
+		t.Errorf("just pressed in the next tick: got: %v, want: %v", got, want)
+	}
+}
+
 // TestLockKeyStates tests that a lock key state a platform does not report falls back to Caps Lock
 // off and Num Lock on.
 func TestLockKeyStates(t *testing.T) {

--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -108,6 +108,21 @@ type userInterfaceImpl struct {
 	origCursorYInClient float64
 	touchesInClient     []touchInClient
 
+	// inputMu guards inputState and the input buffers written by the browser's event handlers
+	// (cursorXInClient, touchesInClient, ...) against the game goroutine, which reads them once per
+	// tick. Unlike GLFW, a browser fires these handlers on its own event loop rather than from a
+	// poll the game loop drives, so they run concurrently with the loop rather than inside it.
+	inputMu sync.Mutex
+
+	// inputEvents holds the key and mouse-button state changes reported by the event handlers but
+	// not yet folded into inputState. They are stamped with InputTime only when the game loop drains
+	// them (#3317).
+	inputEvents []inputButtonEvent
+
+	// releaseAllPending reports that the canvas lost focus and every held key and button should be
+	// released when the queued events are next applied.
+	releaseAllPending bool
+
 	savedCursorX              float64
 	savedCursorY              float64
 	savedOutsideWidth         float64
@@ -747,7 +762,10 @@ func (u *UserInterface) setCanvasEventHandlers(v js.Value) {
 
 	// Blur
 	v.Call("addEventListener", "blur", js.FuncOf(func(this js.Value, args []js.Value) any {
-		u.inputState.releaseAllButtons(u.InputTime())
+		u.inputMu.Lock()
+		u.releaseAllPending = true
+		u.inputMu.Unlock()
+		u.forceUpdateOnMinimumFPSMode()
 		return nil
 	}))
 }
@@ -771,7 +789,9 @@ func (u *UserInterface) appendDroppedFiles(data js.Value) {
 			u.setError(err)
 			return
 		}
+		u.inputMu.Lock()
 		u.inputState.DroppedFiles = fs
+		u.inputMu.Unlock()
 	}
 }
 
@@ -863,6 +883,12 @@ func (u *UserInterface) updateScreenSize() {
 }
 
 func (u *UserInterface) readInputState(inputState *InputState) {
+	u.inputMu.Lock()
+	defer u.inputMu.Unlock()
+	// Fold the events the browser delivered since the last read into the input state before
+	// snapshotting, so each press/release edge is stamped with this tick — the tick that reads it
+	// (#3317).
+	u.applyInputEvents()
 	u.inputState.copyAndReset(inputState)
 	u.keyboardLayoutMap = js.Value{}
 }


### PR DESCRIPTION
# What issue is this addressing?
#3317

## What _type_ of issue is this addressing?
feature

## What this PR does | solves
A browser fires its keyboard and mouse handlers on its own event loop, so an event can arrive at any moment — even after the game loop has already read the input snapshot for the current tick. The handlers stamped such an event with the live tick, which attributed its press and release edges to a tick that had already been sampled, so a key pressed and released between two samples went unnoticed. Pressing keys fast made this frequent on the wasm browser build (#3317).

Queue the key and mouse-button state changes without a timestamp and fold them into the input state with the current input time when the game loop reads it, so an edge is always attributed to the tick that observes it. The GLFW and mobile backends already serialize the input state with a lock; the browser path wrote it unsynchronized, so guard it with an input mutex now, covering the queued events and the buffers the handlers also touch (runes, wheel, lock keys, cursor and touches). Defer the focus-loss release to the game loop as well.

Add a regression test for a press and release delivered within one tick, plus a wasm test for the queue.
