### PR TITLE
ui: reject non-finite Layout results

### DIFF
--- a/internal/ui/context.go
+++ b/internal/ui/context.go
@@ -410,6 +410,9 @@ func (c *context) drawGame(graphicsDriver graphicsdriver.Graphics, ui *UserInter
 // reports whether the screen size changed from the previous layout.
 func (c *context) layoutGame(outsideWidth, outsideHeight float64, screenWidth, screenHeight int) (int, int, bool) {
 	owf, ohf := c.game.Layout(outsideWidth, outsideHeight)
+	if math.IsNaN(owf) || math.IsNaN(ohf) || math.IsInf(owf, 0) || math.IsInf(ohf, 0) {
+		panic("ui: Layout must return finite positive numbers")
+	}
 	if owf <= 0 || ohf <= 0 {
 		panic("ui: Layout must return positive numbers")
 	}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
layoutGame checked the Layout result with <= 0 only, so NaN slipped through every comparison and +Inf passed as well. int(math.Ceil(NaN)) then produced an out-of-range size and failed with a remote panic or OOM far from the cause.

Reject NaN and infinite Layout results with an explicit panic.