### PR TITLE
internal/buffered: do not use the pixel cache for a whole-region read

### DIFF
--- a/exp/vmhost/render.go
+++ b/exp/vmhost/render.go
@@ -261,7 +261,7 @@ func (f *frameRenderer) readPixels(pixels [][]byte, id graphicsdriver.ImageID, r
 		return fmt.Errorf("vmhost: ReadPixels references unknown image %d", id)
 	}
 	for i, r := range regions {
-		hi.img.ReadPixels(pixels[i], r)
+		hi.img.ReadPixels(pixels[i], r, true)
 	}
 	return nil
 }

--- a/image.go
+++ b/image.go
@@ -1262,7 +1262,9 @@ func (i *Image) ReadPixels(pixels []byte) {
 
 	i.invokeUsageCallbacks()
 
-	i.image.ReadPixels(pixels, i.adjustedBounds())
+	// ReadPixels reads a whole region at once, so the pixel cache is not used to avoid keeping a
+	// second copy of the pixels (see #3208).
+	i.image.ReadPixels(pixels, i.adjustedBounds(), false)
 }
 
 // At returns the color of the image at (x, y).
@@ -1310,7 +1312,8 @@ func (i *Image) at(x, y int) (r, g, b, a byte) {
 
 	x, y = i.adjustPosition(x, y)
 	var pix [4]byte
-	i.image.ReadPixels(pix[:], image.Rect(x, y, x+1, y+1))
+	// At reads a single pixel and repeated reads are expected, so the pixel cache is used.
+	i.image.ReadPixels(pix[:], image.Rect(x, y, x+1, y+1), true)
 	return pix[0], pix[1], pix[2], pix[3]
 }
 

--- a/internal/buffered/image.go
+++ b/internal/buffered/image.go
@@ -58,7 +58,15 @@ func (i *Image) Deallocate() {
 	i.cache.deallocate()
 }
 
