### PR TITLE
all: fix documentation and comment issues

### DIFF
--- a/audio/audio.go
+++ b/audio/audio.go
@@ -21,8 +21,10 @@
 // The stream format must be 16-bit little endian or 32-bit float little endian, and 2 channels. The format is as follows:
 //
 //	[data]      = [sample 1] [sample 2] [sample 3] ...
-//	[sample *]  = [channel 1] ...
+//	[sample *]  = [channel 1] [channel 2]
 //	[channel *] = [byte 1] [byte 2] ...
+//
+// A channel is 2 bytes in the 16-bit integer format, and 4 bytes in the 32-bit float format.
 //
 // An audio context (audio.Context object) has a sample rate you can specify
 // and all streams you want to play must have the same sample rate.

--- a/colorm.go
+++ b/colorm.go
@@ -65,6 +65,7 @@ func (c *ColorM) Reset() {
 // Apply pre-multiplies a vector (r, g, b, a, 1) by the matrix
 // where r, g, b, and a are clr's values in straight-alpha format.
 // In other words, Apply calculates ColorM * (r, g, b, a, 1)^T.
+// The result values are clamped to be in the range [0, 1].
 //
 // Deprecated: as of v2.5. Use the colorm package instead.
 func (c *ColorM) Apply(clr color.Color) color.Color {

--- a/colorm/colorm.go
+++ b/colorm/colorm.go
@@ -63,6 +63,7 @@ func (c *ColorM) Reset() {
 // Apply pre-multiplies a vector (r, g, b, a, 1) by the matrix
 // where r, g, b, and a are clr's values in straight-alpha format.
 // In other words, Apply calculates ColorM * (r, g, b, a, 1)^T.
+// The result values are clamped to be in the range [0, 1].
 func (c *ColorM) Apply(clr color.Color) color.Color {
 	return c.affineColorM().Apply(clr)
 }

--- a/gamepad.go
+++ b/gamepad.go
@@ -93,7 +93,7 @@ const (
 
 // StandardGamepadAxis represents a gamepad axis in the standard layout.
 //
-// The layout and the button values are based on the web standard.
+// The layout and the axis values are based on the web standard.
 // See https://www.w3.org/TR/gamepad/#remapping.
 type StandardGamepadAxis = gamepaddb.StandardAxis
 

--- a/graphics.go
+++ b/graphics.go
@@ -68,7 +68,7 @@ func (g GraphicsLibrary) String() string {
 	return ui.GraphicsLibrary(g).String()
 }
 
-// Ensures GraphicsLibraryAuto is zero (the default value for RunOptions).
+// Ensures GraphicsLibraryAuto is zero (the default value for RunGameOptions).
 var _ [GraphicsLibraryAuto]int = [0]int{}
 
 // DebugInfo is a struct to store debug info about the graphics.

--- a/image.go
+++ b/image.go
@@ -1275,7 +1275,7 @@ func (i *Image) ColorModel() color.Model {
 // Note that an important logic should not rely on values returned by ReadPixels, since
 // the returned values can include very slight differences between some machines.
 //
-// ReadPixels can't be called outside the main loop (ebiten.Run's updating function) starts.
+// ReadPixels can't be called outside the main loop (ebiten.RunGame's updating function) starts.
 func (i *Image) ReadPixels(pixels []byte) {
 	b := i.Bounds()
 	if got, want := len(pixels), 4*b.Dx()*b.Dy(); got != want {
@@ -1298,7 +1298,7 @@ func (i *Image) ReadPixels(pixels []byte) {
 // Note that an important logic should not rely on values returned by At, since
 // the returned values can include very slight differences between some machines.
 //
-// At can't be called outside the main loop (ebiten.Run's updating function) starts.
+// At can't be called outside the main loop (ebiten.RunGame's updating function) starts.
 func (i *Image) At(x, y int) color.Color {
 	r, g, b, a := i.at(x, y)
 	return color.RGBA{R: r, G: g, B: b, A: a}
@@ -1314,7 +1314,7 @@ func (i *Image) At(x, y int) color.Color {
 // Note that an important logic should not rely on values returned by RGBA64At,
 // since the returned values can include very slight differences between some machines.
 //
-// RGBA64At can't be called outside the main loop (ebiten.Run's updating function) starts.
+// RGBA64At can't be called outside the main loop (ebiten.RunGame's updating function) starts.
 func (i *Image) RGBA64At(x, y int) color.RGBA64 {
 	r, g, b, a := i.at(x, y)
 	return color.RGBA64{R: uint16(r) * 0x101, G: uint16(g) * 0x101, B: uint16(b) * 0x101, A: uint16(a) * 0x101}

--- a/input.go
+++ b/input.go
@@ -161,7 +161,7 @@ func GamepadSDLID(id GamepadID) string {
 
 // GamepadName returns a string with the name.
 // This function may vary in how it returns descriptions for the same device across platforms.
-// for example the following drivers/platforms see an Xbox One controller as the following:
+// For example, the following drivers/platforms see an Xbox One controller as the following:
 //
 //   - Windows: "Xbox Controller"
 //   - Chrome: "Xbox 360 Controller (XInput STANDARD GAMEPAD)"
@@ -388,7 +388,7 @@ func IsStandardGamepadButtonAvailable(id GamepadID, button StandardGamepadButton
 //
 // UpdateStandardGamepadLayoutMappings is concurrent-safe.
 //
-// UpdateStandardGamepadLayoutMappings mappings take effect immediately even for already connected gamepads.
+// The mappings take effect immediately even for already connected gamepads.
 //
 // UpdateStandardGamepadLayoutMappings works atomically. If an error happens, nothing is updated.
 func UpdateStandardGamepadLayoutMappings(mappings string) (bool, error) {

--- a/inpututil/inpututil.go
+++ b/inpututil/inpututil.go
@@ -267,7 +267,7 @@ func JustConnectedGamepadIDs() []ebiten.GamepadID {
 }
 
 // IsGamepadJustDisconnected returns a boolean value indicating
-// whether the gamepad of the given id is released just in the current tick.
+// whether the gamepad of the given id is disconnected just in the current tick.
 //
 // IsGamepadJustDisconnected must be called in a game's Update, not Draw.
 //

--- a/internal/affine/colorm.go
+++ b/internal/affine/colorm.go
@@ -37,7 +37,7 @@ var (
 
 // ColorM represents a matrix to transform coloring when rendering an image.
 //
-// ColorM is applied to the source alpha color
+// ColorM is applied to the source straight alpha color
 // while an Image's pixels' format is alpha premultiplied.
 // Before applying a matrix, a color is un-multiplied, and after applying the matrix,
 // the color is multiplied again.

--- a/internal/graphicscommand/doc.go
+++ b/internal/graphicscommand/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package graphicscommand represents a low layer for graphics using OpenGL.
+// Package graphicscommand represents a low layer for graphics rendering, independent of graphics drivers.
 package graphicscommand

--- a/run.go
+++ b/run.go
@@ -513,7 +513,7 @@ func IsRunnableOnUnfocused() bool {
 // [SetWindowVisible], since a hidden window can never be focused and would otherwise never run again.
 //
 // Known issue: On browsers, even if the state is on, the game doesn't run in background tabs.
-// This is because browsers throttles background tabs not to often update.
+// This is because browsers throttle background tabs so as not to update too often.
 //
 // SetRunnableOnUnfocused does nothing on mobiles so far.
 //

--- a/text/text.go
+++ b/text/text.go
@@ -160,7 +160,7 @@ var textM sync.Mutex
 // As the cache capacity has limit, it is not guaranteed that all the glyphs for runes given at Draw are cached.
 // The cache is shared with CacheGlyphs.
 //
-// It is OK to call Draw with a same text and a same face at every frame in terms of performance.
+// It is OK to call Draw with the same text and the same face at every frame in terms of performance.
 //
 // Draw/DrawWithOptions and CacheGlyphs are implemented like this:
 //
@@ -196,7 +196,7 @@ func Draw(dst *ebiten.Image, text string, face font.Face, x, y int, clr color.Co
 // As the cache capacity has limit, it is not guaranteed that all the glyphs for runes given at DrawWithOptions are cached.
 // The cache is shared with CacheGlyphs.
 //
-// It is OK to call DrawWithOptions with a same text and a same face at every frame in terms of performance.
+// It is OK to call DrawWithOptions with the same text and the same face at every frame in terms of performance.
 //
 // Draw/DrawWithOptions and CacheGlyphs are implemented like this:
 //
@@ -442,7 +442,7 @@ type Glyph struct {
 }
 
 // AppendGlyphs appends the glyph information to glyphs.
-// You can render each glyphs as you like. See examples/text for an example of AppendGlyphs.
+// You can render each glyph as you like. See examples/text for an example of AppendGlyphs.
 func AppendGlyphs(glyphs []Glyph, face font.Face, text string) []Glyph {
 	textM.Lock()
 	defer textM.Unlock()

--- a/text/v2/layout.go
+++ b/text/v2/layout.go
@@ -108,7 +108,7 @@ var theDrawGlyphEntriesPool = sync.Pool{
 // Then old glyphs might be evicted from the cache.
 // As the cache capacity has limit, it is not guaranteed that all the glyphs for runes given at Draw are cached.
 //
-// It is OK to call Draw with a same text and a same face at every frame in terms of performance.
+// It is OK to call Draw with the same text and the same face at every frame in terms of performance.
 //
 // Draw is concurrent-safe.
 //

--- a/vector/stroke.go
+++ b/vector/stroke.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
-// LineCap represents the way in which how the ends of the stroke are rendered.
+// LineCap represents the way in which the ends of the stroke are rendered.
 type LineCap int
 
 const (
@@ -30,7 +30,7 @@ const (
 	LineCapSquare
 )
 
-// LineJoin represents the way in which how two segments are joined.
+// LineJoin represents the way in which two segments are joined.
 type LineJoin int
 
 const (
@@ -46,13 +46,13 @@ type StrokeOptions struct {
 	// The default (zero) value is 0.
 	Width float32
 
-	// LineCap is the way in which how the ends of the stroke are rendered.
+	// LineCap is the way in which the ends of the stroke are rendered.
 	// Line caps are not rendered when the sub-path is marked as closed.
 	//
 	// The default (zero) value is [LineCapButt].
 	LineCap LineCap
 
-	// LineJoin is the way in which how two segments are joined.
+	// LineJoin is the way in which two segments are joined.
 	//
 	// The default (zero) value is [LineJoinMiter].
 	LineJoin LineJoin


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
- audio: fix the stream format diagram in the package doc
- colorm: document that Apply clamps the result values to [0, 1]
- gamepad: fix the StandardGamepadAxis doc
- graphics: fix RunOptions to RunGameOptions in a comment
- image: replace references to ebiten.Run with ebiten.RunGame
- input: fix the UpdateStandardGamepadLayoutMappings and GamepadName docs
- inpututil: fix the IsGamepadJustDisconnected doc
- internal/affine: fix 'straight alpha' in the ColorM doc
- internal/graphicscommand: make the package doc graphics-driver independent
- run: fix grammar in the SetRunnableOnUnfocused doc
- text, text/v2: fix grammar in the Draw/DrawWithOptions/AppendGlyphs docs
- vector: remove duplicated 'how' in the stroke docs