### PR TITLE
internal/shader: build array comparisons as a balanced tree

### DIFF
--- a/internal/shader/expr.go
+++ b/internal/shader/expr.go
@@ -1420,17 +1420,19 @@ func arrayComparisonExpr(op shaderir.Op, t shaderir.Type, lhs, rhs shaderir.Expr
 		joinOp = shaderir.OrOr
 	}
 
-	// The initial value is the result for an empty array, which always equals another empty array.
-	expr := shaderir.Expr{
-		Type:  shaderir.NumberExpr,
-		Const: gconstant.MakeBool(op == shaderir.EqualOp),
-	}
+	// Build the per-element comparisons first, then combine them into a
+	// balanced tree. The backends render a binary node by recursively
+	// formatting and copying both operands, so a left-nested chain of depth n
+	// would make the whole compilation O(n^2) in the array length (and risk a
+	// deep recursion). A balanced tree keeps it O(n log n) with the same
+	// result, since && and || are associative.
+	elements := make([]shaderir.Expr, t.Length)
 	for i := range t.Length {
 		index := shaderir.Expr{
 			Type:  shaderir.NumberExpr,
 			Const: gconstant.MakeInt64(int64(i)),
 		}
-		e := shaderir.Expr{
+		elements[i] = shaderir.Expr{
 			Type: shaderir.Binary,
 			Op:   elementOp,
 			Exprs: []shaderir.Expr{
@@ -1444,15 +1446,30 @@ func arrayComparisonExpr(op shaderir.Op, t shaderir.Type, lhs, rhs shaderir.Expr
 				},
 			},
 		}
-		if i == 0 {
-			expr = e
-			continue
-		}
-		expr = shaderir.Expr{
-			Type:  shaderir.Binary,
-			Op:    joinOp,
-			Exprs: []shaderir.Expr{expr, e},
+	}
+
+	// The result for an empty array, which always equals another empty array.
+	if len(elements) == 0 {
+		return shaderir.Expr{
+			Type:  shaderir.NumberExpr,
+			Const: gconstant.MakeBool(op == shaderir.EqualOp),
 		}
 	}
-	return expr
+
+	for len(elements) > 1 {
+		next := make([]shaderir.Expr, 0, (len(elements)+1)/2)
+		for i := 0; i < len(elements); i += 2 {
+			if i+1 == len(elements) {
+				next = append(next, elements[i])
+				continue
+			}
+			next = append(next, shaderir.Expr{
+				Type:  shaderir.Binary,
+				Op:    joinOp,
+				Exprs: []shaderir.Expr{elements[i], elements[i+1]},
+			})
+		}
+		elements = next
+	}
+	return elements[0]
 }

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/hajimehoshi/ebiten/v2/internal/graphics"
 	"github.com/hajimehoshi/ebiten/v2/internal/shader"
+	"github.com/hajimehoshi/ebiten/v2/internal/shaderir"
 	"github.com/hajimehoshi/ebiten/v2/internal/shaderir/glsl"
 	"github.com/hajimehoshi/ebiten/v2/internal/shaderir/hlsl"
 	"github.com/hajimehoshi/ebiten/v2/internal/shaderir/msl"
@@ -299,5 +300,68 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	_, err := shader.Compile([]byte(src), "Vertex", "Fragment", 0)
 	if err == nil {
 		t.Errorf("Compile must return an error for a huge constant shift, but got nil")
+	}
+}
+
+// Comparing large arrays must build a balanced tree of element comparisons, not
+// a left-nested chain. A chain makes the backends, which format each binary
+// node by copying its operands, take O(n^2) time and produces a nesting depth
+// proportional to n; a balanced tree keeps the depth logarithmic.
+func TestCompileArrayComparisonIsBalanced(t *testing.T) {
+	const n = 1000
+	src := []byte(fmt.Sprintf(`package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	var a [%d]int
+	var b [%d]int
+	if a == b {
+		return vec4(1)
+	}
+	return vec4(0)
+}`, n, n))
+	s, err := shader.Compile(src, "Vertex", "Fragment", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Max nesting depth of && / || binary nodes in the fragment function.
+	var joinDepth func(e shaderir.Expr) int
+	joinDepth = func(e shaderir.Expr) int {
+		d := 0
+		if e.Type == shaderir.Binary && (e.Op == shaderir.AndAnd || e.Op == shaderir.OrOr) {
+			d = 1
+		}
+		child := 0
+		for _, sub := range e.Exprs {
+			if c := joinDepth(sub); c > child {
+				child = c
+			}
+		}
+		return d + child
+	}
+	var blockDepth func(b *shaderir.Block) int
+	blockDepth = func(b *shaderir.Block) int {
+		m := 0
+		for _, st := range b.Stmts {
+			for _, e := range st.Exprs {
+				if d := joinDepth(e); d > m {
+					m = d
+				}
+			}
+			for _, sub := range st.Blocks {
+				if d := blockDepth(sub); d > m {
+					m = d
+				}
+			}
+		}
+		return m
+	}
+
+	depth := blockDepth(s.FragmentFunc.Block)
+	// A balanced tree over n leaves has depth ~log2(n); a left-nested chain has
+	// depth ~n. For n=1000 the balanced depth is ~10, so anything near n means
+	// the chain is left-nested again.
+	if depth > 64 {
+		t.Errorf("array comparison nesting depth = %d for n=%d; expected a balanced tree (logarithmic), got a left-nested chain", depth, n)
 	}
 }

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -303,10 +303,6 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	}
 }
 
-// Comparing large arrays must build a balanced tree of element comparisons, not
-// a left-nested chain. A chain makes the backends, which format each binary
-// node by copying its operands, take O(n^2) time and produces a nesting depth
-// proportional to n; a balanced tree keeps the depth logarithmic.
 func TestCompileArrayComparisonIsBalanced(t *testing.T) {
 	const n = 1000
 	src := []byte(fmt.Sprintf(`package main
@@ -327,11 +323,11 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	// Max nesting depth of && / || binary nodes in the fragment function.
 	var joinDepth func(e shaderir.Expr) int
 	joinDepth = func(e shaderir.Expr) int {
-		d := 0
+		var d int
 		if e.Type == shaderir.Binary && (e.Op == shaderir.AndAnd || e.Op == shaderir.OrOr) {
 			d = 1
 		}
-		child := 0
+		var child int
 		for _, sub := range e.Exprs {
 			if c := joinDepth(sub); c > child {
 				child = c
@@ -341,7 +337,7 @@ func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
 	}
 	var blockDepth func(b *shaderir.Block) int
 	blockDepth = func(b *shaderir.Block) int {
-		m := 0
+		var m int
 		for _, st := range b.Stmts {
 			for _, e := range st.Exprs {
 				if d := joinDepth(e); d > m {


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
arrayComparisonExpr combined the per-element comparisons into a left-nested chain: ((((e0 && e1) && e2) && ...)). The backends render a binary node by recursively formatting and copying both operands, so this made compiling a comparison of a large array O(n^2) in the element count (a [1000]int comparison took seconds, and larger arrays hang), and also recursed n deep.

Collect the element comparisons and combine them pairwise into a balanced tree. && and || are associative, so the result is unchanged; the depth becomes logarithmic and the work O(n log n).

Add TestCompileArrayComparisonIsBalanced, which measures the nesting depth of the conjunctions and fails on the left-nested chain.
