### PR TITLE
vector: fix QuadTo dropping quadratic loops

### DIFF
--- a/vector/export_test.go
+++ b/vector/export_test.go
@@ -14,7 +14,10 @@
 
 package vector
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type Point struct {
 	X, Y float32
@@ -47,4 +50,24 @@ func CurrentPosition(path *Path) (Point, bool) {
 
 func SubPathCount(path *Path) int {
 	return len(path.subPaths)
+}
+
+// PathOperationsString returns a string representation of the operations in the path.
+func PathOperationsString(path *Path) string {
+	var sb strings.Builder
+	for _, subPath := range path.subPaths {
+		sb.WriteString(fmt.Sprintf("MoveTo(%v, %v)\n", subPath.start.x, subPath.start.y))
+		for _, o := range subPath.ops {
+			switch o.typ {
+			case opTypeLineTo:
+				sb.WriteString(fmt.Sprintf("LineTo(%v, %v)\n", o.p1.x, o.p1.y))
+			case opTypeQuadTo:
+				sb.WriteString(fmt.Sprintf("QuadTo(%v, %v, %v, %v)\n", o.p1.x, o.p1.y, o.p2.x, o.p2.y))
+			}
+		}
+		if subPath.closed {
+			sb.WriteString("Close()\n")
+		}
+	}
+	return sb.String()
 }

--- a/vector/path.go
+++ b/vector/path.go
@@ -268,11 +268,10 @@ func (p *Path) QuadTo(x1, y1, x2, y2 float32) {
 	}
 	p.resetLastSubPathCacheStates()
 	if cur, ok := p.currentPosition(); ok {
-		// A quadratic whose start, control, and end points all coincide is a
-		// single point and can be dropped. When only the start and the end
-		// coincide but the control point differs, the curve is a real loop and
-		// must be kept.
-		if cur.x == x2 && cur.y == y2 && cur.x == x1 && cur.y == y1 {
+		// A quadratic whose start, control, and end points all coincide is a single point and can be dropped.
+		// Even if the start and end points coincide, the curve is not a single point when the control point differs:
+		// it is a degenerate curve (a cusp) which goes to the midpoint and comes back, so it must be kept.
+		if cur.x == x1 && cur.y == y1 && cur.x == x2 && cur.y == y2 {
 			return
 		}
 	}
@@ -678,15 +677,18 @@ func (p *Path) normalize() {
 				cur = op.p1
 			case opTypeQuadTo:
 				switch {
-				case cur == op.p2 && cur == op.p1:
+				case cur == op.p1 && op.p1 == op.p2:
 					// A single point: drop it.
 					continue
+				case cur == op.p2:
+					// A degenerate curve (a cusp), which goes to the midpoint and comes back. Keep it as a curve.
+					cur = op.p2
 				case cur == op.p1, op.p1 == op.p2:
 					op.typ = opTypeLineTo
 					op.p1 = op.p2
 					op.p2 = point{}
 					cur = op.p1
-				case cur != op.p2 && (op.p1.x-cur.x)*(op.p2.y-cur.y)-(op.p2.x-cur.x)*(op.p1.y-cur.y) == 0:
+				case (op.p1.x-cur.x)*(op.p2.y-cur.y)-(op.p2.x-cur.x)*(op.p1.y-cur.y) == 0:
 					op.typ = opTypeLineTo
 					op.p1 = op.p2
 					op.p2 = point{}

--- a/vector/path.go
+++ b/vector/path.go
@@ -184,6 +184,10 @@ type Path struct {
 	// flatPaths is a cached actual rendering positions.
 	// flatPaths is used only for deprecated functions. Do not use this for new functions.
 	flatPaths []flatPath
+
+	// opsScratch is a scratch slice of operations, which normalize uses
+	// when a sub-path has a cusp and the number of operations increases.
+	opsScratch []op
 }
 
 // Reset resets the path.
@@ -663,9 +667,10 @@ func (p *Path) AddPath(src *Path, options *AddPathOptions) {
 	}
 }
 
-// hasCusp reports whether subPath has a cusp, which is a quadratic curve whose start and end points are the same
+// countCusps counts the number of cusps in subPath, which are quadratic curves whose start and end points are the same
 // and whose control point differs from them.
-func hasCusp(subPath *subPath) bool {
+func countCusps(subPath *subPath) int {
+	var n int
 	cur := subPath.start
 	for _, op := range subPath.ops {
 		switch op.typ {
@@ -673,12 +678,12 @@ func hasCusp(subPath *subPath) bool {
 			cur = op.p1
 		case opTypeQuadTo:
 			if cur == op.p2 && cur != op.p1 {
-				return true
+				n++
 			}
 			cur = op.p2
 		}
 	}
-	return false
+	return n
 }
 
 // normalize normalizes the path by removing unnecessary sub-paths and points.
@@ -686,10 +691,12 @@ func (p *Path) normalize() {
 	for i, subPath := range p.subPaths {
 		cur := subPath.start
 		ops := subPath.ops[:0]
-		if hasCusp(&subPath) {
+		if n := countCusps(&subPath); n > 0 {
 			// A cusp is converted into two lines, which increases the number of operations.
-			// Use a new slice in this case to avoid overwriting the source operations before they are read.
-			ops = make([]op, 0, len(subPath.ops)+1)
+			// Normalize into the scratch slice in this case to avoid overwriting the source operations before they are read.
+			// The source operations become the new scratch so that the slices are reused.
+			ops = slices.Grow(p.opsScratch[:0], len(subPath.ops)+n)
+			p.opsScratch = subPath.ops
 		}
 		for _, op := range subPath.ops {
 			switch op.typ {
@@ -706,9 +713,10 @@ func (p *Path) normalize() {
 				case cur == op.p2:
 					// A cusp goes to the midpoint and comes back.
 					// Keep this as lines, not as a curve, so that the 180-degree turn at the tip gets a joint.
+					// Divide by 2 before adding so that the midpoint computation cannot overflow.
 					mid := point{
-						x: (cur.x + op.p1.x) / 2,
-						y: (cur.y + op.p1.y) / 2,
+						x: cur.x/2 + op.p1.x/2,
+						y: cur.y/2 + op.p1.y/2,
 					}
 					if mid == cur {
 						// The midpoint is rounded to the current point in float32, so there is nothing to keep.

--- a/vector/path.go
+++ b/vector/path.go
@@ -185,9 +185,9 @@ type Path struct {
 	// flatPaths is used only for deprecated functions. Do not use this for new functions.
 	flatPaths []flatPath
 
-	// opsScratch is a scratch slice of operations, which normalize uses
+	// opsBuf is a buffer of operations, which normalize uses
 	// when a sub-path has a cusp and the number of operations increases.
-	opsScratch []op
+	opsBuf []op
 }
 
 // Reset resets the path.
@@ -693,10 +693,10 @@ func (p *Path) normalize() {
 		ops := subPath.ops[:0]
 		if n := countCusps(&subPath); n > 0 {
 			// A cusp is converted into two lines, which increases the number of operations.
-			// Normalize into the scratch slice in this case to avoid overwriting the source operations before they are read.
-			// The source operations become the new scratch so that the slices are reused.
-			ops = slices.Grow(p.opsScratch[:0], len(subPath.ops)+n)
-			p.opsScratch = subPath.ops
+			// Normalize into the buffer in this case to avoid overwriting the source operations before they are read.
+			// The source operations become the new buffer so that the slices are reused.
+			ops = slices.Grow(p.opsBuf[:0], len(subPath.ops)+n)
+			p.opsBuf = subPath.ops
 		}
 		for _, op := range subPath.ops {
 			switch op.typ {

--- a/vector/path.go
+++ b/vector/path.go
@@ -269,8 +269,8 @@ func (p *Path) QuadTo(x1, y1, x2, y2 float32) {
 	p.resetLastSubPathCacheStates()
 	if cur, ok := p.currentPosition(); ok {
 		// A quadratic whose start, control, and end points all coincide is a single point and can be dropped.
-		// Even if the start and end points coincide, the curve is not a single point when the control point differs:
-		// it is a degenerate curve (a cusp) which goes to the midpoint and comes back, so it must be kept.
+		// Even if the start and end points coincide, it is not a single point when the control point differs:
+		// it is a cusp, which goes to the midpoint and comes back, so it must be kept.
 		if cur.x == x1 && cur.y == y1 && cur.x == x2 && cur.y == y2 {
 			return
 		}
@@ -663,11 +663,34 @@ func (p *Path) AddPath(src *Path, options *AddPathOptions) {
 	}
 }
 
+// hasCusp reports whether subPath has a cusp, which is a quadratic curve whose start and end points are the same
+// and whose control point differs from them.
+func hasCusp(subPath *subPath) bool {
+	cur := subPath.start
+	for _, op := range subPath.ops {
+		switch op.typ {
+		case opTypeLineTo:
+			cur = op.p1
+		case opTypeQuadTo:
+			if cur == op.p2 && cur != op.p1 {
+				return true
+			}
+			cur = op.p2
+		}
+	}
+	return false
+}
+
 // normalize normalizes the path by removing unnecessary sub-paths and points.
 func (p *Path) normalize() {
 	for i, subPath := range p.subPaths {
 		cur := subPath.start
-		var n int
+		ops := subPath.ops[:0]
+		if hasCusp(&subPath) {
+			// A cusp is converted into two lines, which increases the number of operations.
+			// Use a new slice in this case to avoid overwriting the source operations before they are read.
+			ops = make([]op, 0, len(subPath.ops)+1)
+		}
 		for _, op := range subPath.ops {
 			switch op.typ {
 			case opTypeLineTo:
@@ -681,8 +704,25 @@ func (p *Path) normalize() {
 					// A single point: drop it.
 					continue
 				case cur == op.p2:
-					// A degenerate curve (a cusp), which goes to the midpoint and comes back. Keep it as a curve.
-					cur = op.p2
+					// A cusp goes to the midpoint and comes back.
+					// Keep this as lines, not as a curve, so that the 180-degree turn at the tip gets a joint.
+					mid := point{
+						x: (cur.x + op.p1.x) / 2,
+						y: (cur.y + op.p1.y) / 2,
+					}
+					if mid == cur {
+						// The midpoint is rounded to the current point in float32, so there is nothing to keep.
+						continue
+					}
+					first := op
+					first.typ = opTypeLineTo
+					first.p1 = mid
+					first.p2 = point{}
+					ops = append(ops, first)
+					op.typ = opTypeLineTo
+					op.p1 = op.p2
+					op.p2 = point{}
+					cur = op.p1
 				case cur == op.p1, op.p1 == op.p2:
 					op.typ = opTypeLineTo
 					op.p1 = op.p2
@@ -697,10 +737,9 @@ func (p *Path) normalize() {
 					cur = op.p2
 				}
 			}
-			p.subPaths[i].ops[n] = op
-			n++
+			ops = append(ops, op)
 		}
-		p.subPaths[i].ops = slices.Delete(p.subPaths[i].ops, n, len(subPath.ops))
+		p.subPaths[i].ops = ops
 	}
 
 	// Do not use slices.DeleteFunc as sub-paths's slices should be reused.

--- a/vector/path.go
+++ b/vector/path.go
@@ -268,7 +268,11 @@ func (p *Path) QuadTo(x1, y1, x2, y2 float32) {
 	}
 	p.resetLastSubPathCacheStates()
 	if cur, ok := p.currentPosition(); ok {
-		if cur.x == x2 && cur.y == y2 {
+		// A quadratic whose start, control, and end points all coincide is a
+		// single point and can be dropped. When only the start and the end
+		// coincide but the control point differs, the curve is a real loop and
+		// must be kept.
+		if cur.x == x2 && cur.y == y2 && cur.x == x1 && cur.y == y1 {
 			return
 		}
 	}
@@ -674,14 +678,15 @@ func (p *Path) normalize() {
 				cur = op.p1
 			case opTypeQuadTo:
 				switch {
-				case cur == op.p2:
+				case cur == op.p2 && cur == op.p1:
+					// A single point: drop it.
 					continue
 				case cur == op.p1, op.p1 == op.p2:
 					op.typ = opTypeLineTo
 					op.p1 = op.p2
 					op.p2 = point{}
 					cur = op.p1
-				case (op.p1.x-cur.x)*(op.p2.y-cur.y)-(op.p2.x-cur.x)*(op.p1.y-cur.y) == 0:
+				case cur != op.p2 && (op.p1.x-cur.x)*(op.p2.y-cur.y)-(op.p2.x-cur.x)*(op.p1.y-cur.y) == 0:
 					op.typ = opTypeLineTo
 					op.p1 = op.p2
 					op.p2 = point{}

--- a/vector/path_test.go
+++ b/vector/path_test.go
@@ -542,22 +542,43 @@ func TestStrokeMiterJoinNearlyCollinear(t *testing.T) {
 	}
 }
 
-func TestQuadLoopIsKept(t *testing.T) {
+func TestQuadCuspIsKept(t *testing.T) {
 	var p vector.Path
 	p.MoveTo(0, 0)
 	p.QuadTo(10, 10, 0, 0)
 
-	// The loop reaches (5, 5) at t=0.5, so its bounds must not be empty.
-	if b := p.Bounds(); b.Empty() {
-		t.Errorf("Bounds of a quadratic loop: got empty %v, want a non-empty rectangle", b)
+	// The cusp reaches (5, 5) at t=0.5.
+	if got, want := p.Bounds(), image.Rect(0, 0, 5, 5); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
 	}
 
-	// A quadratic whose start, control, and end all coincide is a single point
-	// and is still dropped.
 	var d vector.Path
 	d.MoveTo(5, 5)
 	d.QuadTo(5, 5, 5, 5)
 	if b := d.Bounds(); !b.Empty() {
-		t.Errorf("Bounds of a fully degenerate quadratic: got %v, want empty", b)
+		t.Errorf("Bounds of a single point: got %v, want empty", b)
+	}
+}
+
+func TestStrokeQuadCusp(t *testing.T) {
+	var p vector.Path
+	p.MoveTo(0, 0)
+	p.LineTo(100, 0)
+	p.QuadTo(100, 50, 100, 0)
+	p.LineTo(200, 0)
+
+	op := &vector.AddStrokeOptions{}
+	op.StrokeOptions.Width = 10
+
+	var sp vector.Path
+	sp.AddStroke(&p, op)
+
+	// The cusp reaches (100, 25) at its midpoint.
+	if got, want := sp.Bounds(), image.Rect(0, -5, 200, 25); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+
+	if got, want := p.Bounds(), image.Rect(0, 0, 200, 25); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
 	}
 }

--- a/vector/path_test.go
+++ b/vector/path_test.go
@@ -18,7 +18,6 @@ import (
 	"image"
 	"image/color"
 	"runtime"
-	"strings"
 	"sync"
 	"testing"
 
@@ -626,10 +625,23 @@ func TestStrokeHugeQuadCusp(t *testing.T) {
 	var sp vector.Path
 	sp.AddStroke(&p, op)
 
-	// AddStroke normalizes the source path in place, so the source path must not hold an infinite point.
-	for _, s := range []string{vector.PathOperationsString(&p), vector.PathOperationsString(&sp)} {
-		if strings.Contains(s, "+Inf") || strings.Contains(s, "-Inf") || strings.Contains(s, "NaN") {
-			t.Errorf("got:\n%v\nwant: no infinity or NaN", s)
-		}
+	// AddStroke normalizes the source path in place.
+	// The midpoint is (3.2e38, 1) without overflowing to infinity.
+	if got, want := vector.PathOperationsString(&p), "MoveTo(3e+38, 1)\nLineTo(3.2e+38, 1)\nLineTo(3e+38, 1)\n"; got != want {
+		t.Errorf("got:\n%v\nwant:\n%v", got, want)
+	}
+
+	// The cusp is equivalent to this out-and-back path.
+	var l vector.Path
+	l.MoveTo(3.0e38, 1)
+	l.LineTo(3.2e38, 1)
+	l.LineTo(3.0e38, 1)
+
+	var lp vector.Path
+	lp.AddStroke(&l, op)
+
+	// The stroked cusp must agree with the stroked out-and-back path exactly.
+	if got, want := vector.PathOperationsString(&sp), vector.PathOperationsString(&lp); got != want {
+		t.Errorf("got:\n%v\nwant:\n%v", got, want)
 	}
 }

--- a/vector/path_test.go
+++ b/vector/path_test.go
@@ -542,8 +542,6 @@ func TestStrokeMiterJoinNearlyCollinear(t *testing.T) {
 	}
 }
 
-// A quadratic curve whose start and end coincide but whose control point
-// differs is a real loop, not a degenerate point, and must be kept.
 func TestQuadLoopIsKept(t *testing.T) {
 	var p vector.Path
 	p.MoveTo(0, 0)

--- a/vector/path_test.go
+++ b/vector/path_test.go
@@ -18,6 +18,7 @@ import (
 	"image"
 	"image/color"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 
@@ -610,5 +611,25 @@ func TestStrokeTinyQuadCusp(t *testing.T) {
 	sp.AddStroke(&p, op)
 	if got, want := vector.SubPathCount(&sp), 0; got != want {
 		t.Errorf("got: %v, want: %v", got, want)
+	}
+}
+
+func TestStrokeHugeQuadCusp(t *testing.T) {
+	// The midpoint of this cusp must not overflow to infinity in float32.
+	var p vector.Path
+	p.MoveTo(3.0e38, 1)
+	p.QuadTo(3.4e38, 1, 3.0e38, 1)
+
+	op := &vector.AddStrokeOptions{}
+	op.StrokeOptions.Width = 4
+
+	var sp vector.Path
+	sp.AddStroke(&p, op)
+
+	// AddStroke normalizes the source path in place, so the source path must not hold an infinite point.
+	for _, s := range []string{vector.PathOperationsString(&p), vector.PathOperationsString(&sp)} {
+		if strings.Contains(s, "+Inf") || strings.Contains(s, "-Inf") || strings.Contains(s, "NaN") {
+			t.Errorf("got:\n%v\nwant: no infinity or NaN", s)
+		}
 	}
 }

--- a/vector/path_test.go
+++ b/vector/path_test.go
@@ -541,3 +541,25 @@ func TestStrokeMiterJoinNearlyCollinear(t *testing.T) {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 }
+
+// A quadratic curve whose start and end coincide but whose control point
+// differs is a real loop, not a degenerate point, and must be kept.
+func TestQuadLoopIsKept(t *testing.T) {
+	var p vector.Path
+	p.MoveTo(0, 0)
+	p.QuadTo(10, 10, 0, 0)
+
+	// The loop reaches (5, 5) at t=0.5, so its bounds must not be empty.
+	if b := p.Bounds(); b.Empty() {
+		t.Errorf("Bounds of a quadratic loop: got empty %v, want a non-empty rectangle", b)
+	}
+
+	// A quadratic whose start, control, and end all coincide is a single point
+	// and is still dropped.
+	var d vector.Path
+	d.MoveTo(5, 5)
+	d.QuadTo(5, 5, 5, 5)
+	if b := d.Bounds(); !b.Empty() {
+		t.Errorf("Bounds of a fully degenerate quadratic: got %v, want empty", b)
+	}
+}

--- a/vector/path_test.go
+++ b/vector/path_test.go
@@ -567,18 +567,48 @@ func TestStrokeQuadCusp(t *testing.T) {
 	p.QuadTo(100, 50, 100, 0)
 	p.LineTo(200, 0)
 
+	// The cusp reaches (100, 25) at its midpoint, so it is equivalent to this out-and-back path.
+	var l vector.Path
+	l.MoveTo(0, 0)
+	l.LineTo(100, 0)
+	l.LineTo(100, 25)
+	l.LineTo(100, 0)
+	l.LineTo(200, 0)
+
+	for _, lineJoin := range []vector.LineJoin{vector.LineJoinMiter, vector.LineJoinBevel, vector.LineJoinRound} {
+		op := &vector.AddStrokeOptions{}
+		op.StrokeOptions.Width = 10
+		op.StrokeOptions.LineJoin = lineJoin
+
+		var sp vector.Path
+		sp.AddStroke(&p, op)
+		var lp vector.Path
+		lp.AddStroke(&l, op)
+
+		// The stroked cusp must agree with the stroked out-and-back path exactly, including the joint at the tip.
+		if got, want := vector.PathOperationsString(&sp), vector.PathOperationsString(&lp); got != want {
+			t.Errorf("LineJoin %d: got:\n%v\nwant:\n%v", lineJoin, got, want)
+		}
+	}
+
+	// AddStroke normalizes the source path in place, and the bounds of the cusp must be kept.
+	if got, want := p.Bounds(), image.Rect(0, 0, 200, 25); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}
+
+func TestStrokeTinyQuadCusp(t *testing.T) {
+	// The midpoint of this cusp is rounded back to the start point in float32, so there is nothing to stroke.
+	var p vector.Path
+	p.MoveTo(1e7, 0)
+	p.QuadTo(1e7+1, 0, 1e7, 0)
+
 	op := &vector.AddStrokeOptions{}
-	op.StrokeOptions.Width = 10
+	op.StrokeOptions.Width = 4
 
 	var sp vector.Path
 	sp.AddStroke(&p, op)
-
-	// The cusp reaches (100, 25) at its midpoint.
-	if got, want := sp.Bounds(), image.Rect(0, -5, 200, 25); got != want {
-		t.Errorf("got: %v, want: %v", got, want)
-	}
-
-	if got, want := p.Bounds(), image.Rect(0, 0, 200, 25); got != want {
+	if got, want := vector.SubPathCount(&sp), 0; got != want {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 }

--- a/vector/stroke.go
+++ b/vector/stroke.go
@@ -174,7 +174,7 @@ func appendParalleledPathFromSubPath(strokePath *Path, subPath *subPath, options
 
 	// As the source path is normalized, every operation is guaranteed to be valid.
 	// A line operation must have a different point from the start point.
-	// A quadratic curve operation must have create a curve, not a line.
+	// A quadratic curve operation must not be a single point, but can be a degenerate curve whose start and end points are the same.
 
 	cur := subPath.start
 
@@ -228,8 +228,15 @@ func appendParalleledLineForQuadIfNeeded(path *Path, p0, p1, p2 point, dist floa
 	if p0 == p1 && p0 == p2 {
 		panic("not reached")
 	}
-	// This curve is empty as the start and the end points are the same.
+	// This curve goes and comes back on a line segment as the start and the end points are the same.
+	// Split it at t=0.5 so that each half is a line, and append paralleled lines for them.
 	if p0 == p2 {
+		p01 := point{
+			x: (p0.x + p1.x) / 2,
+			y: (p0.y + p1.y) / 2,
+		}
+		appendParalleledLine(path, p0, p01, dist)
+		appendParalleledLine(path, p01, p0, dist)
 		return true
 	}
 	// This curve is a line as the control point is the same as the start point.

--- a/vector/stroke.go
+++ b/vector/stroke.go
@@ -198,7 +198,7 @@ func appendParalleledPathFromSubPathReversed(strokePath *Path, subPath *subPath,
 
 	// As the source path is normalized, every operation is guaranteed to be valid.
 	// A line operation must have a different point from the start point.
-	// A quadratic curve operation must have create a curve, not a line.
+	// A quadratic curve operation must not be a single point, but can be a degenerate curve whose start and end points are the same.
 
 	for i, op := range slices.Backward(subPath.ops) {
 		nextP := subPath.startAtOp(i)

--- a/vector/stroke.go
+++ b/vector/stroke.go
@@ -174,7 +174,7 @@ func appendParalleledPathFromSubPath(strokePath *Path, subPath *subPath, options
 
 	// As the source path is normalized, every operation is guaranteed to be valid.
 	// A line operation must have a different point from the start point.
-	// A quadratic curve operation must not be a single point, but can be a degenerate curve whose start and end points are the same.
+	// A quadratic curve operation must not be a single point nor a cusp, which are dropped or converted into lines by normalize.
 
 	cur := subPath.start
 
@@ -187,6 +187,8 @@ func appendParalleledPathFromSubPath(strokePath *Path, subPath *subPath, options
 			appendParalleledQuad(strokePath, cur, op.p1, op.p2, options.Width/2)
 			cur = op.p2
 		}
+		// Add a joint between this operation and the next operation.
+		// This also renders the 180-degree turn at the tip of a cusp, which normalize converted into two lines.
 		addJoint(strokePath, subPath, i, false, options)
 	}
 }
@@ -198,7 +200,7 @@ func appendParalleledPathFromSubPathReversed(strokePath *Path, subPath *subPath,
 
 	// As the source path is normalized, every operation is guaranteed to be valid.
 	// A line operation must have a different point from the start point.
-	// A quadratic curve operation must not be a single point, but can be a degenerate curve whose start and end points are the same.
+	// A quadratic curve operation must not be a single point nor a cusp, which are dropped or converted into lines by normalize.
 
 	for i, op := range slices.Backward(subPath.ops) {
 		nextP := subPath.startAtOp(i)
@@ -208,6 +210,8 @@ func appendParalleledPathFromSubPathReversed(strokePath *Path, subPath *subPath,
 		case opTypeQuadTo:
 			appendParalleledQuad(strokePath, op.p2, op.p1, nextP, options.Width/2)
 		}
+		// Add a joint between this operation and the previous operation.
+		// This also renders the 180-degree turn at the tip of a cusp, which normalize converted into two lines.
 		addJoint(strokePath, subPath, i, true, options)
 	}
 }
@@ -228,15 +232,11 @@ func appendParalleledLineForQuadIfNeeded(path *Path, p0, p1, p2 point, dist floa
 	if p0 == p1 && p0 == p2 {
 		panic("not reached")
 	}
-	// This curve goes and comes back on a line segment as the start and the end points are the same.
-	// Split it at t=0.5 so that each half is a line, and append paralleled lines for them.
+	// A normalized path never has a cusp, whose start and end points are the same,
+	// as normalize drops a single point and converts a cusp into two lines.
+	// This can happen only in doAppendParalleledQuad when a tiny curve is split,
+	// and then the split halves are empty in float32.
 	if p0 == p2 {
-		p01 := point{
-			x: (p0.x + p1.x) / 2,
-			y: (p0.y + p1.y) / 2,
-		}
-		appendParalleledLine(path, p0, p01, dist)
-		appendParalleledLine(path, p01, p0, dist)
 		return true
 	}
 	// This curve is a line as the control point is the same as the start point.


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
QuadTo returned early when the current position equaled the destination, treating any such curve as degenerate. A quadratic whose start and end coincide but whose control point differs is a real loop (at t=0.5 it is at the midpoint of the start and the control point), so the curve was silently dropped and the path lost geometry. normalize had the same assumption and would drop a kept loop as well.

Only drop a quadratic when the start, control, and end points all coincide, and keep a loop through normalize.

Add TestQuadLoopIsKept, which fails without this fix.