### PR TITLE
exp/textinput: end the platform session on the error paths of Field and Composer

### DIFF
--- a/exp/textinput/field.go
+++ b/exp/textinput/field.go
@@ -253,19 +253,14 @@ func (f *Field) IsFocused() bool {
 func (f *Field) cleanUp() {
 	clearVirtualKeyboardFromUI()
 
-	if f.err != nil {
-		return
-	}
-
-	// If the text field still has a session, read the last state and process it just in case.
-	if f.ch != nil {
+	// If the text field still has a session without a recorded error, read
+	// the last state and process it just in case.
+	if f.err == nil && f.ch != nil {
 		select {
 		case state, ok := <-f.ch:
 			if state.Error != nil {
 				f.err = state.Error
-				return
-			}
-			if ok && state.CommitKind.committed() {
+			} else if ok && state.CommitKind.committed() {
 				f.commit(state)
 			} else {
 				f.state = state
@@ -275,6 +270,8 @@ func (f *Field) cleanUp() {
 		}
 	}
 
+	// The platform holds the session until its end callback runs, even after
+	// the session reported an error, so end the session here.
 	if f.end != nil {
 		f.end()
 		f.ch = nil

--- a/exp/textinput/session.go
+++ b/exp/textinput/session.go
@@ -99,8 +99,8 @@ func (s *session) loadComposition() Composition {
 
 // markClosed transitions s to closed and clears the active-session pointer if
 // it points at s. callPlatformEnd controls whether to invoke the platform end
-// callback; pass false when the platform itself has already ended (channel
-// closed from below).
+// callback, which releases what the platform holds for the session; pass
+// false only when the platform tore the session down by itself.
 func (s *session) markClosed(callPlatformEnd bool) {
 	if s.events.takeEndedByUser() {
 		s.state = sessionStateClosedByUser
@@ -177,7 +177,9 @@ func (s *session) Update() error {
 				return nil
 			}
 			if st.Error != nil {
-				s.markClosed(false)
+				// The platform holds the session even after it reported an
+				// error, so release it here as the commit path does.
+				s.markClosed(true)
 				return st.Error
 			}
 			if st.CommitKind.committed() {


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
When a text input state reported a platform error, the sessions were closed without the platform-side teardown. A backend sends the error and closes the Go-side channel, but it keeps what it holds for the session (the Windows IME context association, or the VM host's session) until the end callback runs:

- Field.cleanUp returned early on the recorded error and never called f.end, so the platform-side session leaked after the field was blurred or another field was focused.
- session.Update marked the session closed with callPlatformEnd=false, so s.end was never invoked and the Composer dropped the closed session: a second platform session could start while the errored one still held the platform IME.

Skip only the last-state read on the Field error path, and still end the session on both error paths as the commit path does. The Composer starts a fresh session on the next Update as with the normal flow; a Field keeps returning its recorded error from then on, as before.