### PR TITLE
internal/shader: reject the blank identifier used as a value

### DIFF
--- a/internal/shader/expr.go
+++ b/internal/shader/expr.go
@@ -98,6 +98,11 @@ func (cs *compileState) parseExpr(block *block, fname string, expr ast.Expr, mar
 		}
 		rhst := ts[0]
 
+		if lhs[0].Type == shaderir.Blank || rhs[0].Type == shaderir.Blank {
+			cs.addError(e.Pos(), "cannot use _ as value")
+			return nil, nil, nil, false
+		}
+
 		op := e.Op
 		// https://pkg.go.dev/go/constant/#BinaryOp
 		// "To force integer division of Int operands, use op == token.QUO_ASSIGN instead of
@@ -221,6 +226,10 @@ func (cs *compileState) parseExpr(block *block, fname string, expr ast.Expr, mar
 			for _, expr := range es {
 				if expr.Type == shaderir.FunctionExpr || expr.Type == shaderir.BuiltinFuncExpr {
 					cs.addError(e.Pos(), fmt.Sprintf("function name cannot be an argument: %s", e.Fun))
+					return nil, nil, nil, false
+				}
+				if expr.Type == shaderir.Blank {
+					cs.addError(e.Pos(), "cannot use _ as value")
 					return nil, nil, nil, false
 				}
 			}
@@ -1069,6 +1078,10 @@ func (cs *compileState) parseExpr(block *block, fname string, expr ast.Expr, mar
 		}
 		if len(ts) == 0 {
 			cs.addError(e.Pos(), fmt.Sprintf("unexpected unary operator: %s", e.X))
+			return nil, nil, nil, false
+		}
+		if exprs[0].Type == shaderir.Blank {
+			cs.addError(e.Pos(), "cannot use _ as value")
 			return nil, nil, nil, false
 		}
 

--- a/internal/shader/shader_test.go
+++ b/internal/shader/shader_test.go
@@ -289,6 +289,34 @@ func Fragment(position vec4, texCoord vec3, color vec4) vec4 {
 	}
 }
 
+func TestCompileBlankAsValue(t *testing.T) {
+	values := []string{
+		"min(_, 1)",
+		"1 + _",
+		"min(-_, 1)",
+		"max(+_, 1)",
+		"clamp(-_, 0, 1)",
+		"1 + (-_)",
+	}
+	for _, v := range values {
+		src := []byte(fmt.Sprintf(`package main
+
+func Fragment(position vec4, texCoord vec2, color vec4) vec4 {
+	const x = %s
+	return vec4(x)
+}`, v))
+		t.Run(v, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Compile must not panic when _ is used as a value, but panicked: %v", r)
+				}
+			}()
+			if _, err := shader.Compile(src, "Vertex", "Fragment", 0); err == nil {
+				t.Fatalf("Compile must return an error when _ is used as a value, but got nil")
+			}
+		})
+	}
+}
 func TestCompileHugeShift(t *testing.T) {
 	src := `package main
 


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
In a context where a local variable is not marked as used (a constant declaration or an assignment left-hand side), parsing "_" returned an expression with Type Blank and a nil Const. When such an expression was used as a value, e.g. as an argument of min/max/clamp or an operand of a binary operator, constant folding dereferenced the nil Const and panicked with a nil pointer dereference, crashing the compiler on user input.

Reject a blank identifier used as a value in call arguments and binary operands, reporting "cannot use _ as value" instead.

Add TestCompileBlankAsValue, which panics without this fix.
