### PR TITLE
all: apply modern Go idioms available since Go 1.25

### DIFF
--- a/internal/gamepad/gamepad_js.go
+++ b/internal/gamepad/gamepad_js.go
@@ -42,9 +42,7 @@ func (g *nativeGamepadsImpl) update(gamepads *gamepads) error {
 	// TODO: Use the gamepad events instead of navigator.getGamepads.
 
 	defer func() {
-		for k := range g.indices {
-			delete(g.indices, k)
-		}
+		clear(g.indices)
 	}()
 
 	nav := js.Global().Get("navigator")

--- a/internal/gamepad/gamepad_nintendosdk.go
+++ b/internal/gamepad/gamepad_nintendosdk.go
@@ -54,9 +54,7 @@ func (g *nativeGamepadsImpl) update(gamepads *gamepads) error {
 		C.ebitengine_GetGamepads(&g.gamepads[0])
 	}
 
-	for id := range g.ids {
-		delete(g.ids, id)
-	}
+	clear(g.ids)
 
 	for _, gp := range g.gamepads {
 		if g.ids == nil {

--- a/internal/gamepad/gamepad_playstation5.go
+++ b/internal/gamepad/gamepad_playstation5.go
@@ -54,9 +54,7 @@ func (g *nativeGamepadsImpl) update(gamepads *gamepads) error {
 		C.ebitengine_GetGamepads(&g.gamepads[0])
 	}
 
-	for id := range g.ids {
-		delete(g.ids, id)
-	}
+	clear(g.ids)
 
 	for _, gp := range g.gamepads {
 		if g.ids == nil {

--- a/internal/graphicsdriver/opengl/program.go
+++ b/internal/graphicsdriver/opengl/program.go
@@ -154,9 +154,7 @@ func (s *openGLState) reset(context *context) error {
 
 	s.lastProgram = 0
 	context.ctx.UseProgram(0)
-	for key := range s.lastUniforms {
-		delete(s.lastUniforms, key)
-	}
+	clear(s.lastUniforms)
 
 	if s.arrayBuffer != 0 {
 		context.ctx.DeleteBuffer(uint32(s.arrayBuffer))
@@ -228,9 +226,7 @@ func (s *openGLState) setVertices(context *context, vertices []float32, indices 
 }
 
 func (s *openGLState) resetLastUniforms() {
-	for k := range s.lastUniforms {
-		delete(s.lastUniforms, k)
-	}
+	clear(s.lastUniforms)
 }
 
 // areSameUint32Array returns a boolean indicating if a and b are deeply equal.
@@ -284,9 +280,7 @@ func (g *Graphics) useProgram(program program, uniforms []uniformVariable, textu
 		g.context.ctx.UseProgram(uint32(program))
 
 		g.state.lastProgram = program
-		for k := range g.state.lastUniforms {
-			delete(g.state.lastUniforms, k)
-		}
+		clear(g.state.lastUniforms)
 		g.state.lastActiveTexture = 0
 		g.context.ctx.ActiveTexture(gl.TEXTURE0)
 		g.context.lastTexture = 0 // Make sure next bindTexture call actually does something.

--- a/internal/mipmap/mipmap.go
+++ b/internal/mipmap/mipmap.go
@@ -245,9 +245,7 @@ func (m *Mipmap) Deallocate() {
 		}
 		img.img.Deallocate()
 	}
-	for k := range m.imgs {
-		delete(m.imgs, k)
-	}
+	clear(m.imgs)
 	m.orig.Deallocate()
 }
 

--- a/internal/ui/ui_android.go
+++ b/internal/ui/ui_android.go
@@ -152,7 +152,7 @@ func (u *UserInterface) refreshDisplayInfo() {
 		// TODO: Fix gomobile to detect the error type for this case.
 		return
 	}
-	theDisplayInfo.Store(displayInfoValues{
+	theDisplayInfo.Store(&displayInfoValues{
 		width:  float64(cWidth),
 		height: float64(cHeight),
 		scale:  float64(cScale),

--- a/internal/ui/ui_darwin.go
+++ b/internal/ui/ui_darwin.go
@@ -475,7 +475,10 @@ func (u *glfwBackend) setNativeFullscreen(fullscreen bool) error {
 }
 
 func (u *glfwBackend) isFullscreenAllowedFromUI(mode WindowResizingMode) bool {
-	s := u.desktopWindow.windowSizeLimit.Load().(windowSizeRange)
+	s := u.desktopWindow.windowSizeLimit.Load()
+	if s == nil {
+		return true
+	}
 	if s.maxWidthInDIP != glfw.DontCare || s.maxHeightInDIP != glfw.DontCare {
 		return false
 	}

--- a/internal/ui/ui_darwin.go
+++ b/internal/ui/ui_darwin.go
@@ -476,9 +476,6 @@ func (u *glfwBackend) setNativeFullscreen(fullscreen bool) error {
 
 func (u *glfwBackend) isFullscreenAllowedFromUI(mode WindowResizingMode) bool {
 	s := u.desktopWindow.windowSizeLimit.Load()
-	if s == nil {
-		return true
-	}
 	if s.maxWidthInDIP != glfw.DontCare || s.maxHeightInDIP != glfw.DontCare {
 		return false
 	}

--- a/internal/ui/ui_ios.go
+++ b/internal/ui/ui_ios.go
@@ -137,7 +137,7 @@ func (u *UserInterface) refreshDisplayInfo() {
 
 	var cWidth, cHeight, cScale C.float
 	C.displayInfoOnMainThread(&cWidth, &cHeight, &cScale, C.uintptr_t(view))
-	theDisplayInfo.Store(displayInfoValues{
+	theDisplayInfo.Store(&displayInfoValues{
 		width:  float64(cWidth),
 		height: float64(cHeight),
 		scale:  float64(cScale),

--- a/internal/ui/ui_mobile.go
+++ b/internal/ui/ui_mobile.go
@@ -46,7 +46,7 @@ func (u *UserInterface) init() error {
 		errCh:                 make(chan error),
 	}
 	// Give a default outside size so that the game can start without initializing them.
-	u.userInterfaceImpl.outsideSize.Store(pointF{x: 640, y: 480})
+	u.userInterfaceImpl.outsideSize.Store(&pointF{x: 640, y: 480})
 	u.foreground.Store(true)
 	return nil
 }
@@ -96,11 +96,11 @@ type userInterfaceImpl struct {
 	graphicsDriver        graphicsdriver.Graphics
 	graphicsLibraryInitCh chan struct{}
 
-	outsideSize atomic.Value
+	outsideSize atomic.Pointer[pointF]
 
 	// surfaceSize is the size of the rendering surface, in pixels, as the platform reports it. It is
 	// unset when the platform reports no size, and the size is then derived from the outside size.
-	surfaceSize atomic.Value
+	surfaceSize atomic.Pointer[pointI]
 
 	foreground atomic.Bool
 	errCh      chan error
@@ -179,7 +179,10 @@ func (u *UserInterface) runMobile(game Game, options *RunOptions) (err error) {
 
 // outsideSize must be called on the same goroutine as update().
 func (u *UserInterface) outsideSize() (float64, float64) {
-	s := u.userInterfaceImpl.outsideSize.Load().(pointF)
+	s := u.userInterfaceImpl.outsideSize.Load()
+	if s == nil {
+		return 0, 0
+	}
 	return s.x, s.y
 }
 
@@ -202,7 +205,7 @@ func (u *UserInterface) update() error {
 //
 // screenSize must be called on the same goroutine as update().
 func (u *UserInterface) screenSize(outsideWidth, outsideHeight float64, deviceScaleFactor float64) (int, int) {
-	if s, ok := u.userInterfaceImpl.surfaceSize.Load().(pointI); ok {
+	if s := u.userInterfaceImpl.surfaceSize.Load(); s != nil {
 		return s.x, s.y
 	}
 	// The platform reports no surface size, so derive it from the view's size in device-independent
@@ -215,14 +218,14 @@ func (u *UserInterface) screenSize(outsideWidth, outsideHeight float64, deviceSc
 //
 // SetSurfaceSize is concurrent safe.
 func (u *UserInterface) SetSurfaceSize(width, height int) {
-	u.userInterfaceImpl.surfaceSize.Store(pointI{x: width, y: height})
+	u.userInterfaceImpl.surfaceSize.Store(&pointI{x: width, y: height})
 }
 
 // SetOutsideSize is called from mobile/ebitenmobileview.
 //
 // SetOutsideSize is concurrent safe.
 func (u *UserInterface) SetOutsideSize(outsideWidth, outsideHeight float64) {
-	u.userInterfaceImpl.outsideSize.Store(pointF{x: outsideWidth, y: outsideHeight})
+	u.userInterfaceImpl.outsideSize.Store(&pointF{x: outsideWidth, y: outsideHeight})
 	u.refreshDisplayInfo()
 }
 
@@ -297,13 +300,13 @@ type displayInfoValues struct {
 	scale  float64
 }
 
-var theDisplayInfo atomic.Value
+var theDisplayInfo atomic.Pointer[displayInfoValues]
 
 func (u *UserInterface) displayInfo() (int, int, float64, bool) {
 	// Reading the display info here would require waiting for the main thread
 	// on iOS, which can deadlock.
-	v, ok := theDisplayInfo.Load().(displayInfoValues)
-	if !ok {
+	v := theDisplayInfo.Load()
+	if v == nil {
 		return 0, 0, 1, false
 	}
 	width := int(math.Round(dipFromNativePixels(v.width, v.scale)))

--- a/internal/ui/ui_mobile.go
+++ b/internal/ui/ui_mobile.go
@@ -180,9 +180,6 @@ func (u *UserInterface) runMobile(game Game, options *RunOptions) (err error) {
 // outsideSize must be called on the same goroutine as update().
 func (u *UserInterface) outsideSize() (float64, float64) {
 	s := u.userInterfaceImpl.outsideSize.Load()
-	if s == nil {
-		return 0, 0
-	}
 	return s.x, s.y
 }
 

--- a/internal/ui/window_desktop.go
+++ b/internal/ui/window_desktop.go
@@ -80,9 +80,6 @@ func (w *desktopWindow) getWindowSizeLimitsInDIP() (minw, minh, maxw, maxh int) 
 	}
 
 	s := w.windowSizeLimit.Load()
-	if s == nil {
-		return glfw.DontCare, glfw.DontCare, glfw.DontCare, glfw.DontCare
-	}
 	return s.minWidthInDIP, s.minHeightInDIP, s.maxWidthInDIP, s.maxHeightInDIP
 }
 
@@ -189,9 +186,6 @@ func (w *desktopWindow) getInitWindowSizeInDIP() (int, int) {
 	}
 
 	pt := w.initWindowSizeInDIP.Load()
-	if pt == nil {
-		return 0, 0
-	}
 	return pt.X, pt.Y
 }
 

--- a/internal/ui/window_desktop.go
+++ b/internal/ui/window_desktop.go
@@ -43,7 +43,7 @@ type desktopWindow struct {
 
 	title atomic.Value
 
-	windowSizeLimit atomic.Value
+	windowSizeLimit atomic.Pointer[windowSizeRange]
 
 	iconImages           atomic.Pointer[[]image.Image]
 	windowClosingHandled atomic.Bool
@@ -52,7 +52,7 @@ type desktopWindow struct {
 	initWindowDecorated        atomic.Bool
 	initWindowVisible          atomic.Bool
 	initWindowPositionInDIP    atomic.Pointer[image.Point]
-	initWindowSizeInDIP        atomic.Value
+	initWindowSizeInDIP        atomic.Pointer[image.Point]
 	initWindowFloating         atomic.Bool
 	initWindowMaximized        atomic.Bool
 	initWindowMousePassthrough atomic.Bool
@@ -62,7 +62,7 @@ var _ Window = (*desktopWindow)(nil)
 
 func (w *desktopWindow) init() {
 	w.title.Store("")
-	w.windowSizeLimit.Store(windowSizeRange{
+	w.windowSizeLimit.Store(&windowSizeRange{
 		minWidthInDIP:  glfw.DontCare,
 		minHeightInDIP: glfw.DontCare,
 		maxWidthInDIP:  glfw.DontCare,
@@ -70,7 +70,8 @@ func (w *desktopWindow) init() {
 	})
 	w.initWindowDecorated.Store(true)
 	w.initWindowVisible.Store(true)
-	w.initWindowSizeInDIP.Store(image.Pt(640, 480))
+	p := image.Pt(640, 480)
+	w.initWindowSizeInDIP.Store(&p)
 }
 
 func (w *desktopWindow) getWindowSizeLimitsInDIP() (minw, minh, maxw, maxh int) {
@@ -78,7 +79,10 @@ func (w *desktopWindow) getWindowSizeLimitsInDIP() (minw, minh, maxw, maxh int) 
 		return glfw.DontCare, glfw.DontCare, glfw.DontCare, glfw.DontCare
 	}
 
-	s := w.windowSizeLimit.Load().(windowSizeRange)
+	s := w.windowSizeLimit.Load()
+	if s == nil {
+		return glfw.DontCare, glfw.DontCare, glfw.DontCare, glfw.DontCare
+	}
 	return s.minWidthInDIP, s.minHeightInDIP, s.maxWidthInDIP, s.maxHeightInDIP
 }
 
@@ -88,13 +92,14 @@ func (w *desktopWindow) setWindowSizeLimitsInDIP(minw, minh, maxw, maxh int) boo
 		return false
 	}
 
-	newS := windowSizeRange{
+	newS := &windowSizeRange{
 		minWidthInDIP:  minw,
 		minHeightInDIP: minh,
 		maxWidthInDIP:  maxw,
 		maxHeightInDIP: maxh,
 	}
-	return w.windowSizeLimit.Swap(newS) != newS
+	old := w.windowSizeLimit.Swap(newS)
+	return old == nil || *old != *newS
 }
 
 func (w *desktopWindow) isWindowMaximizable() bool {
@@ -183,7 +188,10 @@ func (w *desktopWindow) getInitWindowSizeInDIP() (int, int) {
 		return microsoftgdk.MonitorResolution()
 	}
 
-	pt := w.initWindowSizeInDIP.Load().(image.Point)
+	pt := w.initWindowSizeInDIP.Load()
+	if pt == nil {
+		return 0, 0
+	}
 	return pt.X, pt.Y
 }
 
@@ -192,7 +200,8 @@ func (w *desktopWindow) setInitWindowSizeInDIP(width, height int) {
 		return
 	}
 
-	w.initWindowSizeInDIP.Store(image.Pt(width, height))
+	pt := image.Pt(width, height)
+	w.initWindowSizeInDIP.Store(&pt)
 }
 
 func (w *desktopWindow) isInitWindowFloating() bool {

--- a/text/v2/internal/chunk/gen.go
+++ b/text/v2/internal/chunk/gen.go
@@ -105,13 +105,9 @@ func fetchProps() (map[string][]entry, error) {
 			continue
 		}
 		cpField = strings.TrimSpace(cpField)
-		var prop, name string
-		if cutoff, after, ok := strings.Cut(rest, "#"); ok {
-			prop = strings.TrimSpace(cutoff)
-			name = strings.TrimSpace(after)
-		} else {
-			prop = strings.TrimSpace(rest)
-		}
+		prop, name, _ := strings.Cut(rest, "#")
+		prop = strings.TrimSpace(prop)
+		name = strings.TrimSpace(name)
 		start, end, err := parseCodepoints(cpField)
 		if err != nil {
 			return nil, fmt.Errorf("parse %q: %w", cpField, err)
@@ -128,16 +124,16 @@ func fetchProps() (map[string][]entry, error) {
 // parseCodepoints accepts "NNNN" or "NNNN..MMMM" and returns the
 // inclusive range; for a single codepoint, start == end.
 func parseCodepoints(s string) (rune, rune, error) {
-	if s, b, ok := strings.Cut(s, ".."); ok {
-		a, err := strconv.ParseInt(s, 16, 32)
+	if before, after, ok := strings.Cut(s, ".."); ok {
+		a, err := strconv.ParseInt(before, 16, 32)
 		if err != nil {
 			return 0, 0, err
 		}
-		bn, err := strconv.ParseInt(b, 16, 32)
+		b, err := strconv.ParseInt(after, 16, 32)
 		if err != nil {
 			return 0, 0, err
 		}
-		return rune(a), rune(bn), nil
+		return rune(a), rune(b), nil
 	}
 	v, err := strconv.ParseInt(s, 16, 32)
 	if err != nil {

--- a/text/v2/internal/chunk/gen.go
+++ b/text/v2/internal/chunk/gen.go
@@ -100,16 +100,15 @@ func fetchProps() (map[string][]entry, error) {
 		if t == "" || strings.HasPrefix(t, "#") {
 			continue
 		}
-		semi := strings.Index(line, ";")
-		if semi < 0 {
+		cpField, rest, ok := strings.Cut(line, ";")
+		if !ok {
 			continue
 		}
-		cpField := strings.TrimSpace(line[:semi])
-		rest := line[semi+1:]
+		cpField = strings.TrimSpace(cpField)
 		var prop, name string
-		if hash := strings.Index(rest, "#"); hash >= 0 {
-			prop = strings.TrimSpace(rest[:hash])
-			name = strings.TrimSpace(rest[hash+1:])
+		if cutoff, after, ok := strings.Cut(rest, "#"); ok {
+			prop = strings.TrimSpace(cutoff)
+			name = strings.TrimSpace(after)
 		} else {
 			prop = strings.TrimSpace(rest)
 		}
@@ -129,16 +128,16 @@ func fetchProps() (map[string][]entry, error) {
 // parseCodepoints accepts "NNNN" or "NNNN..MMMM" and returns the
 // inclusive range; for a single codepoint, start == end.
 func parseCodepoints(s string) (rune, rune, error) {
-	if i := strings.Index(s, ".."); i >= 0 {
-		a, err := strconv.ParseInt(s[:i], 16, 32)
+	if s, b, ok := strings.Cut(s, ".."); ok {
+		a, err := strconv.ParseInt(s, 16, 32)
 		if err != nil {
 			return 0, 0, err
 		}
-		b, err := strconv.ParseInt(s[i+2:], 16, 32)
+		bn, err := strconv.ParseInt(b, 16, 32)
 		if err != nil {
 			return 0, 0, err
 		}
-		return rune(a), rune(b), nil
+		return rune(a), rune(bn), nil
 	}
 	v, err := strconv.ParseInt(s, 16, 32)
 	if err != nil {

--- a/text/v2/internal/oksvg/utils.go
+++ b/text/v2/internal/oksvg/utils.go
@@ -67,12 +67,10 @@ func parseClasses(data string) (map[string]styleAttribute, error) {
 		if v == "" {
 			continue
 		}
-		valueIndex := strings.Index(v, "{")
-		if valueIndex == -1 || valueIndex == len(v)-1 {
+		classesStr, attrStr, ok := strings.Cut(v, "{")
+		if !ok || attrStr == "" {
 			return res, errors.New(v + "}: invalid map format in class definitions")
 		}
-		classesStr := v[:valueIndex]
-		attrStr := v[valueIndex+1:]
 		attrMap, err := parseAttrs(attrStr)
 		if err != nil {
 			return res, err


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Replace the "delete every key" loops with the clear() builtin in the OpenGL state, mipmap deallocation, and the gamepad backends.

Convert the struct-typed atomic.Value fields (window size limits, the initial window size, and the mobile outside/surface/display info) to atomic.Pointer[T], removing the unchecked type assertions on load. The string title and the error field are left as atomic.Value, as the standard library has no typed atomic for them.

Use strings.Cut instead of strings.Index with manual slicing when both halves of the string are needed.

No behavior is changed.
