### PR TITLE
vector: make empty paths a clean no-op

### DIFF
--- a/vector/atlas.go
+++ b/vector/atlas.go
@@ -148,6 +148,14 @@ func (a *atlas) setPaths(dstBounds image.Rectangle, paths []*Path, bounds []imag
 	a.atlasImages = slices.Grow(a.atlasImages, atlasImageCount)[:atlasImageCount]
 	for i := range a.atlasImages {
 		s := a.atlasSizes[i]
+		if s.X <= 0 || s.Y <= 0 {
+			// All regions are empty: keep a clean no-op without creating an image.
+			if a.atlasImages[i] != nil {
+				a.atlasImages[i].Deallocate()
+				a.atlasImages[i] = nil
+			}
+			continue
+		}
 		var origWidth, origHeight int
 		if a.atlasImages[i] != nil {
 			origWidth = a.atlasImages[i].Bounds().Dx()
@@ -179,6 +187,9 @@ func (a *atlas) stencilBufferImageAt(i int, antialias bool, antialiasIndex int) 
 	}
 
 	atlas := a.atlasImages[ar.imageIndex]
+	if atlas == nil {
+		return nil
+	}
 	b := ar.imageBounds
 	if antialias {
 		switch antialiasIndex {

--- a/vector/atlas.go
+++ b/vector/atlas.go
@@ -149,7 +149,6 @@ func (a *atlas) setPaths(dstBounds image.Rectangle, paths []*Path, bounds []imag
 	for i := range a.atlasImages {
 		s := a.atlasSizes[i]
 		if s.X <= 0 || s.Y <= 0 {
-			// All regions are empty: keep a clean no-op without creating an image.
 			if a.atlasImages[i] != nil {
 				a.atlasImages[i].Deallocate()
 				a.atlasImages[i] = nil

--- a/vector/atlas_test.go
+++ b/vector/atlas_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Ebitengine Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vector
+
+import (
+	"image"
+	"testing"
+)
+
+func TestAtlasEmptyPaths(t *testing.T) {
+	for _, antialias := range []bool{false, true} {
+		a := &atlas{}
+		paths := []*Path{{}, {}}
+		bounds := []image.Rectangle{
+			image.Rect(0, 0, 16, 16),
+			image.Rect(0, 0, 16, 16),
+		}
+		a.setPaths(image.Rect(0, 0, 16, 16), paths, bounds, antialias)
+
+		for i, img := range a.atlasImages {
+			if img != nil {
+				t.Errorf("antialias: %v: atlasImages[%d] must be nil when all paths are empty", antialias, i)
+			}
+		}
+		for i := range paths {
+			for j := range 2 {
+				if got := a.stencilBufferImageAt(i, antialias, j); got != nil {
+					t.Errorf("antialias: %v: stencilBufferImageAt(%d, %v, %d): got: %v, want: nil", antialias, i, antialias, j, got)
+				}
+			}
+		}
+	}
+}
+
+func TestAtlasEmptyPathsAfterNonEmptyPaths(t *testing.T) {
+	a := &atlas{}
+
+	var p Path
+	p.MoveTo(0, 0)
+	p.LineTo(16, 0)
+	p.LineTo(16, 16)
+	p.LineTo(0, 16)
+	p.Close()
+	a.setPaths(image.Rect(0, 0, 16, 16), []*Path{&p}, []image.Rectangle{image.Rect(0, 0, 16, 16)}, false)
+	if len(a.atlasImages) == 0 {
+		t.Fatal("atlasImages must not be empty for non-empty paths")
+	}
+	if a.atlasImages[0] == nil {
+		t.Fatal("atlasImages[0] must not be nil for non-empty paths")
+	}
+
+	a.setPaths(image.Rect(0, 0, 16, 16), []*Path{{}}, []image.Rectangle{image.Rect(0, 0, 16, 16)}, false)
+	for i, img := range a.atlasImages {
+		if img != nil {
+			t.Errorf("atlasImages[%d] must be nil when all paths become empty", i)
+		}
+	}
+	if got := a.stencilBufferImageAt(0, false, 0); got != nil {
+		t.Errorf("stencilBufferImageAt(0, false, 0): got: %v, want: nil", got)
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
setPaths only early-returned when there were zero paths, so an all-empty path set still went through atlas allocation. Skip image creation when every region is empty and return nil from stencilBufferImageAt, making empty draws a clean no-op instead of failing.