### PR TITLE
audio/wav: leave the section reader intact on a failed seek

### DIFF
--- a/audio/wav/decode_test.go
+++ b/audio/wav/decode_test.go
@@ -310,11 +310,31 @@ func TestDecodeSeekOutOfRangeLeavesStreamIntact(t *testing.T) {
 		offset int64
 		whence int
 	}{
-		{"SeekStartNegative", -100, io.SeekStart},
-		{"SeekStartPastEnd", size + 4, io.SeekStart},
-		{"SeekCurrentNegative", -100, io.SeekCurrent},
-		{"SeekEndBeforeStart", -(size + 100), io.SeekEnd},
-		{"SeekEndPastEnd", 100, io.SeekEnd},
+		{
+			name:   "SeekStartNegative",
+			offset: -100,
+			whence: io.SeekStart,
+		},
+		{
+			name:   "SeekStartPastEnd",
+			offset: size + 4,
+			whence: io.SeekStart,
+		},
+		{
+			name:   "SeekCurrentNegative",
+			offset: -100,
+			whence: io.SeekCurrent,
+		},
+		{
+			name:   "SeekEndBeforeStart",
+			offset: -(size + 100),
+			whence: io.SeekEnd,
+		},
+		{
+			name:   "SeekEndPastEnd",
+			offset: 100,
+			whence: io.SeekEnd,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s, err := wav.DecodeWithoutResampling(bytes.NewReader(buf))

--- a/audio/wav/decode_test.go
+++ b/audio/wav/decode_test.go
@@ -292,6 +292,43 @@ func TestDecodeSeekInvalidWhence(t *testing.T) {
 	}
 }
 
+// A failed Seek must leave the stream usable. The old code seeked the
+// underlying source before validating the resolved position, so a small
+// negative seek into a file with a large header moved the source into the
+// header region, and the next Read returned header bytes as audio.
+func TestDecodeSeekOutOfRangeLeavesStreamIntact(t *testing.T) {
+	const dataFill = 0xab
+	const headerFill = 0x5a
+	data := bytes.Repeat([]byte{dataFill}, 8000)
+	// A large chunk before 'fmt ' pushes the data chunk far from the file
+	// start, so that a small negative offset resolves inside the header.
+	header := bytes.Repeat([]byte{headerFill}, 200)
+	buf := wavFile(testSampleRate, []chunk{{id: "LIST", data: string(header)}}, nil, data)
+
+	s, err := wav.DecodeWithoutResampling(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.Seek(-100, io.SeekStart); err == nil {
+		t.Fatal("Seek(-100, io.SeekStart): got no error, want an error")
+	}
+
+	b := make([]byte, 8)
+	n, err := s.Read(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(b) {
+		t.Fatalf("Read: got %d bytes, want %d", n, len(b))
+	}
+	for i := range b {
+		if b[i] != dataFill {
+			t.Fatalf("Read after a failed Seek returned byte %d = %#x, want %#x; the stream leaked header bytes", i, b[i], dataFill)
+		}
+	}
+}
+
 func TestDecodeInvalidSampleRate(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/audio/wav/decode_test.go
+++ b/audio/wav/decode_test.go
@@ -293,35 +293,54 @@ func TestDecodeSeekInvalidWhence(t *testing.T) {
 }
 
 func TestDecodeSeekOutOfRangeLeavesStreamIntact(t *testing.T) {
-	const dataFill = 0xab
+	const size = 8000
 	const headerFill = 0x5a
-	data := bytes.Repeat([]byte{dataFill}, 8000)
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i)
+	}
 	// A large chunk before 'fmt ' pushes the data chunk far from the file
 	// start, so that a small negative offset resolves inside the header.
 	header := bytes.Repeat([]byte{headerFill}, 200)
 	buf := wavFile(testSampleRate, []chunk{{id: "LIST", data: string(header)}}, nil, data)
 
-	s, err := wav.DecodeWithoutResampling(bytes.NewReader(buf))
-	if err != nil {
-		t.Fatal(err)
-	}
+	const pos = 4
+	for _, tc := range []struct {
+		name   string
+		offset int64
+		whence int
+	}{
+		{"SeekStartNegative", -100, io.SeekStart},
+		{"SeekStartPastEnd", size + 4, io.SeekStart},
+		{"SeekCurrentNegative", -100, io.SeekCurrent},
+		{"SeekEndBeforeStart", -(size + 100), io.SeekEnd},
+		{"SeekEndPastEnd", 100, io.SeekEnd},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := wav.DecodeWithoutResampling(bytes.NewReader(buf))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := s.Seek(pos, io.SeekStart); err != nil {
+				t.Fatal(err)
+			}
 
-	if _, err := s.Seek(-100, io.SeekStart); err == nil {
-		t.Fatal("Seek(-100, io.SeekStart): got no error, want an error")
-	}
+			if _, err := s.Seek(tc.offset, tc.whence); err == nil {
+				t.Fatalf("Seek(%d, %d): got no error, want an error", tc.offset, tc.whence)
+			}
 
-	b := make([]byte, 8)
-	n, err := s.Read(b)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != len(b) {
-		t.Fatalf("Read: got %d bytes, want %d", n, len(b))
-	}
-	for i := range b {
-		if b[i] != dataFill {
-			t.Fatalf("Read after a failed Seek returned byte %d = %#x, want %#x; the stream leaked header bytes", i, b[i], dataFill)
-		}
+			b := make([]byte, 8)
+			n, err := s.Read(b)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n != len(b) {
+				t.Fatalf("Read: got %d bytes, want %d", n, len(b))
+			}
+			if want := data[pos : pos+len(b)]; !bytes.Equal(b, want) {
+				t.Fatalf("Read after a failed Seek: got %#x, want %#x", b, want)
+			}
+		})
 	}
 }
 

--- a/audio/wav/decode_test.go
+++ b/audio/wav/decode_test.go
@@ -346,7 +346,7 @@ func TestDecodeSeekOutOfRangeLeavesStreamIntact(t *testing.T) {
 			}
 
 			if _, err := s.Seek(tc.offset, tc.whence); err == nil {
-				t.Fatalf("Seek(%d, %d): got no error, want an error", tc.offset, tc.whence)
+				t.Errorf("Seek(%d, %d): got no error, want an error", tc.offset, tc.whence)
 			}
 
 			b := make([]byte, 8)
@@ -355,10 +355,10 @@ func TestDecodeSeekOutOfRangeLeavesStreamIntact(t *testing.T) {
 				t.Fatal(err)
 			}
 			if n != len(b) {
-				t.Fatalf("Read: got %d bytes, want %d", n, len(b))
+				t.Errorf("Read: got %d bytes, want %d", n, len(b))
 			}
 			if want := data[pos : pos+len(b)]; !bytes.Equal(b, want) {
-				t.Fatalf("Read after a failed Seek: got %#x, want %#x", b, want)
+				t.Errorf("Read after a failed Seek: got %#x, want %#x", b, want)
 			}
 		})
 	}

