### PR TITLE
vector: clamp the Acos arguments in ArcTo and LineJoinMiter

### DIFF
--- a/vector/path.go
+++ b/vector/path.go
@@ -483,8 +483,8 @@ func (p *Path) ArcTo(x1, y1, x2, y2, radius float32) {
 	d0 = d0.norm()
 	d1 = d1.norm()
 
-	// theta is the angle between two vectors d0 and d1.
-	theta := math.Acos(float64(d0.x*d1.x + d0.y*d1.y))
+	dot := min(max(float64(d0.x*d1.x+d0.y*d1.y), -1.0), 1.0)
+	theta := math.Acos(dot)
 	// TODO: When theta is bigger than π/2, the arc should be split into two.
 	if theta == 0 {
 		p.LineTo(x2, y2)

--- a/vector/path.go
+++ b/vector/path.go
@@ -484,6 +484,7 @@ func (p *Path) ArcTo(x1, y1, x2, y2, radius float32) {
 	d1 = d1.norm()
 
 	dot := min(max(float64(d0.x*d1.x+d0.y*d1.y), -1.0), 1.0)
+	// theta is the angle between two vectors d0 and d1.
 	theta := math.Acos(dot)
 	// TODO: When theta is bigger than π/2, the arc should be split into two.
 	if theta == 0 {

--- a/vector/path_test.go
+++ b/vector/path_test.go
@@ -501,6 +501,14 @@ func TestBounds(t *testing.T) {
 			},
 			want: image.Rect(10, 20, 30, 40),
 		},
+		{
+			name: "shallow angle arc",
+			path: func(p *vector.Path) {
+				p.MoveTo(676.47327, 1502.2303)
+				p.ArcTo(257.7812, 1856.779, 1046.7478, 1188.3281, 100)
+			},
+			want: image.Rect(676, 1188, 1047, 1503),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/vector/path_test.go
+++ b/vector/path_test.go
@@ -502,7 +502,7 @@ func TestBounds(t *testing.T) {
 			want: image.Rect(10, 20, 30, 40),
 		},
 		{
-			name: "shallow angle arc",
+			name: "nearly collinear arc",
 			path: func(p *vector.Path) {
 				p.MoveTo(676.47327, 1502.2303)
 				p.ArcTo(257.7812, 1856.779, 1046.7478, 1188.3281, 100)
@@ -522,7 +522,7 @@ func TestBounds(t *testing.T) {
 	}
 }
 
-func TestStrokeMiterJoinShallowAngle(t *testing.T) {
+func TestStrokeMiterJoinNearlyCollinear(t *testing.T) {
 	var p vector.Path
 	p.MoveTo(676.47327, 1502.2303)
 	p.LineTo(257.7812, 1856.779)
@@ -537,10 +537,7 @@ func TestStrokeMiterJoinShallowAngle(t *testing.T) {
 	sp.AddStroke(&p, op)
 
 	got := sp.Bounds()
-	if got.Min.X < 0 || got.Min.Y < 0 {
-		t.Errorf("Bounds().Min = %v; want non-negative (a miter spike must not extend far beyond the path)", got.Min)
-	}
-	if got, want := got.Max, (image.Point{X: 1048, Y: 1858}); got.X > want.X || got.Y > want.Y {
-		t.Errorf("Bounds().Max = %v; want within %v (a miter spike must not extend far beyond the path)", got, want)
+	if got, want := got, image.Rect(257, 1187, 1048, 1858); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
 	}
 }

--- a/vector/path_test.go
+++ b/vector/path_test.go
@@ -521,3 +521,26 @@ func TestBounds(t *testing.T) {
 		})
 	}
 }
+
+func TestStrokeMiterJoinShallowAngle(t *testing.T) {
+	var p vector.Path
+	p.MoveTo(676.47327, 1502.2303)
+	p.LineTo(257.7812, 1856.779)
+	p.LineTo(1046.7478, 1188.3281)
+
+	op := &vector.AddStrokeOptions{}
+	op.StrokeOptions.LineJoin = vector.LineJoinMiter
+	op.StrokeOptions.MiterLimit = 4
+	op.StrokeOptions.Width = 1
+
+	var sp vector.Path
+	sp.AddStroke(&p, op)
+
+	got := sp.Bounds()
+	if got.Min.X < 0 || got.Min.Y < 0 {
+		t.Errorf("Bounds().Min = %v; want non-negative (a miter spike must not extend far beyond the path)", got.Min)
+	}
+	if got, want := got.Max, (image.Point{X: 1048, Y: 1858}); got.X > want.X || got.Y > want.Y {
+		t.Errorf("Bounds().Max = %v; want within %v (a miter spike must not extend far beyond the path)", got, want)
+	}
+}

--- a/vector/stroke.go
+++ b/vector/stroke.go
@@ -397,7 +397,8 @@ func addJoint(strokePath *Path, subPath *subPath, opIndex int, reverse bool, opt
 	// Add a joint.
 	switch options.LineJoin {
 	case LineJoinMiter:
-		theta := math.Acos(float64(dir0.x*(-dir1.x) + dir0.y*(-dir1.y)))
+		dot := min(max(float64(dir0.x*(-dir1.x)+dir0.y*(-dir1.y)), -1.0), 1.0)
+		theta := math.Acos(dot)
 		exceed := float32(math.Abs(1/math.Sin(float64(theta/2)))) > options.MiterLimit
 		if !exceed {
 			cp := crossingPointForTwoLines(p0, p0.add(dir0), p1, p1.add(dir1))


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
ArcTo and the miter join compute angles with math.Acos on float32 dot products of normalized vectors. The dot product can slightly exceed 1.0 due to rounding, making Acos return NaN.

In ArcTo, the NaN propagates into the arcs center and the path silently disappears. In LineJoinMiter, the NaN comparison always reports that the miter limit is not exceeded, so a miter spike can be huge.

Clamp the dot products to [-1, 1] before Acos. Includes the fix from #3604 as requested.