### PR TITLE
audio: fix an infinite loop in InfiniteLoop.Read's after-loop read

### DIFF
--- a/audio/loop.go
+++ b/audio/loop.go
@@ -253,7 +253,10 @@ func (i *InfiniteLoop) Read(b []byte) (int, error) {
 					return 0, err
 				}
 				pos += n
-				if err == io.EOF {
+				// Break on EOF, and also when no progress is made so that a
+				// source returning (0, nil) does not spin here forever. The
+				// main read loop above has the same guard.
+				if err != nil || n == 0 {
 					break
 				}
 			}

--- a/audio/loop_test.go
+++ b/audio/loop_test.go
@@ -232,7 +232,6 @@ func (s *stalledReader) Seek(offset int64, whence int) (int64, error) {
 	return s.src.Seek(offset, whence)
 }
 
-// The after-loop read must not spin forever when the source returns (0, nil).
 func TestInfiniteLoopWithStalledSourceAfterLoop(t *testing.T) {
 	const length = 4096
 	src := make([]byte, length)

--- a/audio/loop_test.go
+++ b/audio/loop_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/hajimehoshi/ebiten/v2/audio"
 )
@@ -210,6 +211,48 @@ func (s *slowReader) Read(buf []byte) (int, error) {
 func (s *slowReader) Seek(offset int64, whence int) (int64, error) {
 	s.eof = false
 	return s.src.Seek(offset, whence)
+}
+
+// stalledReader delivers data until its source is exhausted, then reports the
+// end as (0, nil) instead of io.EOF, like a real-time source that simply has
+// no data ready yet. This is a legal io.Reader behavior.
+type stalledReader struct {
+	src io.ReadSeeker
+}
+
+func (s *stalledReader) Read(buf []byte) (int, error) {
+	n, err := s.src.Read(buf)
+	if err == io.EOF {
+		return 0, nil
+	}
+	return n, err
+}
+
+func (s *stalledReader) Seek(offset int64, whence int) (int64, error) {
+	return s.src.Seek(offset, whence)
+}
+
+// The after-loop read must not spin forever when the source returns (0, nil).
+func TestInfiniteLoopWithStalledSourceAfterLoop(t *testing.T) {
+	const length = 4096
+	src := make([]byte, length)
+	loop := audio.NewInfiniteLoop(&stalledReader{src: bytes.NewReader(src)}, length)
+
+	buf := make([]byte, length)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, err := loop.Read(buf); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Read hung: the after-loop read did not break on a (0, nil) source")
+	}
 }
 
 func TestInfiniteLoopWithSlowSource(t *testing.T) {


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
When the loop position reached the end with no error, Read filled the after-loop buffer with a loop that broke only on io.EOF. A source that returns (0, nil), which is legal for a real-time source with no data ready, made pos never advance and the loop never terminate. The main read loop above already guards against this with an m == 0 break; the after-loop loop did not.

Break when no progress is made, mirroring the main loop.

Add TestInfiniteLoopWithStalledSourceAfterLoop, which hangs without this fix.