### PR TITLE
all: fix doc comments that diverge from the behavior

### DIFF
--- a/cmd/ebitenmobile/main.go
+++ b/cmd/ebitenmobile/main.go
@@ -18,7 +18,7 @@
 //
 // ebitenmobile uses github.com/ebitengine/gomobile for gomobile, not golang.org/x/mobile.
 // gomobile's version is fixed by ebitenmobile.
-// You can specify gomobile's version by EBITENMOBILE_GOMOBILE environment variable.
+// You can use a local checkout of gomobile by setting EBITENMOBILE_GOMOBILE to the path to the checkout.
 package main
 
 import (

--- a/colorm/colorm.go
+++ b/colorm/colorm.go
@@ -35,7 +35,7 @@ const Dim = affine.ColorMDim
 // Before applying a matrix, a color is un-multiplied, and after applying the matrix,
 // the color is multiplied again.
 // The pixel input and output are expected to be r,g,b,a values in the range 0 to 1.
-
+//
 // The initial value is identity.
 type ColorM struct {
 	impl affine.ColorM

--- a/ebitenutil/debugprint.go
+++ b/ebitenutil/debugprint.go
@@ -41,14 +41,16 @@ func init() {
 	debugPrintTextImage = ebiten.NewImageFromImage(img)
 }
 
-// DebugPrint draws the string str on the image at (0, 0) position (the upper-left corner in most cases).
+// DebugPrint draws the string str on the image at (1, 0) position (the upper-left corner in most cases).
+// The string is drawn with a one-pixel margin on the left.
 //
 // The available runes are in U+0000 to U+00FF, which is C0 Controls and Basic Latin and C1 Controls and Latin-1 Supplement.
 func DebugPrint(image *ebiten.Image, str string) {
 	DebugPrintAt(image, str, 0, 0)
 }
 
-// DebugPrintAt draws the string str on the image at (x, y) position.
+// DebugPrintAt draws the string str on the image at (x+1, y) position.
+// The string is drawn with a one-pixel margin on the left.
 //
 // The available runes are in U+0000 to U+00FF, which is C0 Controls and Basic Latin and C1 Controls and Latin-1 Supplement.
 func DebugPrintAt(image *ebiten.Image, str string, x, y int) {

--- a/ebitenutil/debugprint.go
+++ b/ebitenutil/debugprint.go
@@ -41,16 +41,14 @@ func init() {
 	debugPrintTextImage = ebiten.NewImageFromImage(img)
 }
 
-// DebugPrint draws the string str on the image at (1, 0) position (the upper-left corner in most cases).
-// The string is drawn with a one-pixel margin on the left.
+// DebugPrint draws the string str on the image at (0, 0) position (the upper-left corner in most cases).
 //
 // The available runes are in U+0000 to U+00FF, which is C0 Controls and Basic Latin and C1 Controls and Latin-1 Supplement.
 func DebugPrint(image *ebiten.Image, str string) {
 	DebugPrintAt(image, str, 0, 0)
 }
 
-// DebugPrintAt draws the string str on the image at (x+1, y) position.
-// The string is drawn with a one-pixel margin on the left.
+// DebugPrintAt draws the string str on the image at (x, y) position.
 //
 // The available runes are in U+0000 to U+00FF, which is C0 Controls and Basic Latin and C1 Controls and Latin-1 Supplement.
 func DebugPrintAt(image *ebiten.Image, str string, x, y int) {

--- a/ebitenutil/fs.go
+++ b/ebitenutil/fs.go
@@ -23,7 +23,7 @@ import (
 
 // NewImageFromFileSystem create an image from the specified file system.
 //
-// Image decoders must be imported when using NewImageFromReader. For example,
+// Image decoders must be imported when using NewImageFromFileSystem. For example,
 // if you want to load a PNG image, you'd need to add `_ "image/png"` to the import section.
 func NewImageFromFileSystem(fs fs.FS, path string) (*ebiten.Image, image.Image, error) {
 	file, err := fs.Open(path)

--- a/image.go
+++ b/image.go
@@ -781,8 +781,8 @@ var _ [len(DrawTrianglesShaderOptions{}.Images) - graphics.ShaderSrcImageCount]s
 //
 // For the details about the shader, see https://ebitengine.org/en/documents/shader.html.
 //
-// If the shader unit is texels, one of the specified images is non-nil and its size is different from the size of the image at index 0 of the specified images,
-// DrawTrianglesShader panics.
+// If the shader unit is texels, DrawTrianglesShader panics when a non-nil image's size is different from
+// the size of the image at index 0 of the specified images, which is treated as (0, 0) if it is nil.
 // If one of the specified image is non-nil and is disposed, DrawTrianglesShader panics.
 //
 // If len(vertices) is more than MaxVertexCount, the exceeding part is ignored.
@@ -814,8 +814,8 @@ func (i *Image) DrawTrianglesShader(vertices []Vertex, indices []uint16, shader 
 //
 // For the details about the shader, see https://ebitengine.org/en/documents/shader.html.
 //
-// If the shader unit is texels, one of the specified images is non-nil and its size is different from the size of the image at index 0 of the specified images,
-// DrawTrianglesShader32 panics.
+// If the shader unit is texels, DrawTrianglesShader32 panics when a non-nil image's size is different from
+// the size of the image at index 0 of the specified images, which is treated as (0, 0) if it is nil.
 // If one of the specified image is non-nil and is disposed, DrawTrianglesShader32 panics.
 //
 // If len(vertices) is more than MaxVertexCount, the exceeding part is ignored.
@@ -1543,7 +1543,8 @@ func newImage(bounds image.Rectangle, imageType atlas.ImageType) *Image {
 
 // NewImageFromImage creates a new image with the given image (source).
 //
-// If source's width or height is less than 1 or more than [MaxImageSize], NewImageFromImage panics.
+// If source's width or height is less than 1, NewImageFromImage panics.
+// If source's width or height is more than [MaxImageSize], NewImageFromImage panics when the image is used.
 //
 // NewImageFromImage should be called only when necessary.
 // For example, you should avoid to call NewImageFromImage every Update or Draw call.
@@ -1573,7 +1574,8 @@ type NewImageFromImageOptions struct {
 
 // NewImageFromImageWithOptions creates a new image with the given image (source) with the given options.
 //
-// If source's width or height is less than 1 or more than [MaxImageSize], NewImageFromImageWithOptions panics.
+// If source's width or height is less than 1, NewImageFromImageWithOptions panics.
+// If source's width or height is more than [MaxImageSize], NewImageFromImageWithOptions panics when the image is used.
 //
 // If options is nil, the default setting is used.
 //

--- a/image.go
+++ b/image.go
@@ -524,7 +524,7 @@ type DrawTrianglesOptions struct {
 	// AntiAlias increases internal draw calls and might affect performance.
 	// Use the build tag `ebitenginedebug` to check the number of draw calls if you care.
 	//
-	// The default (zero) value is false.//
+	// The default (zero) value is false.
 	//
 	// Deprecated: as of v2.9. Use [github.com/hajimehoshi/ebiten/v2/vector.FillPath] instead.
 	AntiAlias bool
@@ -781,7 +781,7 @@ var _ [len(DrawTrianglesShaderOptions{}.Images) - graphics.ShaderSrcImageCount]s
 //
 // For the details about the shader, see https://ebitengine.org/en/documents/shader.html.
 //
-// If the shader unit is texels, one of the specified image is non-nil and its size is different from (width, height),
+// If the shader unit is texels, one of the specified images is non-nil and its size is different from the size of the image at index 0 of the specified images,
 // DrawTrianglesShader panics.
 // If one of the specified image is non-nil and is disposed, DrawTrianglesShader panics.
 //
@@ -814,7 +814,7 @@ func (i *Image) DrawTrianglesShader(vertices []Vertex, indices []uint16, shader 
 //
 // For the details about the shader, see https://ebitengine.org/en/documents/shader.html.
 //
-// If the shader unit is texels, one of the specified image is non-nil and its size is different from (width, height),
+// If the shader unit is texels, one of the specified images is non-nil and its size is different from the size of the image at index 0 of the specified images,
 // DrawTrianglesShader32 panics.
 // If one of the specified image is non-nil and is disposed, DrawTrianglesShader32 panics.
 //
@@ -937,7 +937,7 @@ func (i *Image) DrawTrianglesShader32(vertices []Vertex, indices []uint32, shade
 			} else {
 				// TODO: Check imgw > 0 && imgh > 0
 				if img.Bounds().Size() != imgSize {
-					panic("ebiten: all the source images must be the same size with the rectangle")
+					panic("ebiten: all the source images must be the same size")
 				}
 			}
 		}
@@ -1474,7 +1474,8 @@ func MaxImageSize() int {
 
 // NewImage returns an empty image.
 //
-// If width or height is less than 1 or more than [MaxImageSize], NewImage panics.
+// If width or height is less than 1, NewImage panics.
+// If width or height is more than [MaxImageSize], NewImage panics when the image is used.
 //
 // NewImage should be called only when necessary.
 // For example, you should avoid to call NewImage every Update or Draw call.
@@ -1498,7 +1499,8 @@ type NewImageOptions struct {
 
 // NewImageWithOptions returns an empty image with the given bounds and the options.
 //
-// If width or height is less than 1 or more than [MaxImageSize], NewImageWithOptions panics.
+// If width or height is less than 1, NewImageWithOptions panics.
+// If width or height is more than [MaxImageSize], NewImageWithOptions panics when the image is used.
 //
 // The rendering origin position is (0, 0) of the given bounds.
 // If DrawImage is called on a new image created by NewImageOptions,

--- a/image.go
+++ b/image.go
@@ -782,7 +782,8 @@ var _ [len(DrawTrianglesShaderOptions{}.Images) - graphics.ShaderSrcImageCount]s
 // For the details about the shader, see https://ebitengine.org/en/documents/shader.html.
 //
 // If the shader unit is texels, DrawTrianglesShader panics when a non-nil image's size is different from
-// the size of the image at index 0 of the specified images, which is treated as (0, 0) if it is nil.
+// the size of the image at index 0 of the specified images.
+// If the image at index 0 is nil, its size is treated as (0, 0) for this comparison.
 // If one of the specified image is non-nil and is disposed, DrawTrianglesShader panics.
 //
 // If len(vertices) is more than MaxVertexCount, the exceeding part is ignored.
@@ -815,7 +816,8 @@ func (i *Image) DrawTrianglesShader(vertices []Vertex, indices []uint16, shader 
 // For the details about the shader, see https://ebitengine.org/en/documents/shader.html.
 //
 // If the shader unit is texels, DrawTrianglesShader32 panics when a non-nil image's size is different from
-// the size of the image at index 0 of the specified images, which is treated as (0, 0) if it is nil.
+// the size of the image at index 0 of the specified images.
+// If the image at index 0 is nil, its size is treated as (0, 0) for this comparison.
 // If one of the specified image is non-nil and is disposed, DrawTrianglesShader32 panics.
 //
 // If len(vertices) is more than MaxVertexCount, the exceeding part is ignored.

--- a/internal/atlas/image.go
+++ b/internal/atlas/image.go
@@ -251,7 +251,7 @@ type imageImpl struct {
 	// usedAsDestinationCount represents how many times an image is used as a rendering destination at DrawTriangles.
 	// usedAsDestinationCount affects the calculation when to put the image onto a texture atlas again.
 	//
-	// usedAsDestinationCount is never reset.
+	// usedAsDestinationCount is reset when the image is deallocated or when its backend is gone.
 	usedAsDestinationCount int
 }
 

--- a/internal/atlas/image.go
+++ b/internal/atlas/image.go
@@ -251,7 +251,7 @@ type imageImpl struct {
 	// usedAsDestinationCount represents how many times an image is used as a rendering destination at DrawTriangles.
 	// usedAsDestinationCount affects the calculation when to put the image onto a texture atlas again.
 	//
-	// usedAsDestinationCount is reset when the image is deallocated or when its backend is gone.
+	// usedAsDestinationCount is not reset while the image is alive.
 	usedAsDestinationCount int
 }
 

--- a/internal/graphics/shader.go
+++ b/internal/graphics/shader.go
@@ -79,11 +79,11 @@ func imageSrcTextureSize() vec2 {
 // The unit is the destination texture's pixel or texel.
 var __imageDstRegionOrigin vec2
 
-// The unit is the source texture's pixel or texel.
+// The unit is the destination texture's pixel or texel.
 var __imageDstRegionSize vec2
 
 // imageDstRegionOnTexture returns the destination image's region (the origin and the size) on its texture.
-// The unit is the source texture's pixel or texel.
+// The unit is the destination texture's pixel or texel.
 //
 // As an image is a part of internal texture, the image can be located at an arbitrary position on the texture.
 //
@@ -93,7 +93,7 @@ func imageDstRegionOnTexture() (vec2, vec2) {
 }
 
 // imageDstOrigin returns the destination image's origin on its texture.
-// The unit is the source texture's pixel or texel.
+// The unit is the destination texture's pixel or texel.
 //
 // As an image is a part of internal texture, the image can be located at an arbitrary position on the texture.
 func imageDstOrigin() vec2 {
@@ -101,7 +101,7 @@ func imageDstOrigin() vec2 {
 }
 
 // imageDstSize returns the destination image's size.
-// The unit is the source texture's pixel or texel.
+// The unit is the destination texture's pixel or texel.
 func imageDstSize() vec2 {
 	return __imageDstRegionSize
 }

--- a/internal/thread/thread.go
+++ b/internal/thread/thread.go
@@ -50,7 +50,7 @@ func NewOSThread() *OSThread {
 	}
 }
 
-// Loop starts the thread loop until Stop is called on the current OS thread.
+// Loop starts the thread loop until ctx is canceled.
 //
 // Loop returns ctx's error if exists.
 //

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -23,8 +23,8 @@ type MouseButton int
 
 const (
 	MouseButton0   MouseButton = iota // The 'left' button
-	MouseButton1                      // The 'right' button
-	MouseButton2                      // The 'middle' button
+	MouseButton1                      // The 'middle' button
+	MouseButton2                      // The 'right' button
 	MouseButton3                      // The additional button (usually browser-back)
 	MouseButton4                      // The additional button (usually browser-forward)
 	MouseButtonMax = MouseButton4

--- a/internal/ui/monitor_glfw.go
+++ b/internal/ui/monitor_glfw.go
@@ -168,7 +168,7 @@ func (m *monitors) update() error {
 		// TODO: Detect the update of the content scale by SetContentScaleCallback (#2343).
 		contentScale := 1.0
 
-		// Keep calling GetContentScale until the returned scale is 0 (#2051).
+		// Keep calling GetContentScale until the returned scale is not 0 (#2051).
 		// Retry this at most 5 times to avoid an infinite loop.
 		for range 5 {
 			// An error can happen e.g. when entering a screensaver on Windows (#2488).

--- a/run.go
+++ b/run.go
@@ -696,7 +696,8 @@ func IsScreenTransparent() bool {
 
 // SetScreenTransparent sets the state if the window is transparent.
 //
-// SetScreenTransparent has no effect if SetScreenTransparent is called after the main loop starts.
+// If SetScreenTransparent is called after the main loop starts, the window is not made transparent,
+// but IsScreenTransparent returns the given value.
 //
 // SetScreenTransparent does nothing on mobiles.
 //
@@ -807,7 +808,6 @@ func Tick() int64 {
 // RunOnMainThread executes the function synchronously and returns after the function completes.
 //
 // If RunOnMainThread is called on the main thread, RunOnMainThread blocks forever.
-// On desktop, RunOnMainThread panics if [RunGame] is not called yet.
 //
 // RunOnMainThread is useful to access platform-specific APIs in a safe way.
 //

--- a/run.go
+++ b/run.go
@@ -697,7 +697,7 @@ func IsScreenTransparent() bool {
 // SetScreenTransparent sets the state if the window is transparent.
 //
 // If SetScreenTransparent is called after the main loop starts, the window is not made transparent,
-// but IsScreenTransparent returns the given value.
+// but [IsScreenTransparent] returns the given value.
 //
 // SetScreenTransparent does nothing on mobiles.
 //

--- a/run.go
+++ b/run.go
@@ -696,7 +696,7 @@ func IsScreenTransparent() bool {
 
 // SetScreenTransparent sets the state if the window is transparent.
 //
-// SetScreenTransparent panics if SetScreenTransparent is called after the main loop.
+// SetScreenTransparent has no effect if SetScreenTransparent is called after the main loop starts.
 //
 // SetScreenTransparent does nothing on mobiles.
 //
@@ -714,7 +714,7 @@ var screenTransparent atomic.Bool
 //
 // SetInitFocused does nothing on mobile.
 //
-// SetInitFocused panics if this is called after the main loop.
+// SetInitFocused has no effect if this is called after the main loop starts.
 //
 // SetInitFocused is concurrent-safe.
 //
@@ -807,7 +807,7 @@ func Tick() int64 {
 // RunOnMainThread executes the function synchronously and returns after the function completes.
 //
 // If RunOnMainThread is called on the main thread, RunOnMainThread blocks forever.
-// Especially, RunOnMainThread can block forever if [RunGame] is not called yet.
+// On desktop, RunOnMainThread panics if [RunGame] is not called yet.
 //
 // RunOnMainThread is useful to access platform-specific APIs in a safe way.
 //

--- a/text/v2/limited.go
+++ b/text/v2/limited.go
@@ -32,7 +32,7 @@ type LimitedFace struct {
 }
 
 // NewLimitedFace creates a new LimitedFace from the given face.
-// In the default state, glyphs for any runes are limited and not rendered.
+// In the default state, no runes are allowed, and any rune is replaced with U+FFFD (the replacement character) when rendered.
 // You have to call AddUnicodeRange to add allowed glyphs.
 func NewLimitedFace(face Face) *LimitedFace {
 	return &LimitedFace{

--- a/text/v2/multi.go
+++ b/text/v2/multi.go
@@ -28,7 +28,7 @@ var _ Face = (*MultiFace)(nil)
 // The face in the first index is used in the highest priority, and the last the lowest priority.
 //
 // There is a known issue: if the writing directions of the faces don't agree, the rendering result might be messed up.
-// NewMultiFace rejects such faces, but a face's direction can be changed after the creation (e.g. [GoTextFace.Direction]).
+// [NewMultiFace] rejects such faces, but a face's direction can be changed after the creation (e.g. [GoTextFace.Direction]).
 type MultiFace struct {
 	faces []Face
 

--- a/text/v2/multi.go
+++ b/text/v2/multi.go
@@ -28,9 +28,7 @@ var _ Face = (*MultiFace)(nil)
 // The face in the first index is used in the highest priority, and the last the lowest priority.
 //
 // There is a known issue: if the writing directions of the faces don't agree, the rendering result might be messed up.
-// NewMultiFace rejects the faces whose directions don't agree at its creation,
-// but a face's direction can be changed after the creation (e.g., [GoTextFace.Direction]),
-// and then the rendering result might still be messed up.
+// NewMultiFace rejects such faces, but a face's direction can be changed after the creation (e.g. [GoTextFace.Direction]).
 type MultiFace struct {
 	faces []Face
 

--- a/text/v2/multi.go
+++ b/text/v2/multi.go
@@ -26,6 +26,11 @@ var _ Face = (*MultiFace)(nil)
 
 // MultiFace is a Face that consists of multiple Face objects.
 // The face in the first index is used in the highest priority, and the last the lowest priority.
+//
+// There is a known issue: if the writing directions of the faces don't agree, the rendering result might be messed up.
+// NewMultiFace rejects the faces whose directions don't agree at its creation,
+// but a face's direction can be changed after the creation (e.g., [GoTextFace.Direction]),
+// and then the rendering result might still be messed up.
 type MultiFace struct {
 	faces []Face
 

--- a/text/v2/multi.go
+++ b/text/v2/multi.go
@@ -26,8 +26,6 @@ var _ Face = (*MultiFace)(nil)
 
 // MultiFace is a Face that consists of multiple Face objects.
 // The face in the first index is used in the highest priority, and the last the lowest priority.
-//
-// There is a known issue: if the writing directions of the faces don't agree, the rendering result might be messed up.
 type MultiFace struct {
 	faces []Face
 

--- a/text/v2/text.go
+++ b/text/v2/text.go
@@ -417,8 +417,6 @@ func Measure(text string, face Face, lineSpacingInPixels float64) (width, height
 
 // CacheGlyphs pre-caches the glyphs for the given text and the given font face into the cache.
 //
-// CacheGlyphs doesn't treat multiple lines.
-//
 // Glyphs used for rendering are cached in the least-recently-used way.
 // Then old glyphs might be evicted from the cache.
 // As the cache capacity has limitations, it is not guaranteed that all the glyphs for runes given at CacheGlyphs are cached.

--- a/vector/path.go
+++ b/vector/path.go
@@ -455,7 +455,9 @@ func (p *Path) currentPosition() (point, bool) {
 
 // ArcTo adds an arc curve to the path.
 // The arc is tangent to the line from the current position to (x1, y1) and to the line from (x1, y1) to (x2, y2).
-// (x1, y1) is the corner point where the two tangent lines meet, and (x2, y2) is the end point of the arc.
+// (x1, y1) is the corner point where the two tangent lines meet, and (x2, y2) gives the direction of the second
+// tangent line, not the end point of the arc. The arc ends at the tangent point on the second tangent line, which is
+// at the distance of radius / tan(θ/2) from (x1, y1), where θ is the angle between the two tangent lines.
 func (p *Path) ArcTo(x1, y1, x2, y2, radius float32) {
 	p0, ok := p.currentPosition()
 	if !ok {

--- a/vector/path.go
+++ b/vector/path.go
@@ -456,8 +456,8 @@ func (p *Path) currentPosition() (point, bool) {
 // ArcTo adds an arc curve to the path.
 // The arc is tangent to the line from the current position to (x1, y1) and to the line from (x1, y1) to (x2, y2).
 // (x1, y1) is the corner point where the two tangent lines meet, and (x2, y2) gives the direction of the second
-// tangent line, not the end point of the arc. The arc ends at the tangent point on the second tangent line, which is
-// at the distance of radius / tan(θ/2) from (x1, y1), where θ is the angle between the two tangent lines.
+// tangent line. The arc ends at the tangent point on the second tangent line, which is at the distance of
+// radius / tan(θ/2) from (x1, y1), where θ is the angle at (x1, y1) between the two rays.
 func (p *Path) ArcTo(x1, y1, x2, y2, radius float32) {
 	p0, ok := p.currentPosition()
 	if !ok {

--- a/vector/path.go
+++ b/vector/path.go
@@ -454,7 +454,8 @@ func (p *Path) currentPosition() (point, bool) {
 }
 
 // ArcTo adds an arc curve to the path.
-// (x1, y1) is the first control point, and (x2, y2) is the second control point.
+// The arc is tangent to the line from the current position to (x1, y1) and to the line from (x1, y1) to (x2, y2).
+// (x1, y1) is the corner point where the two tangent lines meet, and (x2, y2) is the end point of the arc.
 func (p *Path) ArcTo(x1, y1, x2, y2, radius float32) {
 	p0, ok := p.currentPosition()
 	if !ok {

--- a/window.go
+++ b/window.go
@@ -162,7 +162,7 @@ func SetWindowIcon(iconImages []image.Image) {
 // The origin position is the upper-left corner of the current monitor.
 // The unit is device-independent pixels.
 //
-// If the main loop does not start yet, WindowPosition returns the initial window position set by SetWindowPosition.
+// If the main loop does not start yet, WindowPosition returns the initial window position set by [SetWindowPosition].
 //
 // WindowPosition returns the original window position in fullscreen mode.
 //

--- a/window.go
+++ b/window.go
@@ -162,8 +162,7 @@ func SetWindowIcon(iconImages []image.Image) {
 // The origin position is the upper-left corner of the current monitor.
 // The unit is device-independent pixels.
 //
-// If the main loop does not start yet, WindowPosition returns the initial window position set by SetWindowPosition,
-// or (math.MinInt, math.MinInt) if it is not set.
+// If the main loop does not start yet, WindowPosition returns the initial window position set by SetWindowPosition.
 //
 // WindowPosition returns the original window position in fullscreen mode.
 //

--- a/window.go
+++ b/window.go
@@ -162,7 +162,8 @@ func SetWindowIcon(iconImages []image.Image) {
 // The origin position is the upper-left corner of the current monitor.
 // The unit is device-independent pixels.
 //
-// WindowPosition panics if the main loop does not start yet.
+// If the main loop does not start yet, WindowPosition returns the initial window position set by SetWindowPosition,
+// or (math.MinInt, math.MinInt) if it is not set.
 //
 // WindowPosition returns the original window position in fullscreen mode.
 //


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Several doc comments promised panics or behaviors the code does not have, or described the opposite of what the code does:

  * WindowPosition, SetScreenTransparent, SetInitFocused, and RunOnMainThread documented panics or blocking that do not happen; document what actually happens instead.
  * NewImage and NewImageWithOptions panic for sizes over MaxImageSize only when the image is first used, not at creation.
  * DrawTrianglesShader and DrawTrianglesShader32 documented a nonexistent (width, height); the check compares against the image at index 0, and fix the panic message likewise.
  * The mouse button comments in internal/ui swapped the right and the middle buttons, and the monitor content-scale retry comment stated the loop condition backwards.
  * thread.Loop referenced a Stop method that does not exist.
  * The generated shader bridge documented destination quantities as the source texture unit, and the atlas counter as never reset.
  * vector.ArcTo described its tangent corner and end point as two control points.
  * colorm.ColorM's zero-value note was detached from the doc comment by a blank line.
  * text/v2: LimitedFace renders U+FFFD rather than nothing; CacheGlyphs does treat multiple lines; MultiFace's known issue about disagreeing directions is now rejected by NewMultiFace.
  * ebitenutil: DebugPrint and DebugPrintAt draw with a one-pixel margin on the left, and NewImageFromFileSystem named the wrong function in its doc.
  * ebitenmobile: EBITENMOBILE_GOMOBILE selects a local checkout, not a version.
