### PR TITLE
audio/vorbis: clip out-of-range values in the int16 conversion

### DIFF
--- a/audio/vorbis/int16.go
+++ b/audio/vorbis/int16.go
@@ -59,7 +59,7 @@ func (r *int16BytesReader) Read(buf []byte) (int, error) {
 	}
 
 	for i := range n {
-		f := r.fbuf[i]
+		f := min(max(r.fbuf[i], -1), 1)
 		s := int16(f * (1<<15 - 1))
 		buf[2*i] = byte(s)
 		buf[2*i+1] = byte(s >> 8)

--- a/audio/vorbis/int16_test.go
+++ b/audio/vorbis/int16_test.go
@@ -216,3 +216,18 @@ func TestInt16BytesReaderEOFWithData(t *testing.T) {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 }
+
+func TestInt16BytesReaderClipsOutOfRange(t *testing.T) {
+	in := []float32{1.5, -1.5, 2, -2, 0.5, -0.5}
+	r := vorbis.NewInt16BytesReaderFromFloat32Reader(&f32reader{data: in}, 1)
+	buf := make([]byte, len(in)*2)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		t.Fatal(err)
+	}
+	want := []int16{32767, -32767, 32767, -32767, 16383, -16383}
+	for i, w := range want {
+		if got := int16(buf[2*i]) | int16(buf[2*i+1])<<8; got != w {
+			t.Errorf("value %d: got: %d, want: %d", i, got, w)
+		}
+	}
+}


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The float to int16 conversion multiplied by 32767 without clipping, so an out-of-range decoded value, which Vorbis decoding can produce past peak 1.0, wrapped around through the implementation-defined float to int conversion and came out as harsh noise. The resampling path in convert clips to [-1, 1] before the same conversion.

Clamp to [-1, 1] before multiplying, mirroring the resampling path.

Add TestInt16BytesReaderClipsOutOfRange, which observes wrapped values without this fix.