### PR TITLE
mobile: bug fix: data races in ebitenmobileview input state

### DIFF
--- a/mobile/ebitenmobileview/input.go
+++ b/mobile/ebitenmobileview/input.go
@@ -28,6 +28,15 @@ type position struct {
 }
 
 var (
+	// inputMu protects the input state of the package: the members below and
+	// ptrToID in input_ios.go. Every platform entry point (the touch and key
+	// callbacks in input_android.go and input_ios.go) holds it across its mutation
+	// and the updateInput copy.
+	//
+	// The entry points are expected to run on the platform UI thread only, so this
+	// mutex is normally uncontended and enforces the convention.
+	inputMu sync.Mutex
+
 	keyPressedTimes  [ui.KeyMax + 1]ui.InputTime
 	keyReleasedTimes [ui.KeyMax + 1]ui.InputTime
 	touches          = map[ui.TouchID]position{}
@@ -41,10 +50,10 @@ var (
 	touchSlice []ui.TouchForInput
 )
 
-var inputM sync.Mutex
-
 // setKeyReleased records a key release. The release of a key that is not down
 // is ignored: the game never saw the key pressed.
+//
+// setKeyReleased must be called with inputMu held.
 func setKeyReleased(key ui.Key) {
 	if keyPressedTimes[key] <= keyReleasedTimes[key] {
 		return
@@ -52,6 +61,9 @@ func setKeyReleased(key ui.Key) {
 	keyReleasedTimes[key] = ui.Get().InputTime()
 }
 
+// updateInput copies the guarded state to the platform input state.
+//
+// updateInput must be called with inputMu held.
 func updateInput(runes []rune) {
 	touchSlice = touchSlice[:0]
 	for id, position := range touches {

--- a/mobile/ebitenmobileview/input.go
+++ b/mobile/ebitenmobileview/input.go
@@ -17,6 +17,8 @@
 package ebitenmobileview
 
 import (
+	"sync"
+
 	"github.com/hajimehoshi/ebiten/v2/internal/ui"
 )
 
@@ -38,6 +40,8 @@ var (
 var (
 	touchSlice []ui.TouchForInput
 )
+
+var inputM sync.Mutex
 
 // setKeyReleased records a key release. The release of a key that is not down
 // is ignored: the game never saw the key pressed.

--- a/mobile/ebitenmobileview/input.go
+++ b/mobile/ebitenmobileview/input.go
@@ -28,13 +28,9 @@ type position struct {
 }
 
 var (
-	// inputMu protects the input state of the package: the members below and
-	// ptrToID in input_ios.go. Every platform entry point (the touch and key
-	// callbacks in input_android.go and input_ios.go) holds it across its mutation
-	// and the updateInput copy.
-	//
-	// The entry points are expected to run on the platform UI thread only, so this
-	// mutex is normally uncontended and enforces the convention.
+	// inputMu protects the variables below and ptrToID in input_ios.go.
+	// The platform entry points are expected to run on the UI thread only;
+	// inputMu makes that confinement explicit.
 	inputMu sync.Mutex
 
 	keyPressedTimes  [ui.KeyMax + 1]ui.InputTime
@@ -44,9 +40,7 @@ var (
 	// capsLock and numLock stay unknown until a physical keyboard reports them.
 	capsLock ui.LockKeyState
 	numLock  ui.LockKeyState
-)
 
-var (
 	touchSlice []ui.TouchForInput
 )
 

--- a/mobile/ebitenmobileview/input_android.go
+++ b/mobile/ebitenmobileview/input_android.go
@@ -132,8 +132,8 @@ var androidKeyToSDL = map[int]int{
 }
 
 func UpdateTouchesOnAndroid(action int, id int, x, y float64) {
-	inputM.Lock()
-	defer inputM.Unlock()
+	inputMu.Lock()
+	defer inputMu.Unlock()
 	switch action {
 	case 0x00, 0x05, 0x02: // ACTION_DOWN, ACTION_POINTER_DOWN, ACTION_MOVE
 		touches[ui.TouchID(id)] = position{x, y}
@@ -145,6 +145,8 @@ func UpdateTouchesOnAndroid(action int, id int, x, y float64) {
 }
 
 func OnKeyDownOnAndroid(keyCode int, unicodeChar int, source int, deviceID int, metaState int) {
+	inputMu.Lock()
+	defer inputMu.Unlock()
 	switch {
 	case source&sourceGamepad == sourceGamepad:
 		// A gamepad can be detected as a keyboard. Detect the device as a gamepad first.
@@ -154,8 +156,6 @@ func OnKeyDownOnAndroid(keyCode int, unicodeChar int, source int, deviceID int, 
 	case source&sourceJoystick == sourceJoystick:
 		// DPAD keys can come here, but they are also treated as an axis at a motion event. Ignore them.
 	case source&sourceKeyboard == sourceKeyboard, source == sourceUnknown && deviceID == virtualKeyboard:
-		inputM.Lock()
-		defer inputM.Unlock()
 		if key, ok := androidKeyToUIKey[keyCode]; ok {
 			keyPressedTimes[key] = ui.Get().InputTime()
 		}
@@ -169,6 +169,8 @@ func OnKeyDownOnAndroid(keyCode int, unicodeChar int, source int, deviceID int, 
 }
 
 func OnKeyUpOnAndroid(keyCode int, source int, deviceID int, metaState int) {
+	inputMu.Lock()
+	defer inputMu.Unlock()
 	switch {
 	case source&sourceGamepad == sourceGamepad:
 		// A gamepad can be detected as a keyboard. Detect the device as a gamepad first.
@@ -178,8 +180,6 @@ func OnKeyUpOnAndroid(keyCode int, source int, deviceID int, metaState int) {
 	case source&sourceJoystick == sourceJoystick:
 		// DPAD keys can come here, but they are also treated as an axis at a motion event. Ignore them.
 	case source&sourceKeyboard == sourceKeyboard, source == sourceUnknown && deviceID == virtualKeyboard:
-		inputM.Lock()
-		defer inputM.Unlock()
 		if key, ok := androidKeyToUIKey[keyCode]; ok {
 			setKeyReleased(key)
 		}

--- a/mobile/ebitenmobileview/input_android.go
+++ b/mobile/ebitenmobileview/input_android.go
@@ -132,6 +132,8 @@ var androidKeyToSDL = map[int]int{
 }
 
 func UpdateTouchesOnAndroid(action int, id int, x, y float64) {
+	inputM.Lock()
+	defer inputM.Unlock()
 	switch action {
 	case 0x00, 0x05, 0x02: // ACTION_DOWN, ACTION_POINTER_DOWN, ACTION_MOVE
 		touches[ui.TouchID(id)] = position{x, y}
@@ -152,6 +154,8 @@ func OnKeyDownOnAndroid(keyCode int, unicodeChar int, source int, deviceID int, 
 	case source&sourceJoystick == sourceJoystick:
 		// DPAD keys can come here, but they are also treated as an axis at a motion event. Ignore them.
 	case source&sourceKeyboard == sourceKeyboard, source == sourceUnknown && deviceID == virtualKeyboard:
+		inputM.Lock()
+		defer inputM.Unlock()
 		if key, ok := androidKeyToUIKey[keyCode]; ok {
 			keyPressedTimes[key] = ui.Get().InputTime()
 		}
@@ -174,6 +178,8 @@ func OnKeyUpOnAndroid(keyCode int, source int, deviceID int, metaState int) {
 	case source&sourceJoystick == sourceJoystick:
 		// DPAD keys can come here, but they are also treated as an axis at a motion event. Ignore them.
 	case source&sourceKeyboard == sourceKeyboard, source == sourceUnknown && deviceID == virtualKeyboard:
+		inputM.Lock()
+		defer inputM.Unlock()
 		if key, ok := androidKeyToUIKey[keyCode]; ok {
 			setKeyReleased(key)
 		}

--- a/mobile/ebitenmobileview/input_ios.go
+++ b/mobile/ebitenmobileview/input_ios.go
@@ -35,8 +35,8 @@ func init() {
 // dispatchKeyPress records a key press, and its release, for a key the platform
 // text editor received instead of the game's view.
 func dispatchKeyPress(key ui.Key) {
-	inputM.Lock()
-	defer inputM.Unlock()
+	inputMu.Lock()
+	defer inputMu.Unlock()
 	keyPressedTimes[key] = ui.Get().InputTime()
 	setKeyReleased(key)
 	updateInput(nil)
@@ -45,8 +45,8 @@ func dispatchKeyPress(key ui.Key) {
 // dispatchKeyDown records a key press for a key the platform text editor
 // received instead of the game's view.
 func dispatchKeyDown(key ui.Key) {
-	inputM.Lock()
-	defer inputM.Unlock()
+	inputMu.Lock()
+	defer inputMu.Unlock()
 	keyPressedTimes[key] = ui.Get().InputTime()
 	updateInput(nil)
 }
@@ -54,8 +54,8 @@ func dispatchKeyDown(key ui.Key) {
 // dispatchKeyUp records a key release for a key the platform text editor
 // received instead of the game's view.
 func dispatchKeyUp(key ui.Key) {
-	inputM.Lock()
-	defer inputM.Unlock()
+	inputMu.Lock()
+	defer inputMu.Unlock()
 	setKeyReleased(key)
 	updateInput(nil)
 }
@@ -76,8 +76,8 @@ func getIDFromPtr(ptr int64) int {
 }
 
 func UpdateTouchesOnIOS(phase int, ptr int64, x, y float64) {
-	inputM.Lock()
-	defer inputM.Unlock()
+	inputMu.Lock()
+	defer inputMu.Unlock()
 	switch phase {
 	case C.UITouchPhaseBegan, C.UITouchPhaseMoved, C.UITouchPhaseStationary:
 		id := getIDFromPtr(ptr)
@@ -94,8 +94,8 @@ func UpdateTouchesOnIOS(phase int, ptr int64, x, y float64) {
 }
 
 func UpdatePressesOnIOS(phase int, keyCode int, keyString string, modifierFlags int) {
-	inputM.Lock()
-	defer inputM.Unlock()
+	inputMu.Lock()
+	defer inputMu.Unlock()
 	// TODO: If a key is kept pressed, ignore the repeated key events.
 	// There seems no way to check whether a key event is a repeated event or not so far.
 	updateLockKeys(modifierFlags)

--- a/mobile/ebitenmobileview/input_ios.go
+++ b/mobile/ebitenmobileview/input_ios.go
@@ -35,6 +35,8 @@ func init() {
 // dispatchKeyPress records a key press, and its release, for a key the platform
 // text editor received instead of the game's view.
 func dispatchKeyPress(key ui.Key) {
+	inputM.Lock()
+	defer inputM.Unlock()
 	keyPressedTimes[key] = ui.Get().InputTime()
 	setKeyReleased(key)
 	updateInput(nil)
@@ -43,6 +45,8 @@ func dispatchKeyPress(key ui.Key) {
 // dispatchKeyDown records a key press for a key the platform text editor
 // received instead of the game's view.
 func dispatchKeyDown(key ui.Key) {
+	inputM.Lock()
+	defer inputM.Unlock()
 	keyPressedTimes[key] = ui.Get().InputTime()
 	updateInput(nil)
 }
@@ -50,6 +54,8 @@ func dispatchKeyDown(key ui.Key) {
 // dispatchKeyUp records a key release for a key the platform text editor
 // received instead of the game's view.
 func dispatchKeyUp(key ui.Key) {
+	inputM.Lock()
+	defer inputM.Unlock()
 	setKeyReleased(key)
 	updateInput(nil)
 }
@@ -70,6 +76,8 @@ func getIDFromPtr(ptr int64) int {
 }
 
 func UpdateTouchesOnIOS(phase int, ptr int64, x, y float64) {
+	inputM.Lock()
+	defer inputM.Unlock()
 	switch phase {
 	case C.UITouchPhaseBegan, C.UITouchPhaseMoved, C.UITouchPhaseStationary:
 		id := getIDFromPtr(ptr)
@@ -86,6 +94,8 @@ func UpdateTouchesOnIOS(phase int, ptr int64, x, y float64) {
 }
 
 func UpdatePressesOnIOS(phase int, keyCode int, keyString string, modifierFlags int) {
+	inputM.Lock()
+	defer inputM.Unlock()
 	// TODO: If a key is kept pressed, ignore the repeated key events.
 	// There seems no way to check whether a key event is a repeated event or not so far.
 	updateLockKeys(modifierFlags)


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The key tables, touches, ptrToID and the reused touchSlice were accessed without synchronization. Concurrent touches or keys raced.

Add a dedicated mutex held across the mutation and the updateInput copy.
