### PR TITLE
internal/glfw: bug fix: a data race in theGoWindows on macOS

### DIFF
--- a/internal/glfw/cocoa_window_darwin.go
+++ b/internal/glfw/cocoa_window_darwin.go
@@ -10,6 +10,7 @@ import (
 	"image"
 	"math"
 	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/ebitengine/purego/objc"
@@ -658,7 +659,7 @@ func registerGLFWClasses() error {
 						window.platform.markedText.Send(sel_release)
 						window.platform.markedText = 0
 					}
-					delete(theGoWindows, self)
+					deleteGoWindow(self)
 					self.SendSuper(objc.RegisterName("dealloc"))
 				},
 			},
@@ -929,16 +930,29 @@ func registerGLFWClasses() error {
 }
 
 // theGoWindows associates ObjC delegate and content-view instances with their Go Windows.
-var theGoWindows = map[objc.ID]*Window{}
+var (
+	theGoWindows  = map[objc.ID]*Window{}
+	theGoWindowsM sync.RWMutex
+)
 
 // getGoWindow returns the Go Window associated with an ObjC instance, or nil if there is none.
 func getGoWindow(id objc.ID) *Window {
+	theGoWindowsM.RLock()
+	defer theGoWindowsM.RUnlock()
 	return theGoWindows[id]
 }
 
 // setGoWindow associates an ObjC instance with a Go Window.
 func setGoWindow(id objc.ID, window *Window) {
+	theGoWindowsM.Lock()
+	defer theGoWindowsM.Unlock()
 	theGoWindows[id] = window
+}
+
+func deleteGoWindow(id objc.ID) {
+	theGoWindowsM.Lock()
+	defer theGoWindowsM.Unlock()
+	delete(theGoWindows, id)
 }
 
 // handleMouseMoved processes mouse movement events.
@@ -1210,7 +1224,7 @@ func (w *Window) platformDestroyWindow() error {
 
 	if w.platform.delegate != 0 {
 		w.platform.object.Send(sel_setDelegate, 0)
-		delete(theGoWindows, w.platform.delegate)
+		deleteGoWindow(w.platform.delegate)
 		w.platform.delegate.Send(sel_release)
 		w.platform.delegate = 0
 	}

--- a/internal/glfw/cocoa_window_darwin.go
+++ b/internal/glfw/cocoa_window_darwin.go
@@ -10,7 +10,6 @@ import (
 	"image"
 	"math"
 	"runtime"
-	"sync"
 	"unsafe"
 
 	"github.com/ebitengine/purego/objc"
@@ -659,7 +658,7 @@ func registerGLFWClasses() error {
 						window.platform.markedText.Send(sel_release)
 						window.platform.markedText = 0
 					}
-					deleteGoWindow(self)
+					delete(theGoWindows, self)
 					self.SendSuper(objc.RegisterName("dealloc"))
 				},
 			},
@@ -930,29 +929,27 @@ func registerGLFWClasses() error {
 }
 
 // theGoWindows associates ObjC delegate and content-view instances with their Go Windows.
-var (
-	theGoWindows  = map[objc.ID]*Window{}
-	theGoWindowsM sync.RWMutex
-)
+//
+// Every access to this map must be on the main thread, like the rest of the glfw package:
+// the entries are written by createNativeWindow and are removed by platformDestroyWindow or by
+// the dealloc callback, and they are read only from the ObjC callbacks registered by
+// registerGLFWClasses, which AppKit invokes on the main thread as it delivers the events to
+// platformPollEvents.
+// Thus no synchronization is needed here.
+var theGoWindows = map[objc.ID]*Window{}
 
 // getGoWindow returns the Go Window associated with an ObjC instance, or nil if there is none.
+//
+// getGoWindow must be called on the main thread.
 func getGoWindow(id objc.ID) *Window {
-	theGoWindowsM.RLock()
-	defer theGoWindowsM.RUnlock()
 	return theGoWindows[id]
 }
 
 // setGoWindow associates an ObjC instance with a Go Window.
+//
+// setGoWindow must be called on the main thread.
 func setGoWindow(id objc.ID, window *Window) {
-	theGoWindowsM.Lock()
-	defer theGoWindowsM.Unlock()
 	theGoWindows[id] = window
-}
-
-func deleteGoWindow(id objc.ID) {
-	theGoWindowsM.Lock()
-	defer theGoWindowsM.Unlock()
-	delete(theGoWindows, id)
 }
 
 // handleMouseMoved processes mouse movement events.
@@ -1224,7 +1221,7 @@ func (w *Window) platformDestroyWindow() error {
 
 	if w.platform.delegate != 0 {
 		w.platform.object.Send(sel_setDelegate, 0)
-		deleteGoWindow(w.platform.delegate)
+		delete(theGoWindows, w.platform.delegate)
 		w.platform.delegate.Send(sel_release)
 		w.platform.delegate = 0
 	}

--- a/internal/glfw/cocoa_window_darwin.go
+++ b/internal/glfw/cocoa_window_darwin.go
@@ -930,24 +930,22 @@ func registerGLFWClasses() error {
 
 // theGoWindows associates ObjC delegate and content-view instances with their Go Windows.
 //
-// Every access to this map must be on the main thread, like the rest of the glfw package:
-// the entries are written by createNativeWindow and are removed by platformDestroyWindow or by
-// the dealloc callback, and they are read only from the ObjC callbacks registered by
-// registerGLFWClasses, which AppKit invokes on the main thread as it delivers the events to
-// platformPollEvents.
+// theGoWindows must be accessed only from the main thread, like the rest of this package:
+// the entries are written and removed while a window is created or destroyed, and read
+// from the ObjC callbacks, which AppKit invokes on the thread that triggers them.
 // Thus no synchronization is needed here.
 var theGoWindows = map[objc.ID]*Window{}
 
 // getGoWindow returns the Go Window associated with an ObjC instance, or nil if there is none.
 //
-// getGoWindow must be called on the main thread.
+// getGoWindow must be called from the main thread.
 func getGoWindow(id objc.ID) *Window {
 	return theGoWindows[id]
 }
 
 // setGoWindow associates an ObjC instance with a Go Window.
 //
-// setGoWindow must be called on the main thread.
+// setGoWindow must be called from the main thread.
 func setGoWindow(id objc.ID, window *Window) {
 	theGoWindows[id] = window
 }


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
theGoWindows was written on creation/destruction and read from ObjC callbacks without synchronization. Concurrent map access raced.

Guard the map with an RWMutex with helpers.
