### PR TITLE
audio: bug fix: a data race in dummyPlayer volume

### DIFF
--- a/audio/export_test.go
+++ b/audio/export_test.go
@@ -133,10 +133,14 @@ func (p *dummyPlayer) IsPlaying() bool {
 }
 
 func (p *dummyPlayer) Volume() float64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.volume
 }
 
 func (p *dummyPlayer) SetVolume(volume float64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.volume = volume
 }
 

--- a/audio/export_test.go
+++ b/audio/export_test.go
@@ -132,18 +132,16 @@ func (p *dummyPlayer) IsPlaying() bool {
 	return p.playing
 }
 
-// Volume returns the volume.
-//
-// The volume is not shared with the goroutine Play spawns, but the mutex is held so that the test
-// double is uniformly safe like the real player it stands in for.
 func (p *dummyPlayer) Volume() float64 {
+	// The volume is not shared with the goroutine Play spawns, but the mutex is held so that the
+	// test double is uniformly safe like the real player it stands in for.
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.volume
 }
 
-// SetVolume sets the volume. See Volume for why the mutex is held.
 func (p *dummyPlayer) SetVolume(volume float64) {
+	// See Volume for why the mutex is held.
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.volume = volume

--- a/audio/export_test.go
+++ b/audio/export_test.go
@@ -132,12 +132,17 @@ func (p *dummyPlayer) IsPlaying() bool {
 	return p.playing
 }
 
+// Volume returns the volume.
+//
+// The volume is not shared with the goroutine Play spawns, but the mutex is held so that the test
+// double is uniformly safe like the real player it stands in for.
 func (p *dummyPlayer) Volume() float64 {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.volume
 }
 
+// SetVolume sets the volume. See Volume for why the mutex is held.
 func (p *dummyPlayer) SetVolume(volume float64) {
 	p.mu.Lock()
 	defer p.mu.Unlock()


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Volume and SetVolume accessed p.volume without holding p.mu, while every other dummyPlayer method holds it. Concurrent Volume/SetVolume raced on the float64.

Guard both accessors with p.mu like the other methods.