### PR TITLE
ebiten: allow nil options to Vibrate

### DIFF
--- a/ebiten_test.go
+++ b/ebiten_test.go
@@ -41,8 +41,3 @@ func TestScreenSizeInFullscreen(t *testing.T) {
 		t.Errorf("h must be positive but not: %d", h)
 	}
 }
-
-func TestVibrateWithNilOptions(t *testing.T) {
-	ebiten.Vibrate(nil)
-	ebiten.VibrateGamepad(0, nil)
-}

--- a/ebiten_test.go
+++ b/ebiten_test.go
@@ -41,3 +41,8 @@ func TestScreenSizeInFullscreen(t *testing.T) {
 		t.Errorf("h must be positive but not: %d", h)
 	}
 }
+
+func TestVibrateWithNilOptions(t *testing.T) {
+	ebiten.Vibrate(nil)
+	ebiten.VibrateGamepad(0, nil)
+}

--- a/vibrate.go
+++ b/vibrate.go
@@ -51,6 +51,9 @@ type VibrateOptions struct {
 //
 // Vibrate is concurrent-safe.
 func Vibrate(options *VibrateOptions) {
+	if options == nil {
+		options = &VibrateOptions{}
+	}
 	vibrate.Vibrate(options.Duration, options.Magnitude)
 }
 
@@ -86,6 +89,9 @@ type VibrateGamepadOptions struct {
 //
 // VibrateGamepad is concurrent-safe.
 func VibrateGamepad(gamepadID GamepadID, options *VibrateGamepadOptions) {
+	if options == nil {
+		options = &VibrateGamepadOptions{}
+	}
 	g := gamepad.Get(gamepadID)
 	if g == nil {
 		return


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
Vibrate dereferenced its options unconditionally, so passing nil panicked, while other APIs accept nil options as the zero value.

Treat nil as the zero value in Vibrate and VibrateGamepad.

Add TestVibrateWithNilOptions.