### PR TITLE
audio: replay no stale remainder at the loop joint of an InfiniteLoop

### DIFF
--- a/audio/loop.go
+++ b/audio/loop.go
@@ -170,7 +170,7 @@ func (i *InfiniteLoop) Read(b []byte) (int, error) {
 	// When the source or the loop reaches its end, go back to the loop start and read again so that
 	// this doesn't return (0, nil). A retry either returns data, stops at the loop start, or grows
 	// the remainder, which is shorter than one value, so the retries end.
-	for {
+	for rewinds := 0; ; rewinds++ {
 		n, err := i.read(b)
 		if err != nil && err != io.EOF {
 			return 0, err
@@ -179,7 +179,7 @@ func (i *InfiniteLoop) Read(b []byte) (int, error) {
 		if !atEnd {
 			return n, nil
 		}
-		if n == 0 && i.pos == i.lstart {
+		if n == 0 && (i.pos == i.lstart || rewinds > 0) {
 			// The loop has no data to repeat.
 			return 0, io.EOF
 		}
@@ -308,6 +308,7 @@ func (i *InfiniteLoop) rewind() error {
 		return err
 	}
 	i.pos = i.lstart
+	i.extra = i.extra[:0]
 	return nil
 }
 

--- a/audio/loop_test.go
+++ b/audio/loop_test.go
@@ -746,3 +746,23 @@ func TestInfiniteLoopWithPartialValueAtLoopStart(t *testing.T) {
 		})
 	}
 }
+
+func TestInfiniteLoopRewindClearsExtra(t *testing.T) {
+	src := make([]byte, 101)
+	for i := range src {
+		src[i] = byte(i)
+	}
+	l := audio.NewInfiniteLoop(bytes.NewReader(src), 200)
+
+	buf := make([]byte, 128)
+	if _, err := l.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	n, err := l.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := buf[:4], []byte{0, 1, 2, 3}; !bytes.Equal(got[:4], want) {
+		t.Errorf("got: %v, want: %v (n: %d)", got, want, n)
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
rewind() did not clear i.extra while Seek does, so a remainder left when the source ended in the middle of a value was replayed at the loop joint, shifting all the following data.

Clear the remainder on rewind. Also end the stream when the second lap yields no data, so a loop with nothing to repeat terminates instead of retrying.

Add TestInfiniteLoopRewindClearsExtra, which observes stale bytes at the seam without this fix.