--- a/audio/wav/decode_test.go
+++ b/audio/wav/decode_test.go
@@ -292,10 +292,6 @@ func TestDecodeSeekInvalidWhence(t *testing.T) {
 	}
 }
 
-// A failed Seek must leave the stream usable. The old code seeked the
-// underlying source before validating the resolved position, so a small
-// negative seek into a file with a large header moved the source into the
-// header region, and the next Read returned header bytes as audio.
 func TestDecodeSeekOutOfRangeLeavesStreamIntact(t *testing.T) {
 	const dataFill = 0xab
 	const headerFill = 0x5a

--- a/audio/wav/sectionreader.go
+++ b/audio/wav/sectionreader.go
@@ -71,13 +71,12 @@ func (s *sectionReader) Seek(offset int64, whence int) (int64, error) {
 		return 0, fmt.Errorf("wav: whence must be io.SeekStart, io.SeekCurrent, or io.SeekEnd but was %d", whence)
 	}
 	if pos < 0 || pos > s.size {
-		return 0, fmt.Errorf("wav: position is out of range")
+		return 0, fmt.Errorf("wav: position must be in [0, %d] but was %d", s.size, pos)
 	}
 
-	n, err := seeker.Seek(pos+s.offset, io.SeekStart)
-	if err != nil {
+	if _, err := seeker.Seek(pos+s.offset, io.SeekStart); err != nil {
 		return 0, err
 	}
-	s.pos = n - s.offset
+	s.pos = pos
 	return s.pos, nil
 }

--- a/audio/wav/sectionreader.go
+++ b/audio/wav/sectionreader.go
@@ -59,11 +59,6 @@ func (s *sectionReader) Seek(offset int64, whence int) (int64, error) {
 		panic("wav: s.src must be io.Seeker but not")
 	}
 
-	// Resolve the target position within the section and validate it before
-	// touching the underlying source, so that a rejected seek leaves both the
-	// source position and s.pos as they were. Seeking first and checking after
-	// would leave the source inside the header when the resolved position is
-	// negative, and the next Read would then return header bytes as audio.
 	var pos int64
 	switch whence {
 	case io.SeekStart:

--- a/audio/wav/sectionreader.go
+++ b/audio/wav/sectionreader.go
@@ -59,23 +59,30 @@ func (s *sectionReader) Seek(offset int64, whence int) (int64, error) {
 		panic("wav: s.src must be io.Seeker but not")
 	}
 
+	// Resolve the target position within the section and validate it before
+	// touching the underlying source, so that a rejected seek leaves both the
+	// source position and s.pos as they were. Seeking first and checking after
+	// would leave the source inside the header when the resolved position is
+	// negative, and the next Read would then return header bytes as audio.
+	var pos int64
 	switch whence {
 	case io.SeekStart:
-		offset += s.offset
+		pos = offset
 	case io.SeekCurrent:
+		pos = s.pos + offset
 	case io.SeekEnd:
-		offset += s.offset + s.size
-		whence = io.SeekStart
+		pos = s.size + offset
 	default:
 		return 0, fmt.Errorf("wav: whence must be io.SeekStart, io.SeekCurrent, or io.SeekEnd but was %d", whence)
 	}
-	n, err := seeker.Seek(offset, whence)
+	if pos < 0 || pos > s.size {
+		return 0, fmt.Errorf("wav: position is out of range")
+	}
+
+	n, err := seeker.Seek(pos+s.offset, io.SeekStart)
 	if err != nil {
 		return 0, err
 	}
 	s.pos = n - s.offset
-	if s.pos < 0 || s.pos > s.size {
-		return 0, fmt.Errorf("wav: position is out of range")
-	}
 	return s.pos, nil
 }


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
sectionReader.Seek seeked the underlying source first and only then checked whether the resolved position was within the section. When the data chunk did not start near the beginning of the file (a large LIST or INFO chunk before it is common), a small negative seek resolved to a valid absolute offset inside the header, so the source seek succeeded and moved into the header while s.pos was left negative and the error was returned. The next Read did not guard s.pos < 0 and returned header bytes as audio. This also violated the io.Seeker contract that a failed seek leaves the stream as it was.

Resolve and validate the target position before touching the source, so a rejected seek changes neither the source position nor s.pos.

Add TestDecodeSeekOutOfRangeLeavesStreamIntact, which fails without this fix.