### PR TITLE
ebitenutil: bug fix: a data race in the debug-print glyph cache

### DIFF
--- a/ebitenutil/debugprint.go
+++ b/ebitenutil/debugprint.go
@@ -21,7 +21,6 @@ import (
 	_ "embed"
 	"image"
 	_ "image/png"
-	"sync"
 
 	"github.com/hajimehoshi/ebiten/v2"
 )
@@ -29,11 +28,7 @@ import (
 //go:embed text.png
 var text_png []byte
 
-var (
-	debugPrintTextImage     *ebiten.Image
-	debugPrintTextSubImages = map[rune]*ebiten.Image{}
-	debugPrintM             sync.Mutex
-)
+var debugPrintTextImage *ebiten.Image
 
 func init() {
 	img, _, err := image.Decode(bytes.NewReader(text_png))
@@ -76,29 +71,14 @@ func drawDebugText(rt *ebiten.Image, str string, ox, oy int) {
 			x += cw
 			continue
 		}
-		s := debugPrintSubImage(c, w)
+		n := w / cw
+		sx := (int(c) % n) * cw
+		sy := (int(c) / n) * ch
+		s := debugPrintTextImage.SubImage(image.Rect(sx, sy, sx+cw, sy+ch)).(*ebiten.Image)
 		op.GeoM.Reset()
 		op.GeoM.Translate(float64(x), float64(y))
 		op.GeoM.Translate(float64(ox+1), float64(oy))
 		rt.DrawImage(s, op)
 		x += cw
 	}
-}
-
-func debugPrintSubImage(c rune, w int) *ebiten.Image {
-	const (
-		cw = 6
-		ch = 16
-	)
-	debugPrintM.Lock()
-	defer debugPrintM.Unlock()
-	if s, ok := debugPrintTextSubImages[c]; ok {
-		return s
-	}
-	n := w / cw
-	sx := (int(c) % n) * cw
-	sy := (int(c) / n) * ch
-	s := debugPrintTextImage.SubImage(image.Rect(sx, sy, sx+cw, sy+ch)).(*ebiten.Image)
-	debugPrintTextSubImages[c] = s
-	return s
 }

--- a/ebitenutil/debugprint.go
+++ b/ebitenutil/debugprint.go
@@ -21,6 +21,7 @@ import (
 	_ "embed"
 	"image"
 	_ "image/png"
+	"sync"
 
 	"github.com/hajimehoshi/ebiten/v2"
 )
@@ -31,6 +32,7 @@ var text_png []byte
 var (
 	debugPrintTextImage     *ebiten.Image
 	debugPrintTextSubImages = map[rune]*ebiten.Image{}
+	debugPrintM             sync.Mutex
 )
 
 func init() {
@@ -74,18 +76,29 @@ func drawDebugText(rt *ebiten.Image, str string, ox, oy int) {
 			x += cw
 			continue
 		}
-		s, ok := debugPrintTextSubImages[c]
-		if !ok {
-			n := w / cw
-			sx := (int(c) % n) * cw
-			sy := (int(c) / n) * ch
-			s = debugPrintTextImage.SubImage(image.Rect(sx, sy, sx+cw, sy+ch)).(*ebiten.Image)
-			debugPrintTextSubImages[c] = s
-		}
+		s := debugPrintSubImage(c, w)
 		op.GeoM.Reset()
 		op.GeoM.Translate(float64(x), float64(y))
 		op.GeoM.Translate(float64(ox+1), float64(oy))
 		rt.DrawImage(s, op)
 		x += cw
 	}
+}
+
+func debugPrintSubImage(c rune, w int) *ebiten.Image {
+	const (
+		cw = 6
+		ch = 16
+	)
+	debugPrintM.Lock()
+	defer debugPrintM.Unlock()
+	if s, ok := debugPrintTextSubImages[c]; ok {
+		return s
+	}
+	n := w / cw
+	sx := (int(c) % n) * cw
+	sy := (int(c) / n) * ch
+	s := debugPrintTextImage.SubImage(image.Rect(sx, sy, sx+cw, sy+ch)).(*ebiten.Image)
+	debugPrintTextSubImages[c] = s
+	return s
 }


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
drawDebugText lazily created per-rune sub-images in debugPrintTextSubImages without synchronization. Concurrent DebugPrint calls raced on the map.

Guard the lookup-or-create path with a dedicated mutex.