### PR TITLE
internal/shader: reject the blank identifier used as a value

### DIFF
--- a/internal/shader/expr.go
+++ b/internal/shader/expr.go
@@ -98,8 +98,6 @@ func (cs *compileState) parseExpr(block *block, fname string, expr ast.Expr, mar
 		}
 		rhst := ts[0]
 
-		// A blank identifier has no value, so it cannot be an operand. Reject it
-		// here; otherwise constant folding dereferences its nil constant.
 		if lhs[0].Type == shaderir.Blank || rhs[0].Type == shaderir.Blank {
 			cs.addError(e.Pos(), "cannot use _ as value")
 			return nil, nil, nil, false

--- a/internal/shader/expr.go
+++ b/internal/shader/expr.go
@@ -98,6 +98,13 @@ func (cs *compileState) parseExpr(block *block, fname string, expr ast.Expr, mar
 		}
 		rhst := ts[0]
 
+		// A blank identifier has no value, so it cannot be an operand. Reject it
+		// here; otherwise constant folding dereferences its nil constant.
+		if lhs[0].Type == shaderir.Blank || rhs[0].Type == shaderir.Blank {
+			cs.addError(e.Pos(), "cannot use _ as value")
+			return nil, nil, nil, false
+		}
+
 		op := e.Op
 		// https://pkg.go.dev/go/constant/#BinaryOp
 		// "To force integer division of Int operands, use op == token.QUO_ASSIGN instead of
@@ -230,6 +237,10 @@ func (cs *compileState) parseExpr(block *block, fname string, expr ast.Expr, mar
 			for _, expr := range es {
 				if expr.Type == shaderir.FunctionExpr || expr.Type == shaderir.BuiltinFuncExpr {
 					cs.addError(e.Pos(), fmt.Sprintf("function name cannot be an argument: %s", e.Fun))
+					return nil, nil, nil, false
+				}
+				if expr.Type == shaderir.Blank {
+					cs.addError(e.Pos(), "cannot use _ as value")
 					return nil, nil, nil, false
 				}
 			}

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -301,3 +301,35 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 		t.Errorf("Compile must return an error for a huge constant shift, but got nil")
 	}
 }
+
+// The blank identifier _ has no value, so using it as a value (an argument or
+// an operand) must be a compile error, not a nil-pointer panic in constant
+// folding.
+func TestCompileBlankAsValue(t *testing.T) {
+	srcs := []string{
+		`package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	const x = min(_, 1)
+	return vec4(x)
+}`,
+		`package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	const x = 1 + _
+	return vec4(x)
+}`,
+	}
+	for _, src := range srcs {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Compile must not panic when _ is used as a value, but panicked: %v", r)
+				}
+			}()
+			if _, err := shader.Compile([]byte(src), "Vertex", "Fragment", 0); err == nil {
+				t.Errorf("Compile must return an error when _ is used as a value, but got nil")
+			}
+		}()
+	}
+}

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -302,9 +302,6 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	}
 }
 
-// The blank identifier _ has no value, so using it as a value (an argument or
-// an operand) must be a compile error, not a nil-pointer panic in constant
-// folding.
 func TestCompileBlankAsValue(t *testing.T) {
 	srcs := []string{
 		`package main


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
In a context where a local variable is not marked as used (a constant declaration or an assignment left-hand side), parsing "_" returned an expression with Type Blank and a nil Const. When such an expression was used as a value, e.g. as an argument of min/max/clamp or an operand of a binary operator, constant folding dereferenced the nil Const and panicked with a nil pointer dereference, crashing the compiler on user input.

Reject a blank identifier used as a value in call arguments and binary operands, reporting "cannot use _ as value" instead.

Add TestCompileBlankAsValue, which panics without this fix.