### PR TITLE
all: use slices.SortFunc and cmp.Compare for sorting

### DIFF
--- a/genkeys.go
+++ b/genkeys.go
@@ -719,7 +719,7 @@ func keyNamesCmp(k0, k1 string) int {
 	if f0 != -1 && f1 != -1 {
 		return cmp.Compare(f0, f1)
 	}
-	return strings.Compare(k0, k1)
+	return cmp.Compare(k0, k1)
 }
 
 const license = `// Copyright 2013 The Ebitengine Authors

--- a/internal/glfw/monitor.go
+++ b/internal/glfw/monitor.go
@@ -8,7 +8,8 @@
 package glfw
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 )
 
 func abs(x int) uint {
@@ -47,23 +48,21 @@ func (m *Monitor) refreshVideoModes() error {
 	if err != nil {
 		return err
 	}
-	sort.Slice(modes, func(i, j int) bool {
-		a := modes[i]
-		b := modes[j]
+	slices.SortFunc(modes, func(a, b *VidMode) int {
 		abpp := a.RedBits + a.GreenBits + a.BlueBits
 		bbpp := b.RedBits + b.GreenBits + b.BlueBits
-		if abpp != bbpp {
-			return abpp < bbpp
+		if c := cmp.Compare(abpp, bbpp); c != 0 {
+			return c
 		}
 		aarea := a.Width * a.Height
 		barea := b.Width * b.Height
-		if aarea != barea {
-			return aarea < barea
+		if c := cmp.Compare(aarea, barea); c != 0 {
+			return c
 		}
-		if a.Width != b.Width {
-			return a.Width < b.Width
+		if c := cmp.Compare(a.Width, b.Width); c != 0 {
+			return c
 		}
-		return a.RefreshRate < b.RefreshRate
+		return cmp.Compare(a.RefreshRate, b.RefreshRate)
 	})
 	m.modes = modes
 	return nil

--- a/text/v2/internal/chunk/gen.go
+++ b/text/v2/internal/chunk/gen.go
@@ -22,10 +22,11 @@ package main
 
 import (
 	"bufio"
+	"cmp"
 	"fmt"
 	"net/http"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -165,8 +166,8 @@ func cleanName(single bool, s string) string {
 }
 
 func writeFile(filename, funcName, propName string, entries []entry) error {
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].start < entries[j].start
+	slices.SortFunc(entries, func(a, b entry) int {
+		return cmp.Compare(a.start, b.start)
 	})
 	var ranges, singles []entry
 	for _, e := range entries {


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Replace the remaining sort.Slice calls with slices.SortFunc, comparing with cmp.Compare instead of a less function. This covers the GLFW video mode ordering and the chunk generator.

In the key-name generator, use cmp.Compare for the final string comparison to match the cmp.Compare calls already used for the numeric keys.

No behavior is changed.