### PR TITLE
internal/file: bug fix: a data race in file on browsers

### DIFF
--- a/internal/file/file_js.go
+++ b/internal/file/file_js.go
@@ -187,17 +187,17 @@ func getFile(entry js.Value) js.Value {
 	return <-ch
 }
 
-func (f *file) ensureFile() js.Value {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.ensureFileLocked()
-}
-
+// ensureFileLocked returns the JS File of the entry, fetching it if it has not been fetched yet.
+//
+// The caller must hold f.mu.
 func (f *file) ensureFileLocked() js.Value {
 	if f.file.Truthy() {
 		return f.file
 	}
 
+	// The lock is held even while getFile waits for its callback. The callback runs on the syscall/js
+	// callback goroutine and never takes the lock, so this cannot deadlock. Holding the lock across
+	// the wait is what makes a concurrent caller reuse this file instead of fetching it once more.
 	f.file = getFile(f.entry)
 	return f.file
 }
@@ -205,18 +205,17 @@ func (f *file) ensureFileLocked() js.Value {
 func (f *file) Stat() (fs.FileInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+
 	return &fileInfo{
 		name: f.entry.Get("name").String(),
 		file: f.ensureFileLocked(),
 	}, nil
 }
 
-func (f *file) ensureUint8Array() (js.Value, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.ensureUint8ArrayLocked()
-}
-
+// ensureUint8ArrayLocked returns the contents of the file as a Uint8Array, loading them if they
+// have not been loaded yet.
+//
+// The caller must hold f.mu.
 func (f *file) ensureUint8ArrayLocked() (js.Value, error) {
 	if f.uint8Array.Truthy() {
 		return f.uint8Array, nil
@@ -237,6 +236,10 @@ func (f *file) ensureUint8ArrayLocked() (js.Value, error) {
 	defer cbCatch.Release()
 
 	f.ensureFileLocked().Call("arrayBuffer").Call("then", cbThen).Call("catch", cbCatch)
+	// The lock is held even during this wait. The promise callbacks run on the syscall/js callback
+	// goroutine and never take the lock, so this cannot deadlock. Holding the lock across the wait is
+	// what makes a concurrent caller reuse these contents instead of fetching and buffering the file
+	// once more.
 	select {
 	case ab := <-chArrayBuffer:
 		f.uint8Array = js.Global().Get("Uint8Array").New(ab)

--- a/internal/file/file_js.go
+++ b/internal/file/file_js.go
@@ -172,6 +172,7 @@ type file struct {
 	file       js.Value
 	offset     int64
 	uint8Array js.Value
+	mu         sync.Mutex
 }
 
 func getFile(entry js.Value) js.Value {
@@ -187,6 +188,12 @@ func getFile(entry js.Value) js.Value {
 }
 
 func (f *file) ensureFile() js.Value {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ensureFileLocked()
+}
+
+func (f *file) ensureFileLocked() js.Value {
 	if f.file.Truthy() {
 		return f.file
 	}
@@ -196,13 +203,21 @@ func (f *file) ensureFile() js.Value {
 }
 
 func (f *file) Stat() (fs.FileInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	return &fileInfo{
 		name: f.entry.Get("name").String(),
-		file: f.ensureFile(),
+		file: f.ensureFileLocked(),
 	}, nil
 }
 
 func (f *file) ensureUint8Array() (js.Value, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ensureUint8ArrayLocked()
+}
+
+func (f *file) ensureUint8ArrayLocked() (js.Value, error) {
 	if f.uint8Array.Truthy() {
 		return f.uint8Array, nil
 	}
@@ -221,7 +236,7 @@ func (f *file) ensureUint8Array() (js.Value, error) {
 	})
 	defer cbCatch.Release()
 
-	f.ensureFile().Call("arrayBuffer").Call("then", cbThen).Call("catch", cbCatch)
+	f.ensureFileLocked().Call("arrayBuffer").Call("then", cbThen).Call("catch", cbCatch)
 	select {
 	case ab := <-chArrayBuffer:
 		f.uint8Array = js.Global().Get("Uint8Array").New(ab)
@@ -233,7 +248,10 @@ func (f *file) ensureUint8Array() (js.Value, error) {
 }
 
 func (f *file) Read(buf []byte) (int, error) {
-	uint8Array, err := f.ensureUint8Array()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	uint8Array, err := f.ensureUint8ArrayLocked()
 	if err != nil {
 		return 0, err
 	}
@@ -258,7 +276,10 @@ func (f *file) Read(buf []byte) (int, error) {
 }
 
 func (f *file) readAll() ([]byte, error) {
-	uint8Array, err := f.ensureUint8Array()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	uint8Array, err := f.ensureUint8ArrayLocked()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/file/file_js.go
+++ b/internal/file/file_js.go
@@ -172,7 +172,12 @@ type file struct {
 	file       js.Value
 	offset     int64
 	uint8Array js.Value
-	mu         sync.Mutex
+
+	// mu guards the lazily fetched values and the offset. It is held even while a helper waits for
+	// a JavaScript callback: the callbacks run on the syscall/js callback goroutine and never take
+	// mu, so waiting under it cannot deadlock, and it is what makes a concurrent caller reuse the
+	// fetched value instead of fetching it again.
+	mu sync.Mutex
 }
 
 func getFile(entry js.Value) js.Value {
@@ -187,17 +192,13 @@ func getFile(entry js.Value) js.Value {
 	return <-ch
 }
 
-// ensureFileLocked returns the JS File of the entry, fetching it if it has not been fetched yet.
+// ensureFileLocked returns the JS File of the entry.
 //
 // The caller must hold f.mu.
 func (f *file) ensureFileLocked() js.Value {
 	if f.file.Truthy() {
 		return f.file
 	}
-
-	// The lock is held even while getFile waits for its callback. The callback runs on the syscall/js
-	// callback goroutine and never takes the lock, so this cannot deadlock. Holding the lock across
-	// the wait is what makes a concurrent caller reuse this file instead of fetching it once more.
 	f.file = getFile(f.entry)
 	return f.file
 }
@@ -212,8 +213,7 @@ func (f *file) Stat() (fs.FileInfo, error) {
 	}, nil
 }
 
-// ensureUint8ArrayLocked returns the contents of the file as a Uint8Array, loading them if they
-// have not been loaded yet.
+// ensureUint8ArrayLocked returns the contents of the file as a Uint8Array.
 //
 // The caller must hold f.mu.
 func (f *file) ensureUint8ArrayLocked() (js.Value, error) {
@@ -236,10 +236,6 @@ func (f *file) ensureUint8ArrayLocked() (js.Value, error) {
 	defer cbCatch.Release()
 
 	f.ensureFileLocked().Call("arrayBuffer").Call("then", cbThen).Call("catch", cbCatch)
-	// The lock is held even during this wait. The promise callbacks run on the syscall/js callback
-	// goroutine and never take the lock, so this cannot deadlock. Holding the lock across the wait is
-	// what makes a concurrent caller reuse these contents instead of fetching and buffering the file
-	// once more.
 	select {
 	case ab := <-chArrayBuffer:
 		f.uint8Array = js.Global().Get("Uint8Array").New(ab)

--- a/internal/file/file_js_test.go
+++ b/internal/file/file_js_test.go
@@ -15,6 +15,8 @@
 package file_test
 
 import (
+	"errors"
+	"io"
 	"io/fs"
 	"slices"
 	"sync"
@@ -120,5 +122,171 @@ func TestDirReadDirConcurrently(t *testing.T) {
 
 	if got, want := names, childNames; !slices.Equal(got, want) {
 		t.Errorf("names: got: %v, want: %v", got, want)
+	}
+}
+
+// fakeFileCalls counts the asynchronous calls a fake file entry receives.
+type fakeFileCalls struct {
+	file        int
+	arrayBuffer int
+}
+
+// newFakeFileEntry returns a fake FileSystemDirectoryEntry with one child file of the given
+// content. Its getFile, file and arrayBuffer settle asynchronously, like a browser does.
+func newFakeFileEntry(t *testing.T, name string, content []byte, calls *fakeFileCalls) js.Value {
+	var funcs []js.Func
+	t.Cleanup(func() {
+		for _, f := range funcs {
+			f.Release()
+		}
+	})
+	register := func(f js.Func) js.Func {
+		funcs = append(funcs, f)
+		return f
+	}
+
+	u8 := js.Global().Get("Uint8Array").New(len(content))
+	js.CopyBytesToJS(u8, content)
+	buf := u8.Get("buffer")
+
+	arrayBuffer := register(js.FuncOf(func(this js.Value, args []js.Value) any {
+		calls.arrayBuffer++
+		executor := register(js.FuncOf(func(this js.Value, args []js.Value) any {
+			js.Global().Call("setTimeout", args[0], 0, buf)
+			return nil
+		}))
+		return js.Global().Get("Promise").New(executor)
+	}))
+
+	fileObj := js.ValueOf(map[string]any{
+		"name":         name,
+		"size":         len(content),
+		"lastModified": 0,
+		"arrayBuffer":  arrayBuffer,
+	})
+
+	fileFn := register(js.FuncOf(func(this js.Value, args []js.Value) any {
+		calls.file++
+		js.Global().Call("setTimeout", args[0], 0, fileObj)
+		return nil
+	}))
+
+	getFile := register(js.FuncOf(func(this js.Value, args []js.Value) any {
+		js.Global().Call("setTimeout", args[2], 0, js.ValueOf(map[string]any{
+			"name":        name,
+			"fullPath":    "/root/" + name,
+			"isFile":      true,
+			"isDirectory": false,
+			"file":        fileFn,
+		}))
+		return nil
+	}))
+
+	return js.ValueOf(map[string]any{
+		"name":        "root",
+		"fullPath":    "/root",
+		"isFile":      false,
+		"isDirectory": true,
+		"getFile":     getFile,
+	})
+}
+
+func openFakeFile(t *testing.T, content []byte, calls *fakeFileCalls) fs.File {
+	t.Helper()
+
+	root := newFakeFileEntry(t, "a.txt", content, calls)
+	fsys, err := file.NewFileEntryFS([]js.Value{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := fsys.Open("a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = f.Close()
+	})
+	return f
+}
+
+func TestFileReadConcurrently(t *testing.T) {
+	content := []byte("0123456789abcdefghij")
+	var calls fakeFileCalls
+	f := openFakeFile(t, content, &calls)
+
+	const goroutines = 2
+	bufs := make([][]byte, goroutines)
+	ns := make([]int, goroutines)
+	errs := make([]error, goroutines)
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bufs[i] = make([]byte, len(content)/goroutines)
+			ns[i], errs[i] = f.Read(bufs[i])
+		}()
+	}
+	wg.Wait()
+
+	if got, want := calls.arrayBuffer, 1; got != want {
+		t.Errorf("arrayBuffer calls: got: %d, want: %d", got, want)
+	}
+
+	var total int
+	for i := range goroutines {
+		if err := errs[i]; err != nil && !errors.Is(err, io.EOF) {
+			t.Fatal(err)
+		}
+		total += ns[i]
+	}
+	if got, want := total, len(content); got != want {
+		t.Errorf("read bytes in total: got: %d, want: %d", got, want)
+	}
+
+	// The reads must cover the content exactly once, in either order.
+	got := string(bufs[0][:ns[0]]) + string(bufs[1][:ns[1]])
+	half := len(content) / goroutines
+	if want, wantSwapped := string(content), string(content[half:])+string(content[:half]); got != want && got != wantSwapped {
+		t.Errorf("concatenated reads: got: %q, want: %q or %q", got, want, wantSwapped)
+	}
+}
+
+func TestFileStatAndReadConcurrently(t *testing.T) {
+	content := []byte("0123456789")
+	var calls fakeFileCalls
+	f := openFakeFile(t, content, &calls)
+
+	var size int64
+	var statErr, readErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		fi, err := f.Stat()
+		if err != nil {
+			statErr = err
+			return
+		}
+		size = fi.Size()
+	}()
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, len(content))
+		_, readErr = f.Read(buf)
+	}()
+	wg.Wait()
+
+	if statErr != nil {
+		t.Fatal(statErr)
+	}
+	if readErr != nil && !errors.Is(readErr, io.EOF) {
+		t.Fatal(readErr)
+	}
+	if got, want := calls.file, 1; got != want {
+		t.Errorf("file calls: got: %d, want: %d", got, want)
+	}
+	if got, want := size, int64(len(content)); got != want {
+		t.Errorf("size: got: %d, want: %d", got, want)
 	}
 }

--- a/internal/file/file_js_test.go
+++ b/internal/file/file_js_test.go
@@ -220,12 +220,10 @@ func TestFileReadConcurrently(t *testing.T) {
 	errs := make([]error, goroutines)
 	var wg sync.WaitGroup
 	for i := range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			bufs[i] = make([]byte, len(content)/goroutines)
 			ns[i], errs[i] = f.Read(bufs[i])
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -260,21 +258,18 @@ func TestFileStatAndReadConcurrently(t *testing.T) {
 	var size int64
 	var statErr, readErr error
 	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		fi, err := f.Stat()
 		if err != nil {
 			statErr = err
 			return
 		}
 		size = fi.Size()
-	}()
-	go func() {
-		defer wg.Done()
+	})
+	wg.Go(func() {
 		buf := make([]byte, len(content))
 		_, readErr = f.Read(buf)
-	}()
+	})
 	wg.Wait()
 
 	if statErr != nil {


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
file kept its lazily loaded values and read offset as plain fields. Concurrent Read/Stat raced on them.

Add a mutex mirroring dir, with locked helpers.
