### PR TITLE
internal/ui: ignore unknown mouse button codes on browsers

### DIFF
--- a/internal/ui/input_js.go
+++ b/internal/ui/input_js.go
@@ -123,11 +123,19 @@ func (u *UserInterface) keyUp(event js.Value) {
 }
 
 func (u *UserInterface) mouseDown(code int) {
-	u.inputState.setMouseButtonPressed(codeToMouseButton[code], u.InputTime())
+	b, ok := codeToMouseButton[code]
+	if !ok {
+		return
+	}
+	u.inputState.setMouseButtonPressed(b, u.InputTime())
 }
 
 func (u *UserInterface) mouseUp(code int) {
-	u.inputState.setMouseButtonReleased(codeToMouseButton[code], u.InputTime())
+	b, ok := codeToMouseButton[code]
+	if !ok {
+		return
+	}
+	u.inputState.setMouseButtonReleased(b, u.InputTime())
 }
 
 func (u *UserInterface) updateInputFromEvent(e js.Value) error {


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
codeToMouseButton maps a MouseEvent.button value to an Ebitengine MouseButton. An unknown code (e.g. an auxiliary button or an out-of-spec value) was looked up with a missing-key access, which returned the zero value MouseButton0 (left button). The glfw backend guards the equivalent lookup with an ok check; do the same for js.
