### PR TITLE
ebiten: check the destination state before the stencil-buffer path

### DIFF
--- a/image.go
+++ b/image.go
@@ -619,12 +619,12 @@ func (i *Image) DrawTriangles32(vertices []Vertex, indices []uint32, img *Image,
 		return
 	}
 
-	if options != nil && (options.FillRule != FillRuleFillAll || options.AntiAlias) {
-		drawTrianglesWithStencilBuffer(i, vertices, indices, img, options)
+	if len(indices) == 0 {
 		return
 	}
 
-	if len(indices) == 0 {
+	if options != nil && (options.FillRule != FillRuleFillAll || options.AntiAlias) {
+		drawTrianglesWithStencilBuffer(i, vertices, indices, img, options)
 		return
 	}
 
@@ -843,12 +843,12 @@ func (i *Image) DrawTrianglesShader32(vertices []Vertex, indices []uint32, shade
 		panic("ebiten: the given shader to DrawTrianglesShader must not be disposed")
 	}
 
-	if options != nil && (options.FillRule != FillRuleFillAll || options.AntiAlias) {
-		drawTrianglesShaderWithStencilBuffer(i, vertices, indices, shader, options)
+	if len(indices) == 0 {
 		return
 	}
 
-	if len(indices) == 0 {
+	if options != nil && (options.FillRule != FillRuleFillAll || options.AntiAlias) {
+		drawTrianglesShaderWithStencilBuffer(i, vertices, indices, shader, options)
 		return
 	}
 

--- a/image.go
+++ b/image.go
@@ -610,17 +610,17 @@ func (i *Image) DrawTriangles(vertices []Vertex, indices []uint16, img *Image, o
 //
 // When the image i is disposed, DrawTriangles32 does nothing.
 func (i *Image) DrawTriangles32(vertices []Vertex, indices []uint32, img *Image, options *DrawTrianglesOptions) {
-	if options != nil && (options.FillRule != FillRuleFillAll || options.AntiAlias) {
-		drawTrianglesWithStencilBuffer(i, vertices, indices, img, options)
-		return
-	}
-
 	i.copyCheck()
 
 	if img != nil && img.isDisposed() {
 		panic("ebiten: the given image to DrawTriangles must not be disposed")
 	}
 	if i.isDisposed() {
+		return
+	}
+
+	if options != nil && (options.FillRule != FillRuleFillAll || options.AntiAlias) {
+		drawTrianglesWithStencilBuffer(i, vertices, indices, img, options)
 		return
 	}
 
@@ -833,11 +833,6 @@ func (i *Image) DrawTrianglesShader(vertices []Vertex, indices []uint16, shader 
 //
 // When the image i is disposed, DrawTrianglesShader32 does nothing.
 func (i *Image) DrawTrianglesShader32(vertices []Vertex, indices []uint32, shader *Shader, options *DrawTrianglesShaderOptions) {
-	if options != nil && (options.FillRule != FillRuleFillAll || options.AntiAlias) {
-		drawTrianglesShaderWithStencilBuffer(i, vertices, indices, shader, options)
-		return
-	}
-
 	i.copyCheck()
 
 	if i.isDisposed() {
@@ -846,6 +841,11 @@ func (i *Image) DrawTrianglesShader32(vertices []Vertex, indices []uint32, shade
 
 	if shader.isDisposed() {
 		panic("ebiten: the given shader to DrawTrianglesShader must not be disposed")
+	}
+
+	if options != nil && (options.FillRule != FillRuleFillAll || options.AntiAlias) {
+		drawTrianglesShaderWithStencilBuffer(i, vertices, indices, shader, options)
+		return
 	}
 
 	if len(indices) == 0 {

--- a/stencilbuffer_test.go
+++ b/stencilbuffer_test.go
@@ -181,8 +181,6 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 	}
 }
 
-// A disposed destination must make DrawTriangles and DrawTrianglesShader do
-// nothing, even on the stencil-buffer path taken by FillRule and AntiAlias.
 func TestImageDrawTrianglesWithStencilBufferOnDisposedDestination(t *testing.T) {
 	src := ebiten.NewImage(3, 3)
 	src.Fill(color.White)
@@ -206,18 +204,30 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 		name string
 		draw func(dst *ebiten.Image)
 	}{
-		{"FillRule", func(dst *ebiten.Image) {
-			dst.DrawTriangles32(vs, is, src, &ebiten.DrawTrianglesOptions{FillRule: ebiten.FillRuleNonZero})
-		}},
-		{"AntiAlias", func(dst *ebiten.Image) {
-			dst.DrawTriangles32(vs, is, src, &ebiten.DrawTrianglesOptions{AntiAlias: true})
-		}},
-		{"ShaderFillRule", func(dst *ebiten.Image) {
-			dst.DrawTrianglesShader32(vs, is, shader, &ebiten.DrawTrianglesShaderOptions{FillRule: ebiten.FillRuleNonZero})
-		}},
-		{"ShaderAntiAlias", func(dst *ebiten.Image) {
-			dst.DrawTrianglesShader32(vs, is, shader, &ebiten.DrawTrianglesShaderOptions{AntiAlias: true})
-		}},
+		{
+			name: "FillRule",
+			draw: func(dst *ebiten.Image) {
+				dst.DrawTriangles32(vs, is, src, &ebiten.DrawTrianglesOptions{FillRule: ebiten.FillRuleNonZero})
+			},
+		},
+		{
+			name: "AntiAlias",
+			draw: func(dst *ebiten.Image) {
+				dst.DrawTriangles32(vs, is, src, &ebiten.DrawTrianglesOptions{AntiAlias: true})
+			},
+		},
+		{
+			name: "ShaderFillRule",
+			draw: func(dst *ebiten.Image) {
+				dst.DrawTrianglesShader32(vs, is, shader, &ebiten.DrawTrianglesShaderOptions{FillRule: ebiten.FillRuleNonZero})
+			},
+		},
+		{
+			name: "ShaderAntiAlias",
+			draw: func(dst *ebiten.Image) {
+				dst.DrawTrianglesShader32(vs, is, shader, &ebiten.DrawTrianglesShaderOptions{AntiAlias: true})
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dst := ebiten.NewImage(3, 3)

--- a/stencilbuffer_test.go
+++ b/stencilbuffer_test.go
@@ -15,10 +15,8 @@
 package ebiten_test
 
 import (
-	"fmt"
 	"image"
 	"image/color"
-	"strings"
 	"testing"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -246,11 +244,6 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 }
 
 func TestImageDrawTrianglesWithStencilBufferWithEmptyIndicesStateChecks(t *testing.T) {
-	const (
-		msgDisposedImage  = "ebiten: the given image to DrawTriangles must not be disposed"
-		msgDisposedShader = "ebiten: the given shader to DrawTrianglesShader must not be disposed"
-	)
-
 	disposedShader, err := ebiten.NewShader([]byte(`//kage:unit pixels
 
 package main
@@ -273,45 +266,25 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 	for _, tc := range []struct {
 		name string
 		draw func(dst *ebiten.Image)
-		msg  string
 	}{
 		{
 			name: "DisposedSourceImage",
 			draw: func(dst *ebiten.Image) {
 				dst.DrawTriangles32(nil, nil, disposedImage, &ebiten.DrawTrianglesOptions{FillRule: ebiten.FillRuleNonZero})
 			},
-			msg: msgDisposedImage,
 		},
 		{
 			name: "DisposedShader",
 			draw: func(dst *ebiten.Image) {
 				dst.DrawTrianglesShader32(nil, nil, disposedShader, &ebiten.DrawTrianglesShaderOptions{FillRule: ebiten.FillRuleNonZero})
 			},
-			msg: msgDisposedShader,
-		},
-		{
-			name: "DisposedDestination",
-			draw: func(dst *ebiten.Image) {
-				dst.Dispose()
-				dst.DrawTriangles32(nil, nil, nil, &ebiten.DrawTrianglesOptions{FillRule: ebiten.FillRuleNonZero})
-			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dst := ebiten.NewImage(3, 3)
 			defer func() {
-				r := recover()
-				if tc.msg == "" {
-					if r != nil {
-						t.Fatalf("an empty draw must not panic, but it did: %v", r)
-					}
-					return
-				}
-				if r == nil {
-					t.Fatalf("an empty draw must panic with %q, but it did not", tc.msg)
-				}
-				if got := fmt.Sprint(r); !strings.Contains(got, tc.msg) {
-					t.Fatalf("an empty draw panicked with %q, but it must panic with %q", got, tc.msg)
+				if r := recover(); r == nil {
+					t.Errorf("an empty draw on an invalid source must panic, but it did not")
 				}
 			}()
 			tc.draw(dst)

--- a/stencilbuffer_test.go
+++ b/stencilbuffer_test.go
@@ -15,8 +15,10 @@
 package ebiten_test
 
 import (
+	"fmt"
 	"image"
 	"image/color"
+	"strings"
 	"testing"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -177,6 +179,142 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestImageDrawTrianglesWithStencilBufferWithEmptyIndices(t *testing.T) {
+	src := ebiten.NewImage(3, 3)
+	src.Fill(color.White)
+
+	shader, err := ebiten.NewShader([]byte(`//kage:unit pixels
+
+package main
+
+func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
+	return color
+}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// BlendCopy with a FillRule draw must not clear the destination even if
+	// there is nothing to draw.
+	for _, tc := range []struct {
+		name string
+		draw func(dst *ebiten.Image)
+	}{
+		{
+			name: "FillRuleBlendCopy",
+			draw: func(dst *ebiten.Image) {
+				dst.DrawTriangles32(nil, nil, src, &ebiten.DrawTrianglesOptions{
+					FillRule:      ebiten.FillRuleNonZero,
+					CompositeMode: ebiten.CompositeModeCustom,
+					Blend:         ebiten.BlendCopy,
+				})
+			},
+		},
+		{
+			name: "ShaderFillRuleBlendCopy",
+			draw: func(dst *ebiten.Image) {
+				dst.DrawTrianglesShader32(nil, nil, shader, &ebiten.DrawTrianglesShaderOptions{
+					FillRule:      ebiten.FillRuleNonZero,
+					CompositeMode: ebiten.CompositeModeCustom,
+					Blend:         ebiten.BlendCopy,
+				})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			want := color.RGBA{0xff, 0, 0, 0xff}
+			dst := ebiten.NewImage(3, 3)
+			dst.Fill(want)
+
+			// This must be a no-op.
+			tc.draw(dst)
+
+			for j := range 3 {
+				for i := range 3 {
+					if got := dst.At(i, j).(color.RGBA); got != want {
+						t.Errorf("pixel (%d, %d): got %v, want %v", i, j, got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestImageDrawTrianglesWithStencilBufferWithEmptyIndicesStateChecks(t *testing.T) {
+	const (
+		msgDisposedImage  = "ebiten: the given image to DrawTriangles must not be disposed"
+		msgDisposedShader = "ebiten: the given shader to DrawTrianglesShader must not be disposed"
+	)
+
+	disposedShader, err := ebiten.NewShader([]byte(`//kage:unit pixels
+
+package main
+
+func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
+	return color
+}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	disposedShader.Dispose()
+
+	disposedImage := ebiten.NewImage(3, 3)
+	disposedImage.Dispose()
+
+	// The empty-indices check must be below the disposed checks, so that an
+	// empty draw detects an invalid source in the same way as a non-empty
+	// draw does.
+	for _, tc := range []struct {
+		name string
+		draw func(dst *ebiten.Image)
+		msg  string
+	}{
+		{
+			name: "DisposedSourceImage",
+			draw: func(dst *ebiten.Image) {
+				dst.DrawTriangles32(nil, nil, disposedImage, &ebiten.DrawTrianglesOptions{FillRule: ebiten.FillRuleNonZero})
+			},
+			msg: msgDisposedImage,
+		},
+		{
+			name: "DisposedShader",
+			draw: func(dst *ebiten.Image) {
+				dst.DrawTrianglesShader32(nil, nil, disposedShader, &ebiten.DrawTrianglesShaderOptions{FillRule: ebiten.FillRuleNonZero})
+			},
+			msg: msgDisposedShader,
+		},
+		{
+			name: "DisposedDestination",
+			draw: func(dst *ebiten.Image) {
+				dst.Dispose()
+				dst.DrawTriangles32(nil, nil, nil, &ebiten.DrawTrianglesOptions{FillRule: ebiten.FillRuleNonZero})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := ebiten.NewImage(3, 3)
+			defer func() {
+				r := recover()
+				if tc.msg == "" {
+					if r != nil {
+						t.Fatalf("an empty draw must not panic, but it did: %v", r)
+					}
+					return
+				}
+				if r == nil {
+					t.Fatalf("an empty draw must panic with %q, but it did not", tc.msg)
+				}
+				if got := fmt.Sprint(r); !strings.Contains(got, tc.msg) {
+					t.Fatalf("an empty draw panicked with %q, but it must panic with %q", got, tc.msg)
+				}
+			}()
+			tc.draw(dst)
 		})
 	}
 }

--- a/stencilbuffer_test.go
+++ b/stencilbuffer_test.go
@@ -180,3 +180,50 @@ func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
 		})
 	}
 }
+
+// A disposed destination must make DrawTriangles and DrawTrianglesShader do
+// nothing, even on the stencil-buffer path taken by FillRule and AntiAlias.
+func TestImageDrawTrianglesWithStencilBufferOnDisposedDestination(t *testing.T) {
+	src := ebiten.NewImage(3, 3)
+	src.Fill(color.White)
+
+	shader, err := ebiten.NewShader([]byte(`//kage:unit pixels
+
+package main
+
+func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
+	return color
+}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vs := []ebiten.Vertex{{DstX: 0, DstY: 0}, {DstX: 2, DstY: 0}, {DstX: 0, DstY: 2}}
+	is := []uint32{0, 1, 2}
+
+	for _, tc := range []struct {
+		name string
+		draw func(dst *ebiten.Image)
+	}{
+		{"FillRule", func(dst *ebiten.Image) {
+			dst.DrawTriangles32(vs, is, src, &ebiten.DrawTrianglesOptions{FillRule: ebiten.FillRuleNonZero})
+		}},
+		{"AntiAlias", func(dst *ebiten.Image) {
+			dst.DrawTriangles32(vs, is, src, &ebiten.DrawTrianglesOptions{AntiAlias: true})
+		}},
+		{"ShaderFillRule", func(dst *ebiten.Image) {
+			dst.DrawTrianglesShader32(vs, is, shader, &ebiten.DrawTrianglesShaderOptions{FillRule: ebiten.FillRuleNonZero})
+		}},
+		{"ShaderAntiAlias", func(dst *ebiten.Image) {
+			dst.DrawTrianglesShader32(vs, is, shader, &ebiten.DrawTrianglesShaderOptions{AntiAlias: true})
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := ebiten.NewImage(3, 3)
+			dst.Dispose()
+			// This must not panic.
+			tc.draw(dst)
+		})
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
DrawTriangles32 and DrawTrianglesShader32 dispatched to the stencil-buffer path for FillRule or AntiAlias before copyCheck and the disposed checks. A disposed destination then panicked inside the stencil path (via dst.Bounds) instead of doing nothing as documented, and a value-copied image was not detected either.

Move copyCheck and the disposed checks above the stencil dispatch. The source-image and shader disposed panics move with them, which only makes them happen a little earlier on a path that would panic anyway.

Add a regression test that a disposed destination is a no-op on the stencil path.
