### PR TITLE
internal/ui: handle touchcancel like touchend on browsers

### DIFF
--- a/internal/ui/input_js.go
+++ b/internal/ui/input_js.go
@@ -26,15 +26,16 @@ var (
 	stringMeta    = js.ValueOf("Meta")
 	stringShift   = js.ValueOf("Shift")
 
-	stringKeydown    = js.ValueOf("keydown")
-	stringKeyup      = js.ValueOf("keyup")
-	stringMousedown  = js.ValueOf("mousedown")
-	stringMouseup    = js.ValueOf("mouseup")
-	stringMousemove  = js.ValueOf("mousemove")
-	stringWheel      = js.ValueOf("wheel")
-	stringTouchstart = js.ValueOf("touchstart")
-	stringTouchend   = js.ValueOf("touchend")
-	stringTouchmove  = js.ValueOf("touchmove")
+	stringKeydown     = js.ValueOf("keydown")
+	stringKeyup       = js.ValueOf("keyup")
+	stringMousedown   = js.ValueOf("mousedown")
+	stringMouseup     = js.ValueOf("mouseup")
+	stringMousemove   = js.ValueOf("mousemove")
+	stringWheel       = js.ValueOf("wheel")
+	stringTouchstart  = js.ValueOf("touchstart")
+	stringTouchend    = js.ValueOf("touchend")
+	stringTouchmove   = js.ValueOf("touchmove")
+	stringTouchcancel = js.ValueOf("touchcancel")
 
 	stringCapsLock = js.ValueOf("CapsLock")
 	stringNumLock  = js.ValueOf("NumLock")
@@ -164,7 +165,7 @@ func (u *UserInterface) updateInputFromEvent(e js.Value) error {
 		// TODO: What if e.deltaMode is not DOM_DELTA_PIXEL?
 		u.inputState.WheelX += -e.Get("deltaX").Float()
 		u.inputState.WheelY += -e.Get("deltaY").Float()
-	case t.Equal(stringTouchstart) || t.Equal(stringTouchend) || t.Equal(stringTouchmove):
+	case t.Equal(stringTouchstart) || t.Equal(stringTouchend) || t.Equal(stringTouchmove) || t.Equal(stringTouchcancel):
 		u.updateTouchesFromEvent(e)
 	}
 

--- a/internal/ui/ui_js.go
+++ b/internal/ui/ui_js.go
@@ -702,6 +702,15 @@ func (u *UserInterface) setCanvasEventHandlers(v js.Value) {
 		}
 		return nil
 	}))
+	v.Call("addEventListener", "touchcancel", js.FuncOf(func(this js.Value, args []js.Value) any {
+		e := args[0]
+		e.Call("preventDefault")
+		if err := u.updateInputFromEvent(e); err != nil {
+			u.setError(err)
+			return nil
+		}
+		return nil
+	}))
 	v.Call("addEventListener", "touchmove", js.FuncOf(func(this js.Value, args []js.Value) any {
 		e := args[0]
 		e.Call("preventDefault")


### PR DESCRIPTION
# What issue is this addressing?
None

## What _type_ of issue is this addressing?
bug

## What this PR does | solves
The browser backend listened to touchstart, touchend and touchmove, but not touchcancel. Touch state is rebuilt from the live targetTouches set, so a touch cancelled by the OS, e.g. by an incoming call or a gesture interruption, never produced an update and stayed pressed forever without even a JustReleased.

Register a touchcancel listener with the same body as touchend and route the event to updateTouchesFromEvent.
