### PR TITLE
fix typos in the doc comments and an error message

### DIFF
--- a/blend.go
+++ b/blend.go
@@ -34,7 +34,7 @@ import (
 //	c_out = BlendOperationRGB((BlendFactorSourceRGB) × c_src, (BlendFactorDestinationRGB) × c_dst)
 //	α_out = BlendOperationAlpha((BlendFactorSourceAlpha) × α_src, (BlendFactorDestinationAlpha) × α_dst)
 //
-// A blend factor is a factor for source and color destination color values.
+// A blend factor is a factor for source and destination color values.
 // The default is source-over (regular alpha blending).
 //
 // A blend operation is a binary operator of a source color and a destination color.
@@ -110,7 +110,7 @@ const (
 
 	// BlendFactorOneMinusSourceColor is a factor:
 	//
-	//     1 - (source color)
+	//     1 - (source RGBA)
 	BlendFactorOneMinusSourceColor
 
 	// BlendFactorSourceAlpha is a factor:

--- a/doc.go
+++ b/doc.go
@@ -115,7 +115,7 @@
 //
 // `ebitenginesinglethread` disables Ebitengine's thread safety to unlock maximum performance. If you use this you will have
 // to manage threads yourself. Functions like `SetWindowSize` will no longer be concurrent-safe with this build tag.
-// They must be called from the main thread or the same goroutine as the given game's callback functions like Update
+// They must be called from the main thread or the same goroutine as the given game's callback functions like Update.
 // `ebitenginesinglethread` works only with desktops and consoles.
 // `ebitenginesinglethread` was deprecated as of v2.7. Use RunGameOptions.SingleThread instead.
 //

--- a/internal/glfw/win32_window_windows.go
+++ b/internal/glfw/win32_window_windows.go
@@ -2413,7 +2413,7 @@ func (w *Window) platformSetCursorMode(mode int) error {
 
 func platformGetScancodeName(scancode int) (string, error) {
 	if scancode < 0 || scancode > (_KF_EXTENDED|0xff) {
-		return "", fmt.Errorf("glwfwin: invalid scancode %d: %w", scancode, InvalidValue)
+		return "", fmt.Errorf("glfw: invalid scancode %d: %w", scancode, InvalidValue)
 	}
 	key := _glfw.platformWindow.keycodes[scancode]
 	if key == KeyUnknown {

--- a/internal/shader/expr.go
+++ b/internal/shader/expr.go
@@ -813,7 +813,7 @@ func (cs *compileState) parseExpr(block *block, fname string, expr ast.Expr, mar
 					}
 				case shaderir.Abs, shaderir.Sign:
 					if argts[0].Main != shaderir.Float && !argts[0].IsFloatVector() && argts[0].Main != shaderir.Int && !argts[0].IsIntVector() {
-						cs.addError(e.Pos(), fmt.Sprintf("cannot use %s as float, vecN, int, or ivenN value in argument to %s", argts[0].String(), callee.BuiltinFunc))
+						cs.addError(e.Pos(), fmt.Sprintf("cannot use %s as float, vecN, int, or ivecN value in argument to %s", argts[0].String(), callee.BuiltinFunc))
 						return nil, nil, nil, false
 					}
 				default:

--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -353,7 +353,7 @@ func (cs *compileState) parse(f *ast.File) {
 		return
 	}
 
-	// Set attribute and varying veraibles.
+	// Set attribute and varying variables.
 	for _, p := range vertexInParams {
 		cs.ir.Attributes = append(cs.ir.Attributes, p.typ)
 	}

--- a/internal/shader/type.go
+++ b/internal/shader/type.go
@@ -105,7 +105,7 @@ func (cs *compileState) parseType(block *block, fname string, expr ast.Expr) (sh
 		cs.addError(t.Pos(), "struct is not implemented")
 		return shaderir.Type{}, false
 	default:
-		cs.addError(t.Pos(), fmt.Sprintf("unepxected type: %v", t))
+		cs.addError(t.Pos(), fmt.Sprintf("unexpected type: %v", t))
 		return shaderir.Type{}, false
 	}
 }

--- a/internal/ui/ui_linbsd.go
+++ b/internal/ui/ui_linbsd.go
@@ -35,7 +35,7 @@ func (u *UserInterface) initializePlatform() error {
 }
 
 func (u *glfwBackend) setApplePressAndHoldEnabled(enabled bool) {
-	// Do nothings.
+	// Do nothing.
 }
 
 type graphicsDriverCreatorImpl struct {

--- a/internal/ui/ui_windows.go
+++ b/internal/ui/ui_windows.go
@@ -38,7 +38,7 @@ func (u *UserInterface) initializePlatform() error {
 }
 
 func (u *glfwBackend) setApplePressAndHoldEnabled(enabled bool) {
-	// Do nothings.
+	// Do nothing.
 }
 
 type graphicsDriverCreatorImpl struct {

--- a/monitor.go
+++ b/monitor.go
@@ -39,7 +39,7 @@ func (m *MonitorType) DeviceScaleFactor() float64 {
 
 // Size returns the size of the monitor in device-independent pixels.
 // This is the same as the screen size in fullscreen mode.
-// The returned value can be given to SetSize function if the perfectly fit fullscreen is needed.
+// The returned value can be given to SetWindowSize function if the perfectly fit fullscreen is needed.
 //
 // On mobiles, Size returns (0, 0) before the game starts e.g. in init functions.
 //

--- a/monitor.go
+++ b/monitor.go
@@ -39,7 +39,7 @@ func (m *MonitorType) DeviceScaleFactor() float64 {
 
 // Size returns the size of the monitor in device-independent pixels.
 // This is the same as the screen size in fullscreen mode.
-// The returned value can be given to SetWindowSize function if the perfectly fit fullscreen is needed.
+// The returned value can be given to [SetWindowSize] if the perfectly fit fullscreen is needed.
 //
 // On mobiles, Size returns (0, 0) before the game starts e.g. in init functions.
 //

--- a/run.go
+++ b/run.go
@@ -404,7 +404,7 @@ func ScreenSize() (int, int) {
 
 // ScreenSizeInFullscreen returns the size in device-independent pixels when the game is fullscreen.
 // The adopted monitor is the 'current' monitor which the window belongs to.
-// The returned value can be given to SetWindowSize function if the perfectly fit fullscreen is needed.
+// The returned value can be given to [SetWindowSize] if the perfectly fit fullscreen is needed.
 //
 // On browsers, ScreenSizeInFullscreen returns the 'window' (global object) size, not 'screen' size.
 // ScreenSizeInFullscreen's returning value is different from the actual screen size and this is a known issue (#2145).

--- a/run.go
+++ b/run.go
@@ -404,7 +404,7 @@ func ScreenSize() (int, int) {
 
 // ScreenSizeInFullscreen returns the size in device-independent pixels when the game is fullscreen.
 // The adopted monitor is the 'current' monitor which the window belongs to.
-// The returned value can be given to SetSize function if the perfectly fit fullscreen is needed.
+// The returned value can be given to SetWindowSize function if the perfectly fit fullscreen is needed.
 //
 // On browsers, ScreenSizeInFullscreen returns the 'window' (global object) size, not 'screen' size.
 // ScreenSizeInFullscreen's returning value is different from the actual screen size and this is a known issue (#2145).

--- a/vector/pathlegacy.go
+++ b/vector/pathlegacy.go
@@ -23,7 +23,7 @@ import (
 // AppendVerticesAndIndicesForFilling works in a similar way to the built-in append function.
 // If the arguments are nils, AppendVerticesAndIndicesForFilling returns new slices.
 //
-// The returned vertice's SrcX and SrcY are 0, and ColorR, ColorG, ColorB, and ColorA are 1.
+// The returned vertices' SrcX and SrcY are 0, and ColorR, ColorG, ColorB, and ColorA are 1.
 //
 // The returned values are intended to be passed to DrawTriangles or DrawTrianglesShader with FillRuleNonZero or FillRuleEvenOdd
 // in order to render a complex polygon like a concave polygon, a polygon with holes, or a self-intersecting polygon.
@@ -65,7 +65,7 @@ func (p *Path) AppendVerticesAndIndicesForFilling(vertices []ebiten.Vertex, indi
 // AppendVerticesAndIndicesForStroke works in a similar way to the built-in append function.
 // If the arguments are nils, AppendVerticesAndIndicesForStroke returns new slices.
 //
-// The returned vertice's SrcX and SrcY are 0, and ColorR, ColorG, ColorB, and ColorA are 1.
+// The returned vertices' SrcX and SrcY are 0, and ColorR, ColorG, ColorB, and ColorA are 1.
 //
 // The returned values are intended to be passed to DrawTriangles or DrawTrianglesShader with a solid (non-transparent) color
 // with FillRuleFillAll or FillRuleNonZero, not FillRuleEvenOdd.


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
- monitor.go, run.go: the doc comments of Monitor.Size and the deprecated ScreenSizeInFullscreen referred to a nonexistent SetSize function. The actual API is SetWindowSize.
- blend.go: fixed a garbled sentence for Blend ('source and color destination color values'), and unified '1 - (source color)' with '(source RGBA)' that the counterpart constants use.
- doc.go: added a missing period that merged two unrelated sentences about the ebitenginesinglethread build tag.
- vector/pathlegacy.go: 'vertice's' is ungrammatical; use vertices'.
- internal/glfw: the error-message prefix 'glwfwin:' was a typo of 'glfw:' that the package uses everywhere else.
- internal/ui: 'Do nothings.' in no-op stubs; use 'Do nothing.'
- internal/shader: 'unepxected' type, 'ivenN' (ivecN), and 'veraibles' (variables) in an error message, a doc comment, and a comment.
