### PR TITLE
internal/gamepad: reject a negative virtual gamepad ID

### DIFF
--- a/internal/gamepad/gamepad_virtual.go
+++ b/internal/gamepad/gamepad_virtual.go
@@ -88,6 +88,9 @@ func (g *gamepads) appendVirtualVibrations(dst []VirtualGamepadVibration) []Virt
 func (g *gamepads) setVirtualGamepads(states []VirtualGamepadState) {
 	maxID := -1
 	for i := range states {
+		if states[i].ID < 0 {
+			continue
+		}
 		maxID = max(maxID, int(states[i].ID))
 	}
 	for len(g.gamepads) <= maxID {
@@ -97,6 +100,9 @@ func (g *gamepads) setVirtualGamepads(states []VirtualGamepadState) {
 	// Connect or update every gamepad in the snapshot at its own ID.
 	for i := range states {
 		s := &states[i]
+		if s.ID < 0 {
+			continue
+		}
 		gp := g.gamepads[s.ID]
 		if gp == nil || !gp.virtual {
 			gp = &Gamepad{

--- a/internal/gamepad/gamepad_virtual_test.go
+++ b/internal/gamepad/gamepad_virtual_test.go
@@ -294,3 +294,14 @@ func TestVirtualGamepadCopiesState(t *testing.T) {
 		t.Errorf("StandardAxisValue(LeftStickHorizontal) = %v; want %v (input mutation leaked)", got, want)
 	}
 }
+
+func TestVirtualGamepadNegativeID(t *testing.T) {
+	updateVirtualGamepads(t, []gamepad.VirtualGamepadState{
+		{ID: -1, SDLID: "neg", Name: "Negative"},
+	})
+	defer updateVirtualGamepads(t, []gamepad.VirtualGamepadState{})
+
+	if got := gamepadIDs(); len(got) != 0 {
+		t.Errorf("gamepad IDs = %v; want none for a negative ID", got)
+	}
+}

--- a/internal/gamepad/gamepad_virtual_test.go
+++ b/internal/gamepad/gamepad_virtual_test.go
@@ -296,12 +296,22 @@ func TestVirtualGamepadCopiesState(t *testing.T) {
 }
 
 func TestVirtualGamepadNegativeID(t *testing.T) {
+	const sdlID = "00000000000000000000000000000000"
 	updateVirtualGamepads(t, []gamepad.VirtualGamepadState{
-		{ID: -1, SDLID: "neg", Name: "Negative"},
+		{
+			ID:    -1,
+			SDLID: sdlID,
+			Name:  "Negative",
+		},
+		{
+			ID:    0,
+			SDLID: sdlID,
+			Name:  "Valid",
+		},
 	})
 	defer updateVirtualGamepads(t, []gamepad.VirtualGamepadState{})
 
-	if got := gamepadIDs(); len(got) != 0 {
-		t.Errorf("gamepad IDs = %v; want none for a negative ID", got)
+	if got, want := gamepadIDs(), []gamepad.ID{0}; !slices.Equal(got, want) {
+		t.Errorf("gamepad IDs = %v; want %v (a negative ID is ignored)", got, want)
 	}
 }


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
setVirtualGamepads indexed the gamepad slice with the user-supplied ID without checking that it is non-negative. A negative ID caused an index out of range panic. The exported Get method already guards against this; apply the same check to the slice indexing in setVirtualGamepads.