### PR TITLE
vector: clamp the Acos argument in LineJoinMiter

### DIFF
--- a/vector/path_test.go
+++ b/vector/path_test.go
@@ -513,3 +513,26 @@ func TestBounds(t *testing.T) {
 		})
 	}
 }
+
+func TestStrokeMiterJoinShallowAngle(t *testing.T) {
+	var p vector.Path
+	p.MoveTo(676.47327, 1502.2303)
+	p.LineTo(257.7812, 1856.779)
+	p.LineTo(1046.7478, 1188.3281)
+
+	op := &vector.AddStrokeOptions{}
+	op.StrokeOptions.LineJoin = vector.LineJoinMiter
+	op.StrokeOptions.MiterLimit = 4
+	op.StrokeOptions.Width = 1
+
+	var sp vector.Path
+	sp.AddStroke(&p, op)
+
+	got := sp.Bounds()
+	if got.Min.X < 0 || got.Min.Y < 0 {
+		t.Errorf("Bounds().Min = %v; want non-negative (a miter spike must not extend far beyond the path)", got.Min)
+	}
+	if got, want := got.Max, (image.Point{X: 1048, Y: 1858}); got.X > want.X || got.Y > want.Y {
+		t.Errorf("Bounds().Max = %v; want within %v (a miter spike must not extend far beyond the path)", got, want)
+	}
+}

--- a/vector/stroke.go
+++ b/vector/stroke.go
@@ -397,7 +397,8 @@ func addJoint(strokePath *Path, subPath *subPath, opIndex int, reverse bool, opt
 	// Add a joint.
 	switch options.LineJoin {
 	case LineJoinMiter:
-		theta := math.Acos(float64(dir0.x*(-dir1.x) + dir0.y*(-dir1.y)))
+		dot := min(max(float64(dir0.x*(-dir1.x)+dir0.y*(-dir1.y)), -1.0), 1.0)
+		theta := math.Acos(dot)
 		exceed := float32(math.Abs(1/math.Sin(float64(theta/2)))) > options.MiterLimit
 		if !exceed {
 			cp := crossingPointForTwoLines(p0, p0.add(dir0), p1, p1.add(dir1))


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The miter join computes the joint angle with math.Acos on a float32 dot product. For a nearly straight joint the dot product can exceed 1.0 due to rounding, making Acos return NaN. The NaN comparison then always reports that the miter limit is not exceeded, so the miter point is computed for nearly parallel lines and can be a huge spike. Clamp the dot product to [-1, 1] before Acos.