### PR TITLE
audio: fix a panic when a comparable source joins uncomparable ones

### DIFF
--- a/audio/audio.go
+++ b/audio/audio.go
@@ -207,18 +207,20 @@ func (c *Context) addPlayingPlayer(p *playerImpl) {
 	defer c.m.Unlock()
 	c.playingPlayers[p] = struct{}{}
 
-	if !reflect.ValueOf(p.sourceIdent()).Comparable() {
-		return
-	}
-
-	// Check the source duplication
+	// Check the source duplication. The comparability must be checked for
+	// every playing player, not only for the added one: an earlier player may
+	// have an uncomparable source, and hashing it below would panic.
 	srcs := map[any]struct{}{}
 	for p := range c.playingPlayers {
-		if _, ok := srcs[p.sourceIdent()]; ok {
+		ident := p.sourceIdent()
+		if !reflect.ValueOf(ident).Comparable() {
+			continue
+		}
+		if _, ok := srcs[ident]; ok {
 			c.err = errors.New("audio: the same source must not be used by multiple Player objects")
 			return
 		}
-		srcs[p.sourceIdent()] = struct{}{}
+		srcs[ident] = struct{}{}
 	}
 }
 

--- a/audio/audio_test.go
+++ b/audio/audio_test.go
@@ -309,10 +309,6 @@ func TestUncomparableSource(t *testing.T) {
 	}
 }
 
-// Adding a player whose source is comparable while a player whose source is
-// uncomparable is playing must not panic. The duplication check hashed every
-// playing player's source ident, so an uncomparable ident already in the set
-// made the map lookup panic with "hash of unhashable type".
 func TestComparableSourceAfterUncomparable(t *testing.T) {
 	setup()
 	defer teardown()

--- a/audio/audio_test.go
+++ b/audio/audio_test.go
@@ -309,6 +309,30 @@ func TestUncomparableSource(t *testing.T) {
 	}
 }
 
+// Adding a player whose source is comparable while a player whose source is
+// uncomparable is playing must not panic. The duplication check hashed every
+// playing player's source ident, so an uncomparable ident already in the set
+// made the map lookup panic with "hash of unhashable type".
+func TestComparableSourceAfterUncomparable(t *testing.T) {
+	setup()
+	defer teardown()
+
+	p1, err := context.NewPlayer(uncomparableSource{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p1.Play()
+
+	p2, err := context.NewPlayer(bytes.NewReader(make([]byte, 4)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2.Play()
+
+	p1.Pause()
+	p2.Pause()
+}
+
 // countingSource is an infinite source counting the Read calls.
 type countingSource struct {
 	reads atomic.Int64


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
addPlayingPlayer guarded only the newly added player with a Comparable check, but it inserted that player into playingPlayers before the guard and then hashed the source ident of every playing player in the duplication loop. When an earlier playing player had an uncomparable source (e.g. a slice-backed io.Reader), hashing its ident panicked with "hash of unhashable type" as soon as a later player with a comparable source started playing.

Check comparability per element inside the loop and skip uncomparable idents.

Add TestComparableSourceAfterUncomparable, which panics without this fix.