### PR TITLE
text/v2: detect Arabic Presentation Forms and RLM in the chunk fast path

### DIFF
--- a/text/v2/internal/chunk/chunk.go
+++ b/text/v2/internal/chunk/chunk.go
@@ -319,12 +319,15 @@ func mayContainStrongRTLInFirstLine(text string) bool {
 	//     (Hebrew, Arabic, Syriac, Arabic Supplement, Thaana, NKo).
 	//   - 0xE0       — 3-byte UTF-8 covering U+0800..U+08FF
 	//     (Samaritan, Mandaic, Syriac Supplement, Arabic Extended-A/B).
+	//   - 0xEF       — 3-byte UTF-8 covering U+FB50..U+FDFF and
+	//     U+FE70..U+FEFF (Arabic Presentation Forms A and B, class AL).
 	//   - 0xF0       — 4-byte UTF-8 covering plane 1
 	//     (Mende Kikakui, Adlam, and other SMP RTL scripts).
 	//
-	// 0xF0 admits false positives for non-RTL SMP content (emoji,
-	// mathematical alphanumerics); those texts go through the bidi
-	// pass and chunk correctly anyway.
+	// 0xEF and 0xF0 admit false positives for non-RTL content (the
+	// private use area and CJK compatibility for 0xEF; emoji and
+	// mathematical alphanumerics for 0xF0); those texts go through the
+	// bidi pass and chunk correctly anyway.
 	//
 	// Line-break bytes are detected inline so the scan stops at the
 	// first line break instead of walking past it.
@@ -332,6 +335,8 @@ func mayContainStrongRTLInFirstLine(text string) bool {
 	//   NEL  U+0085 → 0xC2 0x85
 	//   LS   U+2028 → 0xE2 0x80 0xA8
 	//   PS   U+2029 → 0xE2 0x80 0xA9
+	// RLM (U+200F, class R) shares the 0xE2 0x80 prefix and is detected
+	// alongside the line separators.
 	for i := range len(text) {
 		b := text[i]
 		if b < 0x80 {
@@ -341,14 +346,19 @@ func mayContainStrongRTLInFirstLine(text string) bool {
 			}
 			continue
 		}
-		if (b >= 0xD6 && b <= 0xE0) || b == 0xF0 {
+		if (b >= 0xD6 && b <= 0xE0) || b == 0xEF || b == 0xF0 {
 			return true
 		}
 		if b == 0xC2 && i+1 < len(text) && text[i+1] == 0x85 {
 			return false
 		}
-		if b == 0xE2 && i+2 < len(text) && text[i+1] == 0x80 && (text[i+2] == 0xA8 || text[i+2] == 0xA9) {
-			return false
+		if b == 0xE2 && i+2 < len(text) && text[i+1] == 0x80 {
+			switch text[i+2] {
+			case 0x8F: // RLM U+200F, strong RTL
+				return true
+			case 0xA8, 0xA9: // LS U+2028, PS U+2029
+				return false
+			}
 		}
 	}
 	return false

--- a/text/v2/internal/chunk/chunk.go
+++ b/text/v2/internal/chunk/chunk.go
@@ -319,15 +319,20 @@ func mayContainStrongRTLInFirstLine(text string) bool {
 	//     (Hebrew, Arabic, Syriac, Arabic Supplement, Thaana, NKo).
 	//   - 0xE0       — 3-byte UTF-8 covering U+0800..U+08FF
 	//     (Samaritan, Mandaic, Syriac Supplement, Arabic Extended-A/B).
-	//   - 0xEF       — 3-byte UTF-8 covering U+FB50..U+FDFF and
-	//     U+FE70..U+FEFF (Arabic Presentation Forms A and B, class AL).
+	//   - 0xEF 0xAC..0xBB — 3-byte UTF-8 covering U+FB00..U+FEFF
+	//     (Hebrew Presentation Forms, class R, and Arabic Presentation
+	//     Forms A and B, class AL). The second byte is restricted to
+	//     0xAC..0xBB because 0xEF alone also covers the
+	//     halfwidth/fullwidth forms (U+FF00..U+FFEF, class ON/NSM)
+	//     that appear in almost every Japanese sentence, and pushing
+	//     those off the fast path costs more than it is worth.
 	//   - 0xF0       — 4-byte UTF-8 covering plane 1
 	//     (Mende Kikakui, Adlam, and other SMP RTL scripts).
 	//
-	// 0xEF and 0xF0 admit false positives for non-RTL content (the
-	// private use area and CJK compatibility for 0xEF; emoji and
-	// mathematical alphanumerics for 0xF0); those texts go through the
-	// bidi pass and chunk correctly anyway.
+	// 0xEF and 0xF0 admit false positives for non-RTL content (Latin
+	// ligatures and CJK compatibility forms for 0xEF 0xAC..0xBB;
+	// emoji and mathematical alphanumerics for 0xF0); those texts go
+	// through the bidi pass and chunk correctly anyway.
 	//
 	// Line-break bytes are detected inline so the scan stops at the
 	// first line break instead of walking past it.
@@ -346,7 +351,12 @@ func mayContainStrongRTLInFirstLine(text string) bool {
 			}
 			continue
 		}
-		if (b >= 0xD6 && b <= 0xE0) || b == 0xEF || b == 0xF0 {
+		if (b >= 0xD6 && b <= 0xE0) || b == 0xF0 {
+			return true
+		}
+		// 0xEF with a second byte of 0xAC..0xBB is exactly
+		// U+FB00..U+FEFF, the Hebrew and Arabic presentation forms.
+		if b == 0xEF && i+1 < len(text) && text[i+1] >= 0xAC && text[i+1] <= 0xBB {
 			return true
 		}
 		if b == 0xC2 && i+1 < len(text) && text[i+1] == 0x85 {

--- a/text/v2/internal/chunk/chunk.go
+++ b/text/v2/internal/chunk/chunk.go
@@ -320,17 +320,17 @@ func mayContainStrongRTLInFirstLine(text string) bool {
 	//   - 0xE0       — 3-byte UTF-8 covering U+0800..U+08FF
 	//     (Samaritan, Mandaic, Syriac Supplement, Arabic Extended-A/B).
 	//   - 0xEF 0xAC..0xBB — 3-byte UTF-8 covering U+FB00..U+FEFF
-	//     (Hebrew Presentation Forms, class R, and Arabic Presentation
-	//     Forms A and B, class AL). The second byte is restricted to
-	//     0xAC..0xBB because 0xEF alone also covers the
-	//     halfwidth/fullwidth forms (U+FF00..U+FFEF, class ON/NSM)
-	//     that appear in almost every Japanese sentence, and pushing
-	//     those off the fast path costs more than it is worth.
+	//     exactly (Hebrew Presentation Forms, class R, and Arabic
+	//     Presentation Forms A and B, class AL). The common non-RTL
+	//     forms at U+FF00 and above — halfwidth/fullwidth punctuation
+	//     and katakana, found in almost every Japanese sentence —
+	//     fall outside the second-byte range and keep the fast path.
 	//   - 0xF0       — 4-byte UTF-8 covering plane 1
 	//     (Mende Kikakui, Adlam, and other SMP RTL scripts).
 	//
-	// 0xEF and 0xF0 admit false positives for non-RTL content (Latin
-	// ligatures and CJK compatibility forms for 0xEF 0xAC..0xBB;
+	// 0xEF 0xAC..0xBB and 0xF0 admit false positives for non-RTL
+	// content (variation selectors such as U+FE0F on emoji, Latin
+	// ligatures, and CJK compatibility forms for 0xEF 0xAC..0xBB;
 	// emoji and mathematical alphanumerics for 0xF0); those texts go
 	// through the bidi pass and chunk correctly anyway.
 	//

--- a/text/v2/internal/chunk/chunk_test.go
+++ b/text/v2/internal/chunk/chunk_test.go
@@ -271,6 +271,28 @@ func TestChunks_Levels(t *testing.T) {
 			wantTexts:      []string{"Hello. World", "."},
 			wantLevels:     []bidi.Level{2, 1},
 		},
+		{
+			// Arabic Presentation Form B (U+FEAD, class AL) is strong
+			// RTL but its UTF-8 lead byte 0xEF was not in the fast-path
+			// set, so the text wrongly took the pure-LTR path and every
+			// chunk got level 0. It must match the equivalent Arabic
+			// text (rtl_text_under_ltr_base): one level-1 run plus a
+			// trailing level-0 period.
+			name:       "arabic_presentation_forms",
+			text:       "ﺭ. ﺭ.",
+			wantTexts:  []string{"ﺭ. ﺭ", "."},
+			wantLevels: []bidi.Level{1, 0},
+		},
+		{
+			// RLM (U+200F, class R) is strong RTL with lead byte 0xE2,
+			// which the fast path only inspected for line separators.
+			// It must force the bidi pass so the RLM itself carries
+			// level 1 between the level-0 runs.
+			name:       "rlm_forces_bidi",
+			text:       "ab\u200f. cd.",
+			wantTexts:  []string{"ab", "\u200f", ". cd."},
+			wantLevels: []bidi.Level{0, 1, 0},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/text/v2/internal/chunk/chunk_test.go
+++ b/text/v2/internal/chunk/chunk_test.go
@@ -284,6 +284,15 @@ func TestChunks_Levels(t *testing.T) {
 			wantLevels: []bidi.Level{1, 0},
 		},
 		{
+			// Hebrew Presentation Forms (U+FB21, class R) share the
+			// 0xEF lead byte with the Arabic ones and are fixed the
+			// same way.
+			name:       "hebrew_presentation_forms",
+			text:       "\ufb21. \ufb21.",
+			wantTexts:  []string{"\ufb21. \ufb21", "."},
+			wantLevels: []bidi.Level{1, 0},
+		},
+		{
 			// RLM (U+200F, class R) is strong RTL with lead byte 0xE2,
 			// which the fast path only inspected for line separators.
 			// It must force the bidi pass so the RLM itself carries


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
mayContainStrongRTLInFirstLine is an upper bound that must return true for every first line containing a strong-RTL rune so the bidi pass runs. Its lead-byte set missed two strong-RTL cases:

  * Arabic Presentation Forms A and B (U+FB50..U+FDFF, U+FE70..U+FEFF, class AL), whose UTF-8 lead byte is 0xEF.
  * RLM (U+200F, class R), whose 0xE2 0x80 prefix was only inspected for the LS/PS line separators.

Text made only of those runes took the pure-LTR fast path and every chunk got level 0, so the composition layer laid RTL sentences out left-to-right and AdvanceAt returned wrong caret positions.

Add 0xEF to the lead-byte set and detect RLM alongside the line separators.

Add TestChunks_Levels cases for both, which fail without this fix.