### PR TITLE
vector: bug fix: StrokeCircle non-AA overfilled a disk when the width is thick

### DIFF
--- a/vector/util.go
+++ b/vector/util.go
@@ -289,7 +289,7 @@ func StrokeCircle(dst *ebiten.Image, cx, cy, r float32, strokeWidth float32, clr
 		return
 	}
 
-	if strokeWidth >= r {
+	if strokeWidth >= 2*r {
 		FillCircle(dst, cx, cy, r+strokeWidth/2, clr, false)
 		return
 	}

--- a/vector/util_test.go
+++ b/vector/util_test.go
@@ -242,12 +242,14 @@ func TestStrokePathKeepsSourcePath(t *testing.T) {
 
 func TestStrokeCircleThickStrokeNonAntiAlias(t *testing.T) {
 	dst := ebiten.NewImage(64, 64)
+	defer dst.Deallocate()
 	vector.StrokeCircle(dst, 32, 32, 10, 10, color.White, false)
 	if got, want := dst.At(32, 32), (color.RGBA{}); got != want {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 
 	dst2 := ebiten.NewImage(64, 64)
+	defer dst2.Deallocate()
 	vector.StrokeCircle(dst2, 32, 32, 10, 20, color.White, false)
 	if got, want := dst2.At(32, 32), (color.RGBA{0xff, 0xff, 0xff, 0xff}); got != want {
 		t.Errorf("got: %v, want: %v", got, want)

--- a/vector/util_test.go
+++ b/vector/util_test.go
@@ -239,3 +239,17 @@ func TestStrokePathKeepsSourcePath(t *testing.T) {
 		t.Errorf("got:\n%v\nwant:\n%v", got, want)
 	}
 }
+
+func TestStrokeCircleThickStrokeNonAntiAlias(t *testing.T) {
+	dst := ebiten.NewImage(64, 64)
+	vector.StrokeCircle(dst, 32, 32, 10, 10, color.White, false)
+	if got, want := dst.At(32, 32), (color.RGBA{}); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+
+	dst2 := ebiten.NewImage(64, 64)
+	vector.StrokeCircle(dst2, 32, 32, 10, 20, color.White, false)
+	if got, want := dst2.At(32, 32), (color.RGBA{0xff, 0xff, 0xff, 0xff}); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
#3677 

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The non-AA shortcut switched to FillCircle when strokeWidth >= r, but a stroked circle is a ring with the inner radius r - strokeWidth/2 and the hole disappears only when strokeWidth >= 2r. For r <= strokeWidth < 2r, the center was filled even though the AA path rendered a correct ring with a hole.

Use the regular ring path whenever the hole still exists.

The new regression test failed on the old code (the center pixel was opaque white) and passes with this fix.

Closes #3677 