### PR TITLE
internal/shader: reject arithmetic on boolean operands

### DIFF
--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -350,3 +350,51 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		}()
 	}
 }
+
+func TestCompileBoolArithmetic(t *testing.T) {
+	srcs := []string{
+		`package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	return vec4(float(true + true))
+}`,
+		`package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	return vec4(float(true - true))
+}`,
+		`package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	return vec4(float(true * true))
+}`,
+		`package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	return vec4(float(true / true))
+}`,
+		`package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	a := true
+	b := true
+	c := a + b
+	if c {
+		return vec4(1)
+	}
+	return vec4(0)
+}`,
+	}
+	for _, src := range srcs {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Compile must not panic for bool arithmetic, but panicked: %v", r)
+				}
+			}()
+			if _, err := shader.Compile([]byte(src), "Vertex", "Fragment", 0); err == nil {
+				t.Errorf("Compile must return an error for bool arithmetic, but got nil")
+			}
+		}()
+	}
+}

--- a/internal/shaderir/check.go
+++ b/internal/shaderir/check.go
@@ -82,6 +82,16 @@ func ResolveUntypedConstsForBinaryOp(op Op, lhs, rhs constant.Value, lhst, rhst 
 }
 
 func TypeFromBinaryOp(op Op, lhst, rhst Type, lhsConst, rhsConst constant.Value) (Type, bool) {
+	switch op {
+	case Add, Sub, ComponentWiseMul, MatrixMul, Div:
+		if lhst.Main == Bool || rhst.Main == Bool {
+			return Type{}, false
+		}
+		if (lhsConst != nil && lhsConst.Kind() == constant.Bool) || (rhsConst != nil && rhsConst.Kind() == constant.Bool) {
+			return Type{}, false
+		}
+	}
+
 	// If both are untyped consts, compare the constants and try to truncate them if necessary.
 	if lhst.Main == None && rhst.Main == None {
 		// Assume that the constant types are already adjusted.


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
TypeFromBinaryOp accepted Add/Sub/ComponentWiseMul/MatrixMul/Div when both operands had the same type, including Bool. Constant folding then called go/constant.BinaryOp (or Sign for division) on bool values, which panics ("invalid binary operation true + true"), so a user shader containing e.g. true + true crashed the whole process instead of reporting a compile error. The non-constant form (a + b for bool vars) did not panic but emitted invalid GLSL/HLSL/MSL.

Reject arithmetic operations whose operand is a boolean type or an untyped boolean constant, so they surface as a normal type error.

Add TestCompileBoolArithmetic, which panics without this fix.
