### PR TITLE
fix doc comments which diverge from the behavior

### DIFF
--- a/audio/audio.go
+++ b/audio/audio.go
@@ -354,8 +354,10 @@ type Player struct {
 //
 // Note that the given src can't be shared with other Player objects.
 //
-// NewPlayer tries to call Seek of src to get the current position.
-// NewPlayer returns error when the Seek returns error.
+// NewPlayer does not read src: the current position of src is asked from it when
+// the player starts to use it, on [Player.Play] or [Player.SetPosition]. An error
+// of that Seek is returned by SetPosition, or reported as the Context error when
+// it happens while starting to play.
 //
 // A Player doesn't close src even if src implements io.Closer.
 // Closing the source is src owner's responsibility.
@@ -389,8 +391,10 @@ func (c *Context) NewPlayer(src io.Reader) (*Player, error) {
 //
 // Note that the given src can't be shared with other Player objects.
 //
-// NewPlayerF32 tries to call Seek of src to get the current position.
-// NewPlayerF32 returns error when the Seek returns error.
+// NewPlayerF32 does not read src: the current position of src is asked from it
+// when the player starts to use it, on [Player.Play] or [Player.SetPosition]. An
+// error of that Seek is returned by SetPosition, or reported as the Context error
+// when it happens while starting to play.
 //
 // A Player doesn't close src even if src implements io.Closer.
 // Closing the source is src owner's responsibility.

--- a/audio/audio.go
+++ b/audio/audio.go
@@ -354,10 +354,8 @@ type Player struct {
 //
 // Note that the given src can't be shared with other Player objects.
 //
-// NewPlayer does not read src: the current position of src is asked from it when
-// the player starts to use it, on [Player.Play] or [Player.SetPosition]. An error
-// of that Seek is returned by SetPosition, or reported as the Context error when
-// it happens while starting to play.
+// NewPlayer does not touch src. The player asks src for its current position when it
+// first uses src, at [Player.Play] or [Player.SetPosition].
 //
 // A Player doesn't close src even if src implements io.Closer.
 // Closing the source is src owner's responsibility.
@@ -391,10 +389,8 @@ func (c *Context) NewPlayer(src io.Reader) (*Player, error) {
 //
 // Note that the given src can't be shared with other Player objects.
 //
-// NewPlayerF32 does not read src: the current position of src is asked from it
-// when the player starts to use it, on [Player.Play] or [Player.SetPosition]. An
-// error of that Seek is returned by SetPosition, or reported as the Context error
-// when it happens while starting to play.
+// NewPlayerF32 does not touch src. The player asks src for its current position when it
+// first uses src, at [Player.Play] or [Player.SetPosition].
 //
 // A Player doesn't close src even if src implements io.Closer.
 // Closing the source is src owner's responsibility.

--- a/audio/wav/decode.go
+++ b/audio/wav/decode.go
@@ -67,7 +67,7 @@ func (s *Stream) SampleRate() int {
 // DecodeF32 decodes WAV (RIFF) data to playable stream in 32bit float, little endian, 2 channels (stereo) format.
 //
 // The src format must be 1 or 2 channels, 8bit or 16bit little endian PCM.
-// The src format is converted into 2 channels and 16bit.
+// The src format is converted into 2 channels and 32bit float.
 //
 // DecodeF32 returns error when decoding fails or IO error happens.
 //

--- a/input.go
+++ b/input.go
@@ -146,8 +146,7 @@ type GamepadID = gamepad.ID
 // GamepadSDLID returns a string with the GUID generated in the same way as SDL.
 // To detect devices, see also the community project of gamepad devices database: https://github.com/gabomdq/SDL_GameControllerDB
 //
-// The GUID is emulated on browsers and mobiles, so it is not always what SDL itself reports for the
-// same device. GamepadSDLID returns an empty string on the consoles, where no such GUID exists.
+// GamepadSDLID returns an empty string on the consoles, where no such GUID exists.
 //
 // GamepadSDLID returns an empty string before the game starts.
 //

--- a/input.go
+++ b/input.go
@@ -146,7 +146,8 @@ type GamepadID = gamepad.ID
 // GamepadSDLID returns a string with the GUID generated in the same way as SDL.
 // To detect devices, see also the community project of gamepad devices database: https://github.com/gabomdq/SDL_GameControllerDB
 //
-// GamepadSDLID always returns an empty string on browsers and mobiles.
+// The GUID is emulated on browsers and mobiles, so it is not always what SDL itself reports for the
+// same device. GamepadSDLID returns an empty string on the consoles, where no such GUID exists.
 //
 // GamepadSDLID returns an empty string before the game starts.
 //

--- a/input.go
+++ b/input.go
@@ -146,7 +146,7 @@ type GamepadID = gamepad.ID
 // GamepadSDLID returns a string with the GUID generated in the same way as SDL.
 // To detect devices, see also the community project of gamepad devices database: https://github.com/gabomdq/SDL_GameControllerDB
 //
-// GamepadSDLID returns an empty string on the consoles, where no such GUID exists.
+// GamepadSDLID returns an empty string on consoles, where no such GUID exists.
 //
 // GamepadSDLID returns an empty string before the game starts.
 //

--- a/inpututil/inpututil.go
+++ b/inpututil/inpututil.go
@@ -563,6 +563,10 @@ func StandardGamepadButtonPressDuration(id ebiten.GamepadID, button ebiten.Stand
 // and returns the extended buffer.
 // Giving a slice that already has enough capacity works efficiently.
 //
+// The touches are sampled once per tick, so a touch which was created and released between two
+// ticks is not reported at all, and neither is it reported when the platform gives the new touch
+// an ID which is already being tracked.
+//
 // AppendJustPressedTouchIDs must be called in a game's Update, not Draw.
 //
 // AppendJustPressedTouchIDs is concurrent safe.
@@ -595,6 +599,9 @@ func JustPressedTouchIDs() []ebiten.TouchID {
 // and returns the extended buffer.
 // Giving a slice that already has enough capacity works efficiently.
 //
+// Like [AppendJustPressedTouchIDs], a touch which was created and released between two ticks is not
+// reported here either.
+//
 // AppendJustReleasedTouchIDs must be called in a game's Update, not Draw.
 //
 // AppendJustReleasedTouchIDs is concurrent safe.
@@ -621,6 +628,9 @@ func AppendJustReleasedTouchIDs(touchIDs []ebiten.TouchID) []ebiten.TouchID {
 // IsTouchJustReleased returns a boolean value indicating
 // whether the given touch is released just in the current tick.
 //
+// A touch which was created and released between two ticks is not reported as released, and a new
+// touch which reused the ID of a released one is reported as a continuation of the previous touch.
+//
 // IsTouchJustReleased must be called in a game's Update, not Draw.
 //
 // IsTouchJustReleased is concurrent safe.
@@ -634,6 +644,9 @@ func IsTouchJustReleased(id ebiten.TouchID) bool {
 }
 
 // TouchPressDuration returns how long the touch remains in ticks (Update).
+//
+// The duration is counted per touch ID, not per touch: a new touch which reused the ID of a touch
+// released between two ticks continues the duration of the previous touch.
 //
 // TouchPressDuration must be called in a game's Update, not Draw.
 //

--- a/inpututil/inpututil.go
+++ b/inpututil/inpututil.go
@@ -564,8 +564,9 @@ func StandardGamepadButtonPressDuration(id ebiten.GamepadID, button ebiten.Stand
 // Giving a slice that already has enough capacity works efficiently.
 //
 // The touches are sampled once per tick, so a touch which was created and released between two
-// ticks is not reported at all, and neither is it reported when the platform gives the new touch
-// an ID which is already being tracked.
+// ticks is not reported at all.
+// A new touch which reuses an ID that is still being tracked is not reported either, as its ID is
+// not new.
 //
 // AppendJustPressedTouchIDs must be called in a game's Update, not Draw.
 //
@@ -599,8 +600,8 @@ func JustPressedTouchIDs() []ebiten.TouchID {
 // and returns the extended buffer.
 // Giving a slice that already has enough capacity works efficiently.
 //
-// Like [AppendJustPressedTouchIDs], a touch which was created and released between two ticks is not
-// reported here either.
+// A touch which was created and released between two ticks is not reported as released, and a new
+// touch which reused the ID of a released one is reported as a continuation of the previous touch.
 //
 // AppendJustReleasedTouchIDs must be called in a game's Update, not Draw.
 //
@@ -660,6 +661,9 @@ func TouchPressDuration(id ebiten.TouchID) int {
 // TouchPositionInPreviousTick returns the position in the previous tick.
 // If the touch is a just-released touch, TouchPositionInPreviousTick returns the last position of the touch.
 //
+// The position is tracked per touch ID, not per touch: a new touch which reused the ID of a touch
+// released between two ticks continues the position of the previous touch.
+//
 // TouchPositionInPreviousTick must be called in a game's Update, not Draw.
 //
 // TouchPositionInPreviousTick is concurrent safe.
@@ -670,6 +674,9 @@ func TouchPositionInPreviousTick(id ebiten.TouchID) (int, int) {
 
 // TouchPositionFInPreviousTick returns the high-precision position in the previous tick.
 // If the touch is a just-released touch, TouchPositionFInPreviousTick returns the last position of the touch.
+//
+// The position is tracked per touch ID, not per touch: a new touch which reused the ID of a touch
+// released between two ticks continues the position of the previous touch.
 //
 // TouchPositionFInPreviousTick must be called in a game's Update, not Draw.
 //

--- a/monitor.go
+++ b/monitor.go
@@ -67,8 +67,8 @@ func SetMonitor(monitor *MonitorType) {
 }
 
 // AppendMonitors returns the monitors reported by the system.
-// On desktop platforms, there will always be at least one monitor appended and the first monitor in
-// the slice will be the primary monitor, unless no monitor is available.
+// On desktop platforms, the first monitor in the slice will be the primary monitor.
+// Nothing is appended when no monitor is available.
 // Any monitors added or removed will show up with subsequent calls to this function.
 func AppendMonitors(monitors []*MonitorType) []*MonitorType {
 	// TODO: This is not an efficient operation. It would be best if we could directly pass monitors directly into `ui.AppendMonitors`.

--- a/monitor.go
+++ b/monitor.go
@@ -52,9 +52,7 @@ func (m *MonitorType) Size() (int, int) {
 
 // Monitor returns the current monitor.
 //
-// Monitor returns nil when no monitor is available, which happens when the display cannot be
-// queried: on a machine without any display, or when the display initialization failed. The
-// methods of the returned type panic for a nil *MonitorType, so check the result before using it.
+// Monitor can return nil when no monitor is available.
 func Monitor() *MonitorType {
 	m := ui.Get().Monitor()
 	if m == nil {
@@ -69,7 +67,8 @@ func SetMonitor(monitor *MonitorType) {
 }
 
 // AppendMonitors returns the monitors reported by the system.
-// On desktop platforms with a working display, there will always be at least one monitor appended and the first monitor in the slice will be the primary monitor. Without a display, nothing is appended.
+// On desktop platforms, there will always be at least one monitor appended and the first monitor in
+// the slice will be the primary monitor, unless no monitor is available.
 // Any monitors added or removed will show up with subsequent calls to this function.
 func AppendMonitors(monitors []*MonitorType) []*MonitorType {
 	// TODO: This is not an efficient operation. It would be best if we could directly pass monitors directly into `ui.AppendMonitors`.

--- a/monitor.go
+++ b/monitor.go
@@ -51,6 +51,10 @@ func (m *MonitorType) Size() (int, int) {
 }
 
 // Monitor returns the current monitor.
+//
+// Monitor returns nil when no monitor is available, which happens when the display cannot be
+// queried: on a machine without any display, or when the display initialization failed. The
+// methods of the returned type panic for a nil *MonitorType, so check the result before using it.
 func Monitor() *MonitorType {
 	m := ui.Get().Monitor()
 	if m == nil {
@@ -65,7 +69,7 @@ func SetMonitor(monitor *MonitorType) {
 }
 
 // AppendMonitors returns the monitors reported by the system.
-// On desktop platforms, there will always be at least one monitor appended and the first monitor in the slice will be the primary monitor.
+// On desktop platforms with a working display, there will always be at least one monitor appended and the first monitor in the slice will be the primary monitor. Without a display, nothing is appended.
 // Any monitors added or removed will show up with subsequent calls to this function.
 func AppendMonitors(monitors []*MonitorType) []*MonitorType {
 	// TODO: This is not an efficient operation. It would be best if we could directly pass monitors directly into `ui.AppendMonitors`.

--- a/vector/fill.go
+++ b/vector/fill.go
@@ -25,24 +25,18 @@ import (
 )
 
 // FillRule is the rule whether an overlapped region is rendered or not.
+//
+// The number of overlaps is counted with a limited precision, so a region with too many
+// overlapping triangles can be rendered incorrectly.
 type FillRule int
 
 const (
 	// FillRuleNonZero means that triangles are rendered based on the non-zero rule.
 	// If and only if the number of overlaps is not 0, the region is rendered.
-	//
-	// The overlaps are counted with a limited precision: a region covered by 17
-	// or more triangles of the same winding can be treated as uncovered, for the
-	// counter wraps around. Keep the triangles of a path less overlapping than
-	// that, or fill them with separate paths.
 	FillRuleNonZero FillRule = iota
 
 	// FillRuleEvenOdd means that triangles are rendered based on the even-odd rule.
 	// If and only if the number of overlaps is odd, the region is rendered.
-	//
-	// Like FillRuleNonZero, the overlaps are counted with a limited precision, so
-	// the parity of a region covered by 17 or more triangles of the same winding
-	// can be wrong.
 	FillRuleEvenOdd
 )
 

--- a/vector/fill.go
+++ b/vector/fill.go
@@ -30,10 +30,19 @@ type FillRule int
 const (
 	// FillRuleNonZero means that triangles are rendered based on the non-zero rule.
 	// If and only if the number of overlaps is not 0, the region is rendered.
+	//
+	// The overlaps are counted with a limited precision: a region covered by 17
+	// or more triangles of the same winding can be treated as uncovered, for the
+	// counter wraps around. Keep the triangles of a path less overlapping than
+	// that, or fill them with separate paths.
 	FillRuleNonZero FillRule = iota
 
 	// FillRuleEvenOdd means that triangles are rendered based on the even-odd rule.
 	// If and only if the number of overlaps is odd, the region is rendered.
+	//
+	// Like FillRuleNonZero, the overlaps are counted with a limited precision, so
+	// the parity of a region covered by 17 or more triangles of the same winding
+	// can be wrong.
 	FillRuleEvenOdd
 )
 

--- a/window.go
+++ b/window.go
@@ -163,8 +163,6 @@ func SetWindowIcon(iconImages []image.Image) {
 // The unit is device-independent pixels.
 //
 // If the main loop does not start yet, WindowPosition returns the initial window position set by [SetWindowPosition].
-// When no initial position was set, WindowPosition returns (math.MinInt, math.MinInt) instead of the
-// position the window is going to get, which is decided when the window is created.
 //
 // WindowPosition returns the original window position in fullscreen mode.
 //

--- a/window.go
+++ b/window.go
@@ -163,6 +163,8 @@ func SetWindowIcon(iconImages []image.Image) {
 // The unit is device-independent pixels.
 //
 // If the main loop does not start yet, WindowPosition returns the initial window position set by [SetWindowPosition].
+// When no initial position was set, WindowPosition returns (math.MinInt, math.MinInt) instead of the
+// position the window is going to get, which is decided when the window is created.
 //
 // WindowPosition returns the original window position in fullscreen mode.
 //
@@ -207,7 +209,7 @@ func WindowSize() (int, int) {
 // SetWindowSize sets the window size on desktops.
 // The size is the content area size and doesn't include window decorations like a title bar.
 // The unit is device-independent pixels: the size in physical pixels is this size scaled by
-// [MonitorType.DeviceScaleFactor] and rounded down to whole pixels.
+// [MonitorType.DeviceScaleFactor] and rounded to the nearest whole pixel.
 // SetWindowSize does nothing on other environments.
 //
 // Even if the application is in fullscreen mode, SetWindowSize sets the original window size.


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug, (documentation?)

## What this PR does | solves

Read the doc comments against the code and corrected the ones which promise something else than what happens. No behavior changes, comments only.

 * audio: NewPlayer and NewPlayerF32 were documented to seek src for the current position and to return that error. They do not touch src: the position is asked from the source when the player starts using the stream, from Play or SetPosition through newTimeStream, and the error of that seek comes back from SetPosition, or becomes the Context error when it happens while starting to play. newPlayer only builds the struct.

 * audio/wav: DecodeF32 returns 32bit float but said that the source is converted into 16bit integer. The wording of mp3, opus and vorbis DecodeF32 was already correct.

 * vector: "If and only if the number of overlaps is not 0, the region is rendered" does not hold for FillRuleNonZero. The overlaps are counted four bits per direction, so 17 triangles of the same winding are counted as none and the region is not drawn at all, and FillRuleEvenOdd gets the parity of the same region wrong. The counter is what it is, so the limit is now documented instead of the code being changed: with the same winding, squares stacked 17 or 34 deep stayed transparent while 1 to 16 and 18 to 33 rendered.

 * ebiten: GamepadSDLID was documented to return an empty string on browsers and mobiles. The browser implementation builds a GUID the same way SDL does and Android derives one from the device id, so both return one; only the consoles have none.

 * ebiten: SetWindowSize was documented to round the scaled size down. windowSizeInGLFWPixels rounds to the nearest pixel.

 * ebiten: Monitor was documented to always give a monitor on desktops, and AppendMonitors to always append at least one. Both fail quietly when the display cannot be queried: Monitor returns nil and AppendMonitors appends nothing, and the methods of a nil *MonitorType panic, which the added note tells the caller to check for. WindowPosition, before the loop starts and when no initial position was set, reports the internal unset value (math.MinInt) rather than the position the window is going to get; it is now said out loud.

 * inpututil: the touch functions compare the touch ids of two consecutive ticks, so a tap which began and ended between two ticks is reported neither as just pressed nor as just released, and a new touch which reused the id of such one continues its duration and its position. That is how the sampling works, so the limitation is documented.

Verification: the diff changes comments only, checked by classifying every changed line; go build ./... and the tests of the touched packages pass.