### PR TITLE
internal/shader: fix a panic on a var count mismatch in multiple-value declarations

### DIFF
--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -630,11 +630,6 @@ func (s *compileState) parseVariable(block *block, fname string, vs *ast.ValueSp
 					}
 				}
 
-				// The number of values on the right must match the number of
-				// names on the left, whether or not an explicit type is given.
-				// Abort the whole declaration here: the previous code used
-				// `continue`, which only skipped the first iteration and let a
-				// later iteration index inittypes/initexprs out of range.
 				if len(initexprs) != len(vs.Names) || len(inittypes) != len(vs.Names) {
 					s.addError(vs.Pos(), "the numbers of lhs and rhs don't match")
 					return nil, nil, nil, false

--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -628,10 +628,16 @@ func (s *compileState) parseVariable(block *block, fname string, vs *ast.ValueSp
 					if ok {
 						inittypes = ts
 					}
-					if len(ts) != len(vs.Names) {
-						s.addError(vs.Pos(), "the numbers of lhs and rhs don't match")
-						continue
-					}
+				}
+
+				// The number of values on the right must match the number of
+				// names on the left, whether or not an explicit type is given.
+				// Abort the whole declaration here: the previous code used
+				// `continue`, which only skipped the first iteration and let a
+				// later iteration index inittypes/initexprs out of range.
+				if len(initexprs) != len(vs.Names) || len(inittypes) != len(vs.Names) {
+					s.addError(vs.Pos(), "the numbers of lhs and rhs don't match")
+					return nil, nil, nil, false
 				}
 			}
 

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -302,9 +302,6 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	}
 }
 
-// A multiple-value variable declaration whose right-hand side yields a number
-// of values different from the number of names must be a compile error, not a
-// panic from indexing the value types out of range.
 func TestCompileVarCountMismatch(t *testing.T) {
 	srcs := []string{
 		`package main

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -301,3 +301,55 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("Compile must return an error for a huge constant shift, but got nil")
 	}
 }
+
+// A multiple-value variable declaration whose right-hand side yields a number
+// of values different from the number of names must be a compile error, not a
+// panic from indexing the value types out of range.
+func TestCompileVarCountMismatch(t *testing.T) {
+	srcs := []string{
+		`package main
+
+func f() (int, int) {
+	return 1, 2
+}
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	var a, b, c = f()
+	return vec4(a + b + c)
+}`,
+		`package main
+
+func f() (int, int) {
+	return 1, 2
+}
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	var a, b, c int = f()
+	return vec4(a + b + c)
+}`,
+		`package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	var a, b = 1
+	return vec4(a + b)
+}`,
+		`package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	var a, b int = 1
+	return vec4(a + b)
+}`,
+	}
+	for _, src := range srcs {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Compile must not panic for a var count mismatch, but panicked: %v", r)
+				}
+			}()
+			if _, err := shader.Compile([]byte(src), "Vertex", "Fragment", 0); err == nil {
+				t.Errorf("Compile must return an error for a var count mismatch, but got nil")
+			}
+		}()
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
When the number of values on the right of a multiple-value var declaration differed from the number of names on the left, the count check ran only for the first name (i == 0), only when no explicit type was given (t.Main == None), and used `continue`, which skipped just that first iteration. The loop then proceeded to the remaining names and indexed inittypes[i] / initexprs[i] past their end, panicking with "index out of range". This affected e.g. "var a, b, c = f()" where f returns two values, and "var a, b = 1".

Validate the value count against the name count once, right after parsing the initializer, regardless of the declared type, and abort the declaration with an error instead of continuing.

Add TestCompileVarCountMismatch, which panics without this fix.