### PR TITLE
graphicscommand: return the error from ResetGraphicsDriverState

### DIFF
--- a/internal/graphicscommand/command.go
+++ b/internal/graphicscommand/command.go
@@ -406,7 +406,7 @@ func ResetGraphicsDriverState(graphicsDriver graphicsdriver.Graphics) (err error
 			err = r.Reset()
 		}, true)
 	}
-	return nil
+	return
 }
 
 // MaxImageSize returns the maximum size of an image.


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
ResetGraphicsDriverState assigned the result of r.Reset() to the named return value err, but ended with an explicit 'return nil' that discarded it. The caller's error check in atlas/image.go was dead code, while the sister function InitializeGraphicsDriverState returned the error with a bare return.

Return the named value with a bare return so a failing Reset, e.g. on Android suspend/resume, is reported instead of silently continuing with a broken GL state.
