### PR TITLE
ebiten: fix the index validation of DrawTriangles32 on 32-bit platforms

### DIFF
--- a/image.go
+++ b/image.go
@@ -642,7 +642,7 @@ func (i *Image) DrawTriangles32(vertices []Vertex, indices []uint32, img *Image,
 		panic("ebiten: len(indices) % 3 must be 0")
 	}
 	for i, idx := range indices {
-		if int(idx) >= len(vertices) {
+		if idx >= uint32(len(vertices)) {
 			panic(fmt.Sprintf("ebiten: indices[%d] must be less than len(vertices) (%d) but was %d", i, len(vertices), idx))
 		}
 	}
@@ -880,7 +880,7 @@ func (i *Image) DrawTrianglesShader32(vertices []Vertex, indices []uint32, shade
 		panic("ebiten: len(indices) % 3 must be 0")
 	}
 	for i, idx := range indices {
-		if int(idx) >= len(vertices) {
+		if idx >= uint32(len(vertices)) {
 			panic(fmt.Sprintf("ebiten: indices[%d] must be less than len(vertices) (%d) but was %d", i, len(vertices), idx))
 		}
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -4585,7 +4585,6 @@ func TestImageDrawTrianglesShaderWithGreaterIndexThanVerticesCount(t *testing.T)
 	dst.DrawTrianglesShader(vs, is, shader, nil)
 }
 
-// An index not less than 2^31 must panic even on a 32-bit platform, where int(idx) would otherwise wrap to a negative value.
 func TestImageDrawTriangles32WithGreaterIndexThanVerticesCount(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {

--- a/image_test.go
+++ b/image_test.go
@@ -4585,6 +4585,47 @@ func TestImageDrawTrianglesShaderWithGreaterIndexThanVerticesCount(t *testing.T)
 	dst.DrawTrianglesShader(vs, is, shader, nil)
 }
 
+// An index not less than 2^31 must panic even on a 32-bit platform, where int(idx) would otherwise wrap to a negative value.
+func TestImageDrawTriangles32WithGreaterIndexThanVerticesCount(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("DrawTriangles32 must panic but not")
+		}
+	}()
+
+	const w, h = 16, 16
+	dst := ebiten.NewImage(w, h)
+	src := ebiten.NewImage(w, h)
+
+	vs := make([]ebiten.Vertex, 4)
+	is := []uint32{0, 1, 2, 1, 2, math.MaxUint32}
+	dst.DrawTriangles32(vs, is, src, nil)
+}
+
+func TestImageDrawTrianglesShader32WithGreaterIndexThanVerticesCount(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("DrawTrianglesShader32 must panic but not")
+		}
+	}()
+
+	const w, h = 16, 16
+	dst := ebiten.NewImage(w, h)
+
+	vs := make([]ebiten.Vertex, 4)
+	is := []uint32{0, 1, 2, 1, 2, math.MaxUint32}
+	shader, err := ebiten.NewShader([]byte(`
+		package main
+		func Fragment(dstPos vec4, src0Pos vec2, color vec4) vec4 {
+			return color
+		}
+	`))
+	if err != nil {
+		t.Fatalf("could not compile shader: %v", err)
+	}
+	dst.DrawTrianglesShader32(vs, is, shader, nil)
+}
+
 // Issue #2733
 func TestImageGeoMAfterDraw(t *testing.T) {
 	src := ebiten.NewImage(1, 1)


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The loop checked int(idx) >= len(vertices), but on a 32-bit platform int is 32 bits, so any index not less than 2^31 wrapped to a negative value and passed the check. The documented panic for an out-of-range index never happened on js/wasm and linux/386, and the bogus index was fed to the GPU driver instead.

Compare idx against uint32(len(vertices)) directly. len(vertices) is truncated to MaxVertexCount, which is at most MaxUint32, just above, so the conversion is safe.

Add regression tests for DrawTriangles32 and DrawTrianglesShader32 with an index of MaxUint32.