### PR TITLE
internal/gamepad: write the JS gamepad value under the per-gamepad lock

### DIFF
--- a/internal/gamepad/gamepad_js.go
+++ b/internal/gamepad/gamepad_js.go
@@ -94,7 +94,9 @@ func (g *nativeGamepadsImpl) update(gamepads *gamepads) error {
 				mapping: gp.Get("mapping").String(),
 			}
 		}
+		gamepad.m.Lock()
 		gamepad.native.(*nativeGamepadImpl).value = gp
+		gamepad.m.Unlock()
 	}
 
 	// Remove an unused gamepads.


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
nativeGamepadImpl.value is read by Gamepad.Axis, Button, and similar methods under g.m. The JS backend wrote it under theGamepads.m only, so a user goroutine calling Axis while the frame loop runs update raced on the js.Value. Take g.m on the write side as desktop backends do.