-func (i *Image) ReadPixels(graphicsDriver graphicsdriver.Graphics, pixels []byte, region image.Rectangle) (bool, error) {
+// ReadPixels reads the pixels in region into pixels.
+//
+// If useCache is false, the pixels are read from the GPU directly into pixels without consulting or
+// populating the pixel cache. This avoids keeping a second copy of the pixels and is used when a whole
+// region is read at once, as ebiten.Image.ReadPixels does.
+func (i *Image) ReadPixels(graphicsDriver graphicsdriver.Graphics, pixels []byte, region image.Rectangle, useCache bool) (bool, error) {
+	if !useCache {
+		return i.cache.readPixelsDirectly(i.img, graphicsDriver, pixels, region)
+	}
 	return i.cache.readPixels(i.img, graphicsDriver, pixels, region)
 }
 

--- a/internal/buffered/image_test.go
+++ b/internal/buffered/image_test.go
@@ -31,6 +31,65 @@ func TestMain(m *testing.M) {
 	t.MainWithRunLoop(m)
 }
 
+func TestReadPixelsWithoutCache(t *testing.T) {
+	const size = 16
+	img := buffered.NewImage(size, size, atlas.ImageTypeRegular)
+
+	// Write a 2x2 block to the GPU directly.
+	pix := make([]byte, 4*2*2)
+	for i := range pix {
+		pix[i] = 0x40
+	}
+	img.WritePixels(pix, image.Rect(2, 2, 4, 4))
+
+	// Add a pending write to the dots buffer.
+	img.WritePixels([]byte{0xff, 0xff, 0xff, 0xff}, image.Rect(3, 3, 4, 4))
+
+	want := make([]byte, 4*size*size)
+	for y := 2; y < 4; y++ {
+		for x := 2; x < 4; x++ {
+			v := byte(0x40)
+			if x == 3 && y == 3 {
+				v = 0xff
+			}
+			idx := 4 * (y*size + x)
+			for i := range 4 {
+				want[idx+i] = v
+			}
+		}
+	}
+
+	// Read the whole region without the cache: the pending writes must be applied to the result,
+	// and no tile must be cached.
+	got := make([]byte, 4*size*size)
+	ok, err := img.ReadPixels(ui.Get().GraphicsDriverForTesting(), got, image.Rect(0, 0, size, size), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ReadPixels failed")
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+	if got := img.CachedPixelsSizeForTesting(); got != 0 {
+		t.Errorf("cached pixels size: got: %d, want: 0", got)
+	}
+
+	// Reading a single pixel keeps using the cache.
+	var dot [4]byte
+	ok, err = img.ReadPixels(ui.Get().GraphicsDriverForTesting(), dot[:], image.Rect(0, 0, 1, 1), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ReadPixels failed")
+	}
+	if got, want := img.CachedPixelsSizeForTesting(), 4*size*size; got != want {
+		t.Errorf("cached pixels size: got: %d, want: %d", got, want)
+	}
+}
+
 func TestUnsyncedPixels(t *testing.T) {
 	dst := buffered.NewImage(16, 16, atlas.ImageTypeRegular)
 
@@ -39,7 +98,7 @@ func TestUnsyncedPixels(t *testing.T) {
 
 	// Merge the entry into the cached pixels.
 	// The entry for dots is now gone in the current implementation.
-	ok, err := dst.ReadPixels(ui.Get().GraphicsDriverForTesting(), make([]byte, 4*16*16), image.Rect(0, 0, 16, 16))
+	ok, err := dst.ReadPixels(ui.Get().GraphicsDriverForTesting(), make([]byte, 4*16*16), image.Rect(0, 0, 16, 16), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +120,7 @@ func TestUnsyncedPixels(t *testing.T) {
 
 	// Check the result is correct.
 	var got [4]byte
-	ok, err = dst.ReadPixels(ui.Get().GraphicsDriverForTesting(), got[:], image.Rect(0, 0, 1, 1))
+	ok, err = dst.ReadPixels(ui.Get().GraphicsDriverForTesting(), got[:], image.Rect(0, 0, 1, 1), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +164,7 @@ func TestReadPixelsOnLargeImage(t *testing.T) {
 	// Read the same region twice. The entry for dots must be applied to the result both times.
 	for range 2 {
 		got := make([]byte, 4*4*4)
-		ok, err := img.ReadPixels(ui.Get().GraphicsDriverForTesting(), got, image.Rect(1, 1, 5, 5))
+		ok, err := img.ReadPixels(ui.Get().GraphicsDriverForTesting(), got, image.Rect(1, 1, 5, 5), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -140,7 +199,7 @@ func TestReadPixelsOnLargeImageAcrossTiles(t *testing.T) {
 
 	// Reading one pixel caches only the tile containing it.
 	var dot [4]byte
-	ok, err := img.ReadPixels(ui.Get().GraphicsDriverForTesting(), dot[:], image.Rect(0, 0, 1, 1))
+	ok, err := img.ReadPixels(ui.Get().GraphicsDriverForTesting(), dot[:], image.Rect(0, 0, 1, 1), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +230,7 @@ func TestReadPixelsOnLargeImageAcrossTiles(t *testing.T) {
 	// Read the same region twice. The entry for dots must be applied to the result both times.
 	for range 2 {
 		got := make([]byte, 4*8*8)
-		ok, err := img.ReadPixels(ui.Get().GraphicsDriverForTesting(), got, image.Rect(252, 252, 260, 260))
+		ok, err := img.ReadPixels(ui.Get().GraphicsDriverForTesting(), got, image.Rect(252, 252, 260, 260), true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/buffered/pixelcache.go
+++ b/internal/buffered/pixelcache.go
@@ -86,6 +86,17 @@ func (c *pixelCache) tileRegion(idx image.Point) image.Rectangle {
 	return r.Intersect(image.Rect(0, 0, c.width, c.height))
 }
 
+// readPixelsDirectly reads the pixels in region from the GPU directly into pixels, without consulting
+// or populating the cache.
+// The pending writes in the dots buffer and in the cached tiles must be applied to the GPU before reading.
+// Unlike readPixels, this does not keep a second copy of the pixels, which is suitable for reading a whole
+// region at once as ebiten.Image.ReadPixels does.
+func (c *pixelCache) readPixelsDirectly(img *atlas.Image, graphicsDriver graphicsdriver.Graphics, pixels []byte, region image.Rectangle) (bool, error) {
+	// The pending writes are the primary data, so they have to be applied to the GPU first.
+	c.writeBackPixelsIfNeeded(img)
+	return img.ReadPixels(graphicsDriver, pixels, region)
+}
+
 // readPixels reads the pixels in region into pixels, loading the tiles intersecting region as needed.
 func (c *pixelCache) readPixels(img *atlas.Image, graphicsDriver graphicsdriver.Graphics, pixels []byte, region image.Rectangle) (bool, error) {
 	if region.Dx() == 1 && region.Dy() == 1 {

--- a/internal/mipmap/mipmap.go
+++ b/internal/mipmap/mipmap.go
@@ -73,8 +73,8 @@ func (m *Mipmap) markDirty() {
 	}
 }
 
-func (m *Mipmap) ReadPixels(graphicsDriver graphicsdriver.Graphics, pixels []byte, region image.Rectangle) (ok bool, err error) {
-	return m.orig.ReadPixels(graphicsDriver, pixels, region)
+func (m *Mipmap) ReadPixels(graphicsDriver graphicsdriver.Graphics, pixels []byte, region image.Rectangle, useCache bool) (ok bool, err error) {
+	return m.orig.ReadPixels(graphicsDriver, pixels, region, useCache)
 }
 
 func (m *Mipmap) DrawTriangles(srcs [graphics.ShaderSrcImageCount]*Mipmap, vertices []float32, indices []uint32, blend graphicsdriver.Blend, dstRegion image.Rectangle, srcRegions [graphics.ShaderSrcImageCount]image.Rectangle, shader *atlas.Shader, uniforms []uint32, canSkipMipmap bool) {

--- a/internal/ui/image.go
+++ b/internal/ui/image.go
@@ -183,13 +183,13 @@ func (i *Image) WritePixels(pix []byte, region image.Rectangle) {
 	i.mipmap.WritePixels(pix, region)
 }
 
-func (i *Image) ReadPixels(pixels []byte, region image.Rectangle) {
+func (i *Image) ReadPixels(pixels []byte, region image.Rectangle, useCache bool) {
 	// Check the error existence and avoid unnecessary calls.
 	if i.ui.error() != nil {
 		return
 	}
 
-	if err := i.ui.readPixels(i, pixels, region); err != nil {
+	if err := i.ui.readPixels(i, pixels, region, useCache); err != nil {
 		if panicOnErrorOnReadingPixels {
 			panic(err)
 		}
@@ -201,11 +201,11 @@ func (i *Image) ReadPixels(pixels []byte, region image.Rectangle) {
 //
 // The caller must not hold the mutex: a failed read is retried in a frame, and the frame needs the
 // mutex to draw the image.
-func (i *Image) readPixels(pixels []byte, region image.Rectangle) (bool, error) {
+func (i *Image) readPixels(pixels []byte, region image.Rectangle, useCache bool) (bool, error) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
-	return i.mipmap.ReadPixels(i.ui.graphicsDriver, pixels, region)
+	return i.mipmap.ReadPixels(i.ui.graphicsDriver, pixels, region, useCache)
 }
 
 func (i *Image) DumpScreenshot(name string, blackbg bool) (string, error) {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -161,12 +161,12 @@ func newUserInterface() (*UserInterface, error) {
 	return u, nil
 }
 
-func (u *UserInterface) readPixels(img *Image, pixels []byte, region image.Rectangle) error {
+func (u *UserInterface) readPixels(img *Image, pixels []byte, region image.Rectangle, useCache bool) error {
 	if !u.running.Load() {
 		panic("ui: ReadPixels cannot be called before the game starts")
 	}
 
-	ok, err := img.readPixels(pixels, region)
+	ok, err := img.readPixels(pixels, region, useCache)
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func (u *UserInterface) readPixels(img *Image, pixels []byte, region image.Recta
 
 		var err error
 		u.context.runInFrame(func() {
-			ok, imgErr := img.readPixels(pixels, region)
+			ok, imgErr := img.readPixels(pixels, region, useCache)
 			if imgErr != nil {
 				err = imgErr
 				return


### PR DESCRIPTION
# What issue is this addressing?
#3208 

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
ebiten.Image.ReadPixels reads a whole region at once, so copying the pixels into the CPU-side pixel cache is wasteful: the pixels are copied twice (GPU to cache, then cache to the caller's buffer) and the extra copy is kept until the image is drawn to or deallocated.

Add a useCache flag threaded from ebiten.Image.ReadPixels down to internal/buffered. When false, the pixels are read from the GPU directly into the caller's buffer without consulting or populating the cache, after writing back the pending writes in the dots buffer and the cached tiles. At keeps using the cache, as repeated one-pixel reads are what the cache is for.

Fixes #3